### PR TITLE
fix(ui): show app icon on satellite-image and ACARS sub-windows

### DIFF
--- a/crates/sdr-ui/src/acars_viewer.rs
+++ b/crates/sdr-ui/src/acars_viewer.rs
@@ -317,6 +317,18 @@ fn build_acars_viewer_window(state: &Rc<AppState>) -> adw::Window {
         .default_height(ACARS_VIEWER_WINDOW_HEIGHT)
         .modal(false)
         .build();
+    // Link to the GApplication so Wayland's
+    // `xdg_toplevel_set_app_id` carries `com.sdr.rs` and the
+    // WM can resolve our icon. Unlike the satellite-image
+    // viewers we don't have a parent window to inherit from
+    // (this opens from the aviation-panel button click), so
+    // pull the active app via the gio default-application
+    // registry. See apt_viewer.rs for the full rationale.
+    if let Some(app) =
+        gtk4::gio::Application::default().and_then(|a| a.downcast::<gtk4::Application>().ok())
+    {
+        window.set_application(Some(&app));
+    }
 
     // ─── Header bar ───
     let header = adw::HeaderBar::new();

--- a/crates/sdr-ui/src/app.rs
+++ b/crates/sdr-ui/src/app.rs
@@ -43,6 +43,17 @@ pub fn build_app_with_options(start_hidden: bool) -> adw::Application {
             icon_theme.add_search_path("data");
         }
 
+        // Default every window the app creates to the app icon.
+        // Without this the WM/compositor only ties the main
+        // `AdwApplicationWindow` to `com.sdr.rs` (via the matching
+        // `application_id`); the satellite-image viewers (APT /
+        // LRPT / SSTV) and the ACARS log viewer use bare
+        // `adw::Window::builder()` and otherwise show up in the
+        // window list / task switcher with the default fallback
+        // icon. `set_default_icon_name` covers existing AND
+        // future windows without per-builder churn.
+        gtk4::Window::set_default_icon_name(APP_ID);
+
         // Periodically trim the glibc heap to return freed pages
         // to the OS.
         #[cfg(all(target_os = "linux", target_env = "gnu"))]

--- a/crates/sdr-ui/src/apt_viewer.rs
+++ b/crates/sdr-ui/src/apt_viewer.rs
@@ -724,6 +724,16 @@ pub fn open_apt_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
         .transient_for(parent)
         .modal(false)
         .build();
+    // Link to the GApplication (inherited from the parent
+    // `AdwApplicationWindow`) so Wayland compositors set this
+    // toplevel's `app_id` to `com.sdr.rs`. Without it the WM
+    // falls back to the bare `gtk` app_id and can't resolve
+    // our icon — even though `transient_for` ties our window
+    // to the main one for stacking, the icon-lookup path uses
+    // app_id, not the parent link. `set_application` is a
+    // no-op when the parent has no application set (only true
+    // in tests / no-display contexts).
+    window.set_application(parent.application().as_ref());
 
     let header = adw::HeaderBar::new();
 

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -2322,6 +2322,11 @@ pub fn open_lrpt_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
         .transient_for(parent)
         .modal(false)
         .build();
+    // Inherit the parent's GApplication so Wayland's
+    // `xdg_toplevel_set_app_id` carries `com.sdr.rs` and the
+    // WM can resolve our icon. See apt_viewer.rs for the full
+    // rationale.
+    window.set_application(parent.application().as_ref());
 
     let header = adw::HeaderBar::new();
 

--- a/crates/sdr-ui/src/sstv_viewer.rs
+++ b/crates/sdr-ui/src/sstv_viewer.rs
@@ -573,6 +573,11 @@ pub fn open_sstv_viewer_window<W: gtk4::prelude::IsA<gtk4::Window>>(
         .transient_for(parent)
         .modal(false)
         .build();
+    // Inherit the parent's GApplication so Wayland's
+    // `xdg_toplevel_set_app_id` carries `com.sdr.rs` and the
+    // WM can resolve our icon. See apt_viewer.rs for the full
+    // rationale.
+    window.set_application(parent.application().as_ref());
 
     let header = adw::HeaderBar::new();
 


### PR DESCRIPTION
## Summary

The four floating sub-windows (APT / LRPT / SSTV image viewers, ACARS log viewer) showed the WM's "icon not found" placeholder instead of the SDR-RS icon. Root cause is Wayland-specific: compositors look up icons via the toplevel's \`app_id\` (set via \`xdg_toplevel_set_app_id\`), which only gets populated when a window is linked to a \`GApplication\`. The main window is an \`AdwApplicationWindow\` so it gets that link automatically; the sub-windows are bare \`adw::Window\` and weren't.

Fixes:
- \`app.rs\`: \`gtk4::Window::set_default_icon_name(APP_ID)\` at startup — fallback for X11 / older WMs that read the per-window icon-name property.
- \`apt_viewer.rs\`, \`lrpt_viewer.rs\`, \`sstv_viewer.rs\`: \`window.set_application(parent.application().as_ref())\` after build, inheriting from the existing transient_for parent.
- \`acars_viewer.rs\`: same fix, but the ACARS viewer doesn't take a parent (opens from a panel button click), so pull the active app via \`gtk4::gio::Application::default()\` + downcast.

Verified on Hyprland.

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo test --workspace --lib\` 418 passed
- [x] Smoke: ACARS viewer now shows the SDR-RS icon (was the broken-image placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed application icon display in all satellite imagery and telemetry data viewers. The SDR-RS application icon now appears correctly in the ACARS telemetry log viewer, APT satellite imagery viewer, LRPT weather data viewer, and SSTV image viewer windows.
  * Enhanced window management by properly linking all viewer windows to the application system, ensuring consistent icon branding and improved visual identification throughout the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->