### PR TITLE
docs(mac): sidebar architecture + refresh README (closes #451)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Every activity panel is an `AdwPreferencesPage` of flat `AdwPreferencesGroup`s w
 
 **Session persistence:**
 
-Four config keys per side live in `activity_bar.rs`: `ui_sidebar_{left,right}_{selected,open,width_px}`. Load at launch via `load_session(config)`, apply before wiring handlers (seed-then-wire prevents the initial `set_active` / `set_show_sidebar` calls from writing back). On change, persist via `save_*` helpers. Pixel widths are converted to `AdwOverlaySplitView`'s `[0, 1]` fraction via `apply_sidebar_width`'s one-shot `notify::width` handler once the split view has its first real allocation.
+Three config keys per side (six total) live in `activity_bar.rs`: `ui_sidebar_{left,right}_{selected,open,width_px}`. Load at launch via `load_session(config)`, apply before wiring handlers (seed-then-wire prevents the initial `set_active` / `set_show_sidebar` calls from writing back). On change, persist via `save_*` helpers. Pixel widths are converted to `AdwOverlaySplitView`'s `[0, 1]` fraction via `apply_sidebar_width`'s one-shot `notify::width` handler once the split view has its first real allocation.
 
 **macOS counterpart:** the same activity-bar pattern is implemented in SwiftUI on the Mac side, sharing the same six `ui_sidebar_*` config keys via the engine's config FFI (ABI 0.21+). Contributor docs for the SwiftUI version live in `apps/macos/README.md` → "Sidebar architecture (macOS)".
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,8 @@ Every activity panel is an `AdwPreferencesPage` of flat `AdwPreferencesGroup`s w
 
 Four config keys per side live in `activity_bar.rs`: `ui_sidebar_{left,right}_{selected,open,width_px}`. Load at launch via `load_session(config)`, apply before wiring handlers (seed-then-wire prevents the initial `set_active` / `set_show_sidebar` calls from writing back). On change, persist via `save_*` helpers. Pixel widths are converted to `AdwOverlaySplitView`'s `[0, 1]` fraction via `apply_sidebar_width`'s one-shot `notify::width` handler once the split view has its first real allocation.
 
+**macOS counterpart:** the same activity-bar pattern is implemented in SwiftUI on the Mac side, sharing the same six `ui_sidebar_*` config keys via the engine's config FFI (ABI 0.21+). Contributor docs for the SwiftUI version live in `apps/macos/README.md` → "Sidebar architecture (macOS)".
+
 ### Satellite reception
 
 NOAA APT (epic #468), Meteor-M LRPT (epic #469), and ISS SSTV (epic #472) are all shipped end-to-end.

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -22,19 +22,59 @@ apps/macos/
 │                                   local package dependency
 ├── SDRMac/                       — app source (Xcode module)
 │   ├── SDRMacApp.swift           — @main App struct, Window/Settings scenes
-│   ├── ContentView.swift         — top-level NavigationSplitView
+│   ├── ContentView.swift         — top-level layout (HStack with
+│   │                               activity bars + custom resize
+│   │                               handles flanking the panels)
 │   ├── Models/
-│   │   └── CoreModel.swift       — @Observable model wrapping SdrCore
+│   │   ├── CoreModel.swift       — @Observable model wrapping SdrCore;
+│   │   │                           also owns the sidebar session state
+│   │   ├── BandPreset.swift      — quick-tune presets shown on the
+│   │   │                           General panel
+│   │   ├── Bookmark.swift        — bookmark record + decode helpers
+│   │   ├── BookmarksStore.swift  — JSON-backed bookmark persistence
+│   │   ├── AveragingMode.swift   — Display-panel averaging picker enum
+│   │   ├── RtlTcpClientFavorite.swift — RTL-TCP client favorites store
+│   │   ├── TranscriptionDriver.swift  — Apple SpeechAnalyzer pipeline
+│   │   └── UsbHotplugMonitor.swift    — IOKit USB plug/unplug events
+│   ├── Renderer/
+│   │   ├── MetalSpectrumNSView.swift  — Metal hosted view + draw loop
+│   │   ├── SpectrumRenderer.swift     — spectrum + waterfall renderer
+│   │   ├── SpectrumWaterfallView.swift — SwiftUI wrapper
+│   │   ├── Shaders.metal              — fragment + compute shaders
+│   │   ├── Palettes.swift             — colormap tables
+│   │   └── PowerModeObserver.swift    — low-power mode coalescing
 │   ├── Views/
-│   │   ├── HeaderToolbar.swift   — play/stop, center frequency, mode
-│   │   ├── SourceSection.swift   — RTL-SDR tuner sidebar panel
-│   │   ├── RadioSection.swift    — demod/squelch/volume sidebar panel
-│   │   ├── DisplaySection.swift  — FFT size/window/dB range sidebar
-│   │   ├── CenterView.swift      — spectrum+waterfall placeholder (M4)
-│   │   ├── StatusBar.swift       — bottom status strip
-│   │   ├── SettingsView.swift    — Cmd-, settings scene
-│   │   ├── SDRCommands.swift     — menu-bar commands
-│   │   └── Formatters.swift      — shared display helpers (formatRate, …)
+│   │   ├── ActivityBar/                — sidebar activity-bar pattern
+│   │   │   ├── ActivityEntry.swift     — Left/RightActivity enums
+│   │   │   ├── ActivityBarView.swift   — generic icon column
+│   │   │   └── ActivityPanelHost.swift — switch routing each
+│   │   │                                 activity → its panel view
+│   │   ├── Panels/                     — one Form-based view per
+│   │   │   │                             left activity
+│   │   │   ├── GeneralPanelView.swift  — band presets + Source
+│   │   │   ├── RadioPanelView.swift    — bandwidth/squelch/filters
+│   │   │   ├── AudioPanelView.swift    — sink/volume/network/recording
+│   │   │   ├── DisplayPanelView.swift  — FFT/waterfall/levels
+│   │   │   └── ScannerPanelView.swift  — master switch + active + timing
+│   │   ├── HeaderToolbar.swift         — play/stop, frequency, demod
+│   │   ├── CenterView.swift            — spectrum + status host
+│   │   ├── StatusBar.swift             — bottom status strip
+│   │   ├── BookmarksPanel.swift        — right activity panel
+│   │   ├── TranscriptionPanel.swift    — right activity panel
+│   │   ├── SourceSection.swift         — Source rows reused on
+│   │   │                                  the General panel
+│   │   ├── RecordingSection.swift      — Recording rows reused on
+│   │   │                                  the Audio panel
+│   │   ├── RtlTcpServerSection.swift   — Share activity panel body
+│   │   ├── SettingsView.swift          — Cmd-, settings scene
+│   │   ├── SDRCommands.swift           — menu-bar commands
+│   │   ├── BandwidthEntry.swift        — typed bandwidth field
+│   │   ├── FrequencyDigitsEntry.swift  — 12-digit tuner display
+│   │   ├── FrequencyAxis.swift         — axis labels
+│   │   ├── SpectrumGridView.swift      — grid overlay
+│   │   ├── VfoOverlayView.swift        — draggable VFO marker
+│   │   ├── RadioReferenceDialog.swift  — RR search sheet
+│   │   └── Formatters.swift            — shared display helpers
 │   ├── Resources/
 │   │   ├── Info.plist            — bundle metadata (CFBundle* names
 │   │   │                           here are user-facing `sdr-rs`)
@@ -115,9 +155,16 @@ make swift-test
 - **The `.app` this produces is NOT shippable.** Ad-hoc signed,
   no Developer ID, no notarization. That's M6 (production
   signing + notarization + stapling + GitHub Actions).
-- **macOS deployment target is 14 (Sonoma)** per the epic spec —
-  `@Observable`, `NavigationSplitView`, modern AsyncStream
-  semantics all need 14+.
+- **macOS deployment target is 26 (Tahoe).** Bumped from the
+  original 14 floor for the Apple-native transcription pipeline
+  (`SpeechAnalyzer` + `SpeechTranscriber`, both new in macOS 26).
+  Set in `Packages/SdrCoreKit/Package.swift` (`.macOS(.v26)`)
+  and `MACOSX_DEPLOYMENT_TARGET = 26.0` in the Xcode project.
+  The Rust side stays on `MACOSX_DEPLOYMENT_TARGET = "14.0"` in
+  `.cargo/config.toml` — Rust has no macOS-26-only deps, so
+  keeping its archive 14-compatible costs nothing and means the
+  same `libsdr_ffi.a` would link against an older Swift host
+  if we ever needed to.
 - **Xcode 16 or newer is required to open the project.** The
   `.xcodeproj` uses `objectVersion = 77` and the
   `PBXFileSystemSynchronizedRootGroup` ISA added in Xcode 16 so
@@ -127,7 +174,171 @@ make swift-test
   to `objectVersion = 63` and maintain explicit `PBXGroup`
   members — not a regression worth taking on unless someone
   actually hits it.
-- **Mach-O deployment-target pin** lives in `.cargo/config.toml`
-  (`MACOSX_DEPLOYMENT_TARGET = "14.0"`), matching the Xcode
-  project's setting so the Rust static archive's object files
-  and the Swift-linked host agree on the min-OS stamp.
+- **Mach-O deployment-target pin** for the Rust archive lives in
+  `.cargo/config.toml` (`MACOSX_DEPLOYMENT_TARGET = "14.0"`).
+  The Swift host's pin is higher (26.0, see above) — that's
+  fine because the linker honors the higher of the two.
+
+## Sidebar architecture (macOS)
+
+The macOS app uses the same VS Code-style activity-bar pattern as
+the GTK frontend (epic [#441](https://github.com/jasonherald/rtl-sdr/issues/441),
+GTK parallel [#420](https://github.com/jasonherald/rtl-sdr/issues/420)):
+narrow icon strips on each window edge switch the adjacent panel
+between "activities". Left bar hosts General / Radio / Audio /
+Display / Scanner / Share; right bar hosts Transcript / Bookmarks.
+See [`docs/design/sidebar-activity-bar-redesign.md`](../../docs/design/sidebar-activity-bar-redesign.md)
+for the full design rationale — the same doc applies to both
+frontends since the pattern was designed cross-platform.
+
+### Key files
+
+- `apps/macos/SDRMac/Views/ActivityBar/ActivityEntry.swift` — the
+  `ActivityEntry` protocol plus the canonical `LeftActivity` and
+  `RightActivity` enums (single source of truth for icon SF
+  Symbol + display name + `⌘N` shortcut index + persistence
+  string). Each case's `rawValue` is the persistence key and
+  matches the Linux `ActivityBarEntry.name` field exactly.
+- `apps/macos/SDRMac/Views/ActivityBar/ActivityBarView.swift` —
+  generic `View` over `ActivityEntry` rendering the 44 pt icon
+  column. Click semantics mirror the GTK
+  `wire_activity_bar_clicks`: clicking a different icon swaps
+  selection AND opens the panel; clicking the active icon
+  toggles the panel while keeping the selection.
+- `apps/macos/SDRMac/Views/ActivityBar/ActivityPanelHost.swift` —
+  `LeftPanelHost` / `RightPanelHost` switch on the active
+  activity and route to the matching panel view.
+- `apps/macos/SDRMac/ContentView.swift` — top-level layout. An
+  `HStack` nests the two activity bars around two conditional
+  panel slots and the center column. The custom resize handle
+  lives here as a private `resizeHandle(side:)` helper —
+  `Color.white.opacity(0.001)` for hit-testability +
+  `NSCursor.resizeLeftRight.push()` on hover + `DragGesture`
+  for drag + `.onTapGesture(count: 2)` for double-click reset.
+  See the [SwiftUI `Color.clear` hit-test](#swift-side-gotchas)
+  note below.
+- `apps/macos/SDRMac/Models/CoreModel.swift` — owns the sidebar
+  session state (`sidebarLeftSelected` / `_Open` / `_Width` and
+  the matching right-side trio). Setters write through to the
+  shared `sdr-config` JSON via the `SdrCore.setConfig*` FFI
+  surface (ABI 0.21+, [issue #449](https://github.com/jasonherald/rtl-sdr/issues/449)).
+
+### Adding a new activity
+
+1. Append a case to `LeftActivity` (or `RightActivity`) in
+   `ActivityEntry.swift`. Keep existing cases' order + raw values
+   stable — they're config keys read by the Linux side too.
+   Match the SF Symbol pick to the Linux Adwaita icon by feel
+   (the mapping is necessarily approximate; see the doc-comment
+   table on `LeftActivity.systemImage` for the current picks).
+   The `shortcutIndex` accessor must return the next free slot;
+   `ActivityBarView` wires `⌘N` (left) or `⌘⇧N` (right) from it.
+2. Add a panel view under `Views/Panels/` (one `Form`-of-
+   `Section`s per the convention below) and route to it from
+   the `switch` in `LeftPanelHost` / `RightPanelHost`.
+3. If the panel needs new model state, add `@Observable`
+   properties on `CoreModel` plus matching setters that write
+   through to the FFI engine; reuse `setConfigString` /
+   `setConfigBool` / `setConfigUInt32` for any config-persisted
+   value so the state round-trips with the Linux side.
+
+### Panel layout convention
+
+Every left activity hosts a `Form` of `Section`s with `header:
+Text(title)` + `footer: Text(short description).font(.caption)`.
+We deliberately avoid `DisclosureGroup` for top-level sections —
+matches the GTK decision to drop `AdwExpanderRow` since the
+extra inset stacked on the group's own inset read cluttered.
+"Always visible, scrollable" looks cleaner than "expanded by
+default, collapsible." See `RadioPanelView.swift` for the
+canonical example (five flat sections; conditional rows inside
+each based on demod mode).
+
+`SourceSection`, `RecordingSection`, and `RtlTcpServerSection`
+are `View`-typed reusable bodies — older surfaces from before
+the redesign that still slot cleanly into the per-activity
+panels they belong to (`General` reuses `SourceSection`; `Audio`
+reuses `RecordingSection`; `Share` is `RtlTcpServerSection`).
+
+### Session persistence
+
+Six config keys (three per side) live as static `let` constants
+on `CoreModel`: `sidebarLeftSelectedKey` / `_OpenKey` /
+`_WidthKey` plus the right-side trio. Values match the Linux
+constants in `crates/sdr-ui/src/sidebar/activity_bar.rs`
+(`ui_sidebar_{left,right}_{selected,open,width_px}`) so a user
+running both frontends gets a consistent layout — the keys are
+read from the same shared `sdr-config` JSON via the engine's
+config FFI (ABI 0.21+, see [`include/sdr_core.h`](../../include/sdr_core.h)
+and [`SdrCore.setConfigString`](Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift)).
+
+`CoreModel.bootstrap()` calls `loadSidebarSession()` after
+constructing the `SdrCore` handle, restoring the persisted
+values onto the observable properties before `ContentView`
+first paints (no flash of default state). On change, the
+`setSidebar*` setters update the observable AND push the new
+value to the FFI; the `sdr-config` auto-save thread flushes
+to disk on its tick.
+
+### Resize behavior
+
+Per-side clamp ranges live as static constants on `CoreModel`:
+`sidebarLeftWidthRange = 220...640` and
+`sidebarRightWidthRange = 360...840`, matching the Linux
+constants. Defaults are `sidebarLeftDefaultWidth = 320` and
+`sidebarRightDefaultWidth = 420` — the right is wider because
+its panels (Transcript / Bookmarks) hold list rows that read
+better with extra room. Drag clamps to the matching range
+during the gesture; the model setter clamps again on commit so
+a non-UI caller can't poison persistent state. Double-click on
+the resize handle snaps that side to its default width.
+
+The drag handle uses a custom 8 px hit target rather than
+`HSplitView` or `NSSplitViewController` — see the [Swift-side
+gotchas](#swift-side-gotchas) below for the rationale.
+
+### Swift-side gotchas
+
+The custom resize handle has two non-obvious lessons baked in
+that are worth preserving when touching this code:
+
+- **`Color.clear` is not hit-testable, even with
+  `.contentShape(Rectangle())`.** SwiftUI's renderer treats
+  `.clear` as "draws nothing AND skip hit-testing." For an
+  invisible-but-hittable surface (drag handles, double-click
+  targets), use `Color.white.opacity(0.001)` instead — visually
+  identical, but the view draws (and therefore hits) normally.
+  Any `opacity > 0` works; 0.001 stays inside the "no pixels
+  drawn" optimization.
+- **Don't reach for `NSSplitViewController` /
+  `NSSplitViewItem` here.** Burned several iterations on
+  [PR #500](https://github.com/jasonherald/rtl-sdr/pull/500)
+  trying the "Apple-blessed" pattern via
+  `NSViewControllerRepresentable`: `viewDidLoad` doesn't run
+  until `controller.view` is first accessed (so the first
+  `updateNSViewController` finds host controllers nil and every
+  pane silently stays on `EmptyView()`); `sizeThatFits`
+  returning `proposal.width ?? 0` collapses the view to 0×0
+  on first paint; without `preferredThicknessFraction`,
+  `NSSplitView`'s first-paint distribution gives the side
+  panes their `maximumThickness` and pushes the center to
+  negative width. The pure-SwiftUI custom-handle approach
+  hits every spec acceptance criterion (cursor / drag / clamp
+  / release-persist / double-click reset / Mac↔Linux config
+  round-trip) without fighting the layout. `NSSplitViewController`
+  belongs as a window's `contentViewController`, not embedded
+  inside a SwiftUI hierarchy.
+
+### Cross-references
+
+- GTK contributor guide: [`CLAUDE.md` → Sidebar architecture](../../CLAUDE.md#sidebar-architecture).
+  The top-level guide describes the GTK side of the same
+  pattern. The two are close cousins; this document focuses on
+  the Mac-specific bits (SwiftUI hosting, custom handle,
+  Apple-native transcription).
+- Design doc (cross-platform): [`docs/design/sidebar-activity-bar-redesign.md`](../../docs/design/sidebar-activity-bar-redesign.md).
+- Tracking epic: [#441](https://github.com/jasonherald/rtl-sdr/issues/441)
+  (Mac sidebar redesign). Per-sub-ticket land logs are in the
+  closed PRs `#491` (scaffolding) → `#493` (General/Radio/Audio/
+  Display) → `#497` (Scanner) → `#499` (session persistence) →
+  `#500` (resize persistence). This doc closes #451.


### PR DESCRIPTION
## Summary

- New "Sidebar architecture (macOS)" section in `apps/macos/README.md` mirroring the GTK `CLAUDE.md` structure (key files / adding an activity / panel convention / session persistence / resize behavior / cross-references).
- Closes the last ticket in the #441 redesign epic.

## Drive-bys

The README was stale enough that updating just the new section would have left a misleading source-layout listing and a wrong macOS deployment target alongside the new content. Cleaned both up while I was here:

- **Source layout** — replaced the pre-redesign tree with the current one. New entries: `Views/ActivityBar/`, `Views/Panels/`, the Metal `Renderer/`, and the broader `Models/` set (BandPreset, Bookmark, BookmarksStore, AveragingMode, RtlTcpClientFavorite, TranscriptionDriver, UsbHotplugMonitor).
- **macOS deployment target** — fixed stale "14 (Sonoma)" claim; the real floor is 26 (Tahoe), bumped for the Apple-native transcription pipeline (`SpeechAnalyzer` + `SpeechTranscriber`, both new in macOS 26).
- **Mach-O note** — clarified the Rust archive's `14.0` pin is intentionally lower than the Swift host's `26.0`; the linker honors the higher of the two, so the asymmetry is fine and keeps the static archive 14-compatible at no cost.

## Lessons captured

The "Swift-side gotchas" subsection preserves two non-obvious things that took meaningful debug time during the resize handle work:

1. **`Color.clear` is not hit-testable**, even with `.contentShape(Rectangle())`. Use `Color.white.opacity(0.001)` for invisible drag/touch surfaces.
2. **Don't reach for `NSSplitViewController` in `NSViewControllerRepresentable`.** Burned several iterations on PR #500 trying it; the pure-SwiftUI custom-handle approach hits every spec acceptance criterion without fighting the layout. (`viewDidLoad` lifecycle, `sizeThatFits` collapse, `preferredThicknessFraction` first-paint distribution — see the README for specifics.)

## Cross-links

- Reverse-link from the GTK `CLAUDE.md` sidebar section so a Linux-side contributor finds the SwiftUI counterpart without having to know to look in `apps/macos/`.
- Forward-link from the new Mac doc to the GTK `CLAUDE.md` and the cross-platform design doc (`docs/design/sidebar-activity-bar-redesign.md`).

## Test plan

- [x] `make mac-app` — clean build (no code changes; sanity-checks the asset/resource pipeline)
- [x] Markdown link targets resolve: `../../CLAUDE.md#sidebar-architecture`, `../../docs/design/sidebar-activity-bar-redesign.md`, `../../include/sdr_core.h`, the SdrCoreKit Package.swift relative path
- [x] Section heading levels match the rest of the README (`##` for top-level, `###` for sub-sections)
- [ ] CodeRabbit review

## Links

- Closes #451
- Last redesign-epic ticket from #441 (which closes alongside as the final sub-ticket lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded macOS app architecture and directory/component guidance
  * Updated platform deployment target and build/signing requirements
  * Enhanced sidebar patterns: two-activity-bar architecture, resize-handle behavior, hit-testing/layout notes
  * Clarified session persistence docs and corrected per-side config key count; added macOS counterpart note describing shared sidebar config keys
<!-- end of auto-generated comment: release notes by coderabbit.ai -->