### PR TITLE
fix(ui): snap bandwidth to mode default when out-of-range; doc the IMD-vs-real-signal trap

### DIFF
--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -8925,7 +8925,27 @@ fn update_bandwidth_row_range_for_mode(
     // sounding right. Per silent-fail investigation following
     // the NOAA 15 pass.
     let target = if current < min_bw || current > max_bw {
-        sdr_radio::demod::default_bandwidth_for_mode(mode).ok()
+        // Match on the result so a `default_bandwidth_for_mode`
+        // failure is logged and we still emit a corrective value
+        // — falling through with `None` would leave the row at
+        // its now-out-of-range pre-clamp value, defeating the
+        // whole snap. The min/max fallback is the same edge of
+        // the range we're crossing, so the user always sees a
+        // value inside the new mode's allowed band even when
+        // the lookup helper goes sideways. Per CR round 1 on
+        // PR #612.
+        let safe = match sdr_radio::demod::default_bandwidth_for_mode(mode) {
+            Ok(default_bw) => default_bw,
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    ?mode,
+                    "default_bandwidth_for_mode failed — falling back to range edge"
+                );
+                if current < min_bw { min_bw } else { max_bw }
+            }
+        };
+        Some(safe)
     } else {
         None
     };

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -8910,10 +8910,22 @@ fn update_bandwidth_row_range_for_mode(
     adj.set_lower(min_bw);
     adj.set_upper(max_bw);
     let current = radio.bandwidth_row.value();
-    let target = if current < min_bw {
-        Some(min_bw)
-    } else if current > max_bw {
-        Some(max_bw)
+    // When the existing value is outside the new mode's range,
+    // snap to the new mode's *default* rather than its min or max.
+    // The min/max represent absolute floors/ceilings; the default
+    // is the right "this mode's natural setting" for a value that
+    // we already know belongs to a different regime. The bug this
+    // fixes: app starts with bandwidth_row at the panel's mode-
+    // agnostic 12.5 kHz default, demod dropdown loads as WFM,
+    // range update clamps to WFM_MIN (50 kHz) — which crushes
+    // FM broadcast deviation peaks and produces fuzzy/static-
+    // sounding audio. Same trap fires after a satellite NFM
+    // 38 kHz session if the user manually flips back to WFM.
+    // Falling back to WFM's 150 kHz default keeps broadcast
+    // sounding right. Per silent-fail investigation following
+    // the NOAA 15 pass.
+    let target = if current < min_bw || current > max_bw {
+        sdr_radio::demod::default_bandwidth_for_mode(mode).ok()
     } else {
         None
     };

--- a/docs/guides/apt-reception.md
+++ b/docs/guides/apt-reception.md
@@ -264,11 +264,15 @@ reaches the dongle's front-end, or a 137 MHz LNA/SAW combo (e.g.
 SAWbird+ NOAA) that does both notch and band-specific gain. See
 [FM broadcast notch](#fm-broadcast-notch-filter) for the rationale.
 
-A useful sanity check: the audio recording (`audio-NOAA-*.wav`)
-should contain a clear 2400 Hz tone with audible amplitude
-modulation at the 0.5-second line rate. If the WAV plays back as
-pure hiss with no perceptible 2400 Hz tone, no APT carrier reached
-the demod regardless of what you saw on the waterfall.
+A useful sanity check: the audio recording (saved alongside the
+PNG in `~/sdr-recordings/` as `audio-{satellite}-{timestamp}.wav`
+when the "also save audio" toggle is on) typically contains an
+audible 2400 Hz tone whose amplitude modulates at the APT line
+period (0.5 s, ≈2 lines/sec) once a carrier is present. If the
+WAV plays back as pure hiss with no perceptible 2400 Hz tone for
+the whole pass, no APT carrier reached the demod regardless of
+what you saw on the waterfall — borderline / fading conditions
+will sit somewhere in between.
 
 ### Image has wavy horizontal banding
 

--- a/docs/guides/apt-reception.md
+++ b/docs/guides/apt-reception.md
@@ -238,6 +238,38 @@ Possibilities:
 - **No notch filter and you're near a strong FM broadcast tower** —
   see the [FM broadcast notch](#fm-broadcast-notch-filter) section.
 
+### "I see signal in the waterfall but the image is still noise"
+
+Counter-intuitive, but the most common explanation isn't a software
+bug — it's that **what looks like a satellite signal in the waterfall
+is actually FM broadcast intermodulation**. At 137 MHz the RTL-SDR's
+front-end can produce IMD products from strong 88-108 MHz FM
+broadcast that show up as broad bumps or bands on the waterfall
+right where the satellite *should* be. They look like signal but
+carry no satellite content, so the FM demod produces only noise and
+the decoder gets nothing usable.
+
+How to tell them apart:
+
+- **Real satellite carrier**: a narrow (~38 kHz) bright vertical
+  band that drifts ±3.5 kHz over the pass (Doppler), strongest at
+  closest approach, gone before AOS and after LOS.
+- **FM broadcast IMD**: present continuously regardless of any
+  satellite pass, often with audible artefacts that correlate with
+  the strongest local FM station's modulation if you tune there.
+
+**The fix is hardware, not software.** Either an FM-bandstop notch
+(e.g. Nooelec FM Bandstop) to kill the offending energy before it
+reaches the dongle's front-end, or a 137 MHz LNA/SAW combo (e.g.
+SAWbird+ NOAA) that does both notch and band-specific gain. See
+[FM broadcast notch](#fm-broadcast-notch-filter) for the rationale.
+
+A useful sanity check: the audio recording (`audio-NOAA-*.wav`)
+should contain a clear 2400 Hz tone with audible amplitude
+modulation at the 0.5-second line rate. If the WAV plays back as
+pure hiss with no perceptible 2400 Hz tone, no APT carrier reached
+the demod regardless of what you saw on the waterfall.
+
 ### Image has wavy horizontal banding
 
 FM broadcast IMD. Get a notch filter. The pattern often


### PR DESCRIPTION
## Summary

Two fixes from a deep audit of "signal looks fine in waterfall but APT image is just noise":

- **bandwidth row**: when `update_bandwidth_row_range_for_mode` finds the existing value outside the new mode's range, snap to the mode's *default* (e.g. WFM=150 kHz) instead of its min or max. Fixes the WFM-stuck-at-50kHz trap on app startup (panel default 12.5 kHz < WFM_MIN 50 kHz → silently clamped to 50 kHz → broadcast FM deviation peaks crushed → fuzzy / static audio). Same trap fires after a satellite NFM 38 kHz session if you flip back to WFM manually.
- **apt-reception.md**: dedicated subsection for "I see signal in the waterfall but the image is still noise" — explains that this is most often FM broadcast IMD producing front-end products at 137 MHz (NOT a software bug), names how to distinguish a real satellite carrier from IMD, and points at the hardware fixes (FM-bandstop notch, SAWbird+ NOAA, or 137-centered LNA).

## Background

Investigation across a week of NOAA captures (27 WAVs, NOAA-15/18/19) showed **none** of them contain a real 2400 Hz APT subcarrier — they're all FM-demoded noise. The decoder itself is fine (proven by the in-tree `noaa19_apt_11025hz.wav` fixture decoding to a clean cloud image). The audio chain is fine when bandwidth is set correctly (verified with a 250 kHz WFM broadcast capture showing +14.5 dB voice prominence). The silent passes are an RF / antenna problem — the satellite carrier never reaches the front-end with usable SNR, often masked by FM broadcast IMD that looks like signal in the waterfall.

The bandwidth bug is independent and got surfaced by the same investigation: persisted state from a satellite NFM 38 kHz session led to WFM displaying as 50 kHz on the next launch, which made FM broadcast sound like garbage and made it look like the audio chain itself was broken (it wasn't).

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace --lib` 418 passed
- [ ] Smoke: launch the app, verify WFM 89.x defaults to a sensible bandwidth (150 kHz) and FM broadcast sounds clear
- [ ] Smoke: switch from WFM 200 kHz → NFM, bandwidth snaps to NFM default 12.5 kHz (in-range NFM values would have stayed); switch back to WFM, snaps to WFM default 150 kHz

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Bandwidth control now snaps to the mode’s default value when changing demodulation modes; if the default is unavailable it falls back to the nearest valid endpoint.

* **Documentation**
  * Added APT reception troubleshooting covering FM broadcast intermodulation vs. real satellite carriers, hardware remedies (FM notch / 137 MHz LNA/SAW) and an audio-based validation check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->