### PR TITLE
SwiftUI: per-bookmark scan + priority toggles (closes #490)

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -653,6 +653,109 @@ public final class SdrCore: @unchecked Sendable {
         })
     }
 
+    /// One scanner channel for `setScannerChannels`. Owned-Swift
+    /// shape so callers can build the array without managing C
+    /// memory; the wrapper handles the `withCString` /
+    /// `withUnsafeBufferPointer` lifetime dance internally.
+    ///
+    /// `priority`: `0` = normal rotation, `>= 1` = priority
+    /// (matches the engine `ScannerChannel.priority` semantics).
+    /// `dwellMs` / `hangMs` are the host-resolved timings (the
+    /// caller has already folded any per-bookmark override on
+    /// top of the scanner default).
+    ///
+    /// CTCSS / voice-squelch overrides are not part of this
+    /// v1 surface — neither has a Mac UI yet. They land at the
+    /// tail of the C struct in a future minor bump.
+    public struct ScannerChannel: Sendable {
+        public var name: String
+        public var frequencyHz: UInt64
+        public var demodMode: DemodMode
+        public var bandwidthHz: Double
+        public var priority: UInt8
+        public var dwellMs: UInt32
+        public var hangMs: UInt32
+
+        public init(
+            name: String,
+            frequencyHz: UInt64,
+            demodMode: DemodMode,
+            bandwidthHz: Double,
+            priority: UInt8 = 0,
+            dwellMs: UInt32,
+            hangMs: UInt32
+        ) {
+            self.name = name
+            self.frequencyHz = frequencyHz
+            self.demodMode = demodMode
+            self.bandwidthHz = bandwidthHz
+            self.priority = priority
+            self.dwellMs = dwellMs
+            self.hangMs = hangMs
+        }
+    }
+
+    /// Replace the scanner's channel list with the host's
+    /// projection of scan-enabled bookmarks. Pass an empty
+    /// array to clear — the scanner drops its rotation set
+    /// and settles to `.idle` on the next state tick.
+    ///
+    /// Per-entry validation lives on the Rust side: invalid
+    /// UTF-8 names, unknown demod modes, non-positive
+    /// bandwidths all throw `SdrCoreError.invalidArg` before
+    /// any DSP dispatch happens.
+    ///
+    /// The names are borrowed for the call's duration via
+    /// nested `withCString`s; the engine clones each into its
+    /// own `String` before this method returns, so the
+    /// `[ScannerChannel]` argument can be discarded immediately.
+    public func setScannerChannels(_ channels: [ScannerChannel]) throws {
+        if channels.isEmpty {
+            try checkRc(sdr_core_update_scanner_channels(handle, nil, 0))
+            return
+        }
+        // Build a parallel array of `Data` holding NUL-terminated
+        // UTF-8 bytes — gives us a stable pointer per name that
+        // we can hand into `SdrScannerChannel.name_utf8`. The
+        // pointers stay valid for the duration of the
+        // `withUnsafeBufferPointer` block below; the FFI clones
+        // each name into the engine's owned `String` before
+        // returning.
+        let nameBuffers: [[CChar]] = channels.map { ch in
+            // `Array(ch.name.utf8) + [0]` builds a NUL-
+            // terminated UTF-8 byte array; reinterpret as
+            // `CChar` (signed on macOS x86_64 / ARM, matching
+            // `c_char` on the Rust side).
+            ch.name.utf8CString.map { CChar($0) }
+        }
+        try nameBuffers.withUnsafeBufferPointer { (nameBufsPtr: UnsafeBufferPointer<[CChar]>) in
+            // Build the C array on the stack (well, on the heap
+            // via Array's storage, but lifetime-bound to this
+            // closure). Each `name_utf8` points into the
+            // matching `nameBuffers[i]` storage, valid for the
+            // duration of the FFI call.
+            var cChannels: [SdrScannerChannel] = []
+            cChannels.reserveCapacity(channels.count)
+            for (idx, ch) in channels.enumerated() {
+                let namePtr = nameBufsPtr[idx].withUnsafeBufferPointer { $0.baseAddress }
+                cChannels.append(SdrScannerChannel(
+                    name_utf8: namePtr,
+                    frequency_hz: ch.frequencyHz,
+                    demod_mode: ch.demodMode.rawValue,
+                    bandwidth_hz: ch.bandwidthHz,
+                    priority: ch.priority,
+                    dwell_ms: ch.dwellMs,
+                    hang_ms: ch.hangMs
+                ))
+            }
+            try cChannels.withUnsafeBufferPointer { cPtr in
+                try checkRc(sdr_core_update_scanner_channels(
+                    handle, cPtr.baseAddress, cPtr.count
+                ))
+            }
+        }
+    }
+
     // ==========================================================
     //  Config — ABI 0.21, issue #449. Round-trips against the
     //  shared `sdr-config` JSON file passed to the engine at

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -655,8 +655,8 @@ public final class SdrCore: @unchecked Sendable {
 
     /// One scanner channel for `setScannerChannels`. Owned-Swift
     /// shape so callers can build the array without managing C
-    /// memory; the wrapper handles the `withCString` /
-    /// `withUnsafeBufferPointer` lifetime dance internally.
+    /// memory; the wrapper internally `strdup`s each name into
+    /// heap storage and frees it after the FFI call returns.
     ///
     /// `priority`: `0` = normal rotation, `>= 1` = priority
     /// (matches the engine `ScannerChannel.priority` semantics).
@@ -705,10 +705,16 @@ public final class SdrCore: @unchecked Sendable {
     /// bandwidths all throw `SdrCoreError.invalidArg` before
     /// any DSP dispatch happens.
     ///
-    /// The names are borrowed for the call's duration via
-    /// nested `withCString`s; the engine clones each into its
-    /// own `String` before this method returns, so the
-    /// `[ScannerChannel]` argument can be discarded immediately.
+    /// Each channel's `name` is heap-copied via `strdup` and
+    /// freed after the FFI call returns — the engine clones
+    /// each name into its own `String` before
+    /// `sdr_core_update_scanner_channels` returns, so the
+    /// `[ScannerChannel]` argument can be discarded
+    /// immediately. The earlier nested-
+    /// `withUnsafeBufferPointer` approach was UB (pointer
+    /// extracted from an inner closure outlived its scope);
+    /// `strdup` is the documented Swift→C lifetime workaround.
+    /// Per `CodeRabbit` round 1 on PR #615.
     public func setScannerChannels(_ channels: [ScannerChannel]) throws {
         if channels.isEmpty {
             try checkRc(sdr_core_update_scanner_channels(handle, nil, 0))

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -714,45 +714,56 @@ public final class SdrCore: @unchecked Sendable {
             try checkRc(sdr_core_update_scanner_channels(handle, nil, 0))
             return
         }
-        // Build a parallel array of `Data` holding NUL-terminated
-        // UTF-8 bytes — gives us a stable pointer per name that
-        // we can hand into `SdrScannerChannel.name_utf8`. The
-        // pointers stay valid for the duration of the
-        // `withUnsafeBufferPointer` block below; the FFI clones
-        // each name into the engine's owned `String` before
-        // returning.
-        let nameBuffers: [[CChar]] = channels.map { ch in
-            // `Array(ch.name.utf8) + [0]` builds a NUL-
-            // terminated UTF-8 byte array; reinterpret as
-            // `CChar` (signed on macOS x86_64 / ARM, matching
-            // `c_char` on the Rust side).
-            ch.name.utf8CString.map { CChar($0) }
+        // Heap-allocate each name via `strdup` and free it on
+        // exit. The earlier nested-`withUnsafeBufferPointer`
+        // approach extracted `$0.baseAddress` from an inner
+        // closure — that pointer escapes its closure's scope
+        // even though the underlying Array storage happened
+        // to outlive it, which is undefined behavior under
+        // Swift's pointer-lifetime contract. Per `CodeRabbit`
+        // round 1 on PR #615.
+        //
+        // The engine clones each name into an owned `String`
+        // before `sdr_core_update_scanner_channels` returns,
+        // so the `defer free` runs after the bytes have been
+        // copied — no use-after-free.
+        let namePointers: [UnsafeMutablePointer<CChar>?] = channels.map { ch in
+            ch.name.withCString { strdup($0) }
         }
-        try nameBuffers.withUnsafeBufferPointer { (nameBufsPtr: UnsafeBufferPointer<[CChar]>) in
-            // Build the C array on the stack (well, on the heap
-            // via Array's storage, but lifetime-bound to this
-            // closure). Each `name_utf8` points into the
-            // matching `nameBuffers[i]` storage, valid for the
-            // duration of the FFI call.
-            var cChannels: [SdrScannerChannel] = []
-            cChannels.reserveCapacity(channels.count)
-            for (idx, ch) in channels.enumerated() {
-                let namePtr = nameBufsPtr[idx].withUnsafeBufferPointer { $0.baseAddress }
-                cChannels.append(SdrScannerChannel(
-                    name_utf8: namePtr,
-                    frequency_hz: ch.frequencyHz,
-                    demod_mode: ch.demodMode.rawValue,
-                    bandwidth_hz: ch.bandwidthHz,
-                    priority: ch.priority,
-                    dwell_ms: ch.dwellMs,
-                    hang_ms: ch.hangMs
-                ))
-            }
-            try cChannels.withUnsafeBufferPointer { cPtr in
-                try checkRc(sdr_core_update_scanner_channels(
-                    handle, cPtr.baseAddress, cPtr.count
-                ))
-            }
+        defer { namePointers.forEach { free($0) } }
+
+        // `strdup` returns nil on allocation failure. If any
+        // entry failed, surface as `internal` rather than
+        // sending a partial channel list (the Rust side
+        // would reject a null name in any entry, but bailing
+        // here gives the host a cleaner error message).
+        guard !namePointers.contains(where: { $0 == nil }) else {
+            throw SdrCoreError(
+                code: .internal,
+                message: "setScannerChannels: failed to copy channel names"
+            )
+        }
+
+        var cChannels: [SdrScannerChannel] = []
+        cChannels.reserveCapacity(channels.count)
+        for (idx, ch) in channels.enumerated() {
+            // Force-unwrap is safe — the guard above rejected
+            // any nil entry. Casting to `UnsafePointer` since
+            // the FFI takes `*const c_char`.
+            cChannels.append(SdrScannerChannel(
+                name_utf8: UnsafePointer(namePointers[idx]!),
+                frequency_hz: ch.frequencyHz,
+                demod_mode: ch.demodMode.rawValue,
+                bandwidth_hz: ch.bandwidthHz,
+                priority: ch.priority,
+                dwell_ms: ch.dwellMs,
+                hang_ms: ch.hangMs
+            ))
+        }
+        try cChannels.withUnsafeBufferPointer { cPtr in
+            try checkRc(sdr_core_update_scanner_channels(
+                handle, cPtr.baseAddress, cPtr.count
+            ))
         }
     }
 

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCore.swift
@@ -720,6 +720,24 @@ public final class SdrCore: @unchecked Sendable {
             try checkRc(sdr_core_update_scanner_channels(handle, nil, 0))
             return
         }
+
+        // Pre-validate names for embedded NUL bytes — Swift
+        // `String` allows them but C `strdup` (per POSIX) stops
+        // copying at the first `\0`, silently truncating the
+        // channel name at the FFI boundary. A truncated name
+        // breaks `ChannelKey` identity, which corrupts lockout
+        // / unlock matching and the active-channel readout.
+        // Surface as `.invalidArg` so the caller knows which
+        // entry is bad, rather than letting the engine receive
+        // a half-name that won't match anywhere. Per
+        // `CodeRabbit` round 2 on PR #615.
+        if let badIndex = channels.firstIndex(where: { $0.name.utf8.contains(0) }) {
+            throw SdrCoreError(
+                code: .invalidArg,
+                message: "setScannerChannels: channel[\(badIndex)].name contains an embedded NUL byte"
+            )
+        }
+
         // Heap-allocate each name via `strdup` and free it on
         // exit. The earlier nested-`withUnsafeBufferPointer`
         // approach extracted `$0.baseAddress` from an inner

--- a/apps/macos/SDRMac/Models/Bookmark.swift
+++ b/apps/macos/SDRMac/Models/Bookmark.swift
@@ -67,6 +67,44 @@ struct Bookmark: Codable, Identifiable, Hashable {
     /// Per issue #339 (flyout) / #241 (RadioReference import).
     var rrCategory: String?
 
+    // MARK: Scanner participation
+
+    /// Include this bookmark in scanner rotation. `nil` is
+    /// treated as `false` (off) — same default as the Linux
+    /// `Bookmark.scan_enabled` field, which serializes via
+    /// `#[serde(default)]` and so produces the same on-disk
+    /// shape (key absent OR `false`) for an existing bookmark
+    /// the user hasn't opted in. Per issue #490, mirrors
+    /// Linux PR #375.
+    var scanEnabled: Bool?
+
+    /// Priority tier — `nil` or `0` is normal rotation, `>= 1`
+    /// is priority (the scanner state machine checks priority
+    /// channels more often). Schema parity with the Linux
+    /// `Bookmark.priority: u8` field. The bookmark-row toggle
+    /// in the flyout is a Bool affordance over this — see
+    /// `priorityEnabled` below.
+    ///
+    /// `UInt8?` rather than `Bool?` because the Linux side
+    /// already encodes higher tiers (reserved for #365 priority-
+    /// interrupt follow-up). Storing the underlying integer
+    /// keeps the Mac-saved `bookmarks.json` round-trippable
+    /// through the Linux frontend without losing tier
+    /// information that a future Linux release might write.
+    var priority: UInt8?
+
+    /// `Bool`-valued view of `priority` for the UI toggle.
+    /// `true` when `priority >= 1`. Setting to `true` writes
+    /// `1` (single non-zero tier the Mac UI surfaces today);
+    /// setting to `false` clears to `nil` rather than `0` so
+    /// the JSON omits the key for never-configured bookmarks
+    /// — matches the Linux `#[serde(default)]` "absent → 0"
+    /// shape on round-trip.
+    var priorityEnabled: Bool {
+        get { (priority ?? 0) >= 1 }
+        set { priority = newValue ? 1 : nil }
+    }
+
     /// JSON key mapping so the on-disk schema matches the
     /// Linux side's snake_case field name (`rr_category`).
     /// Enables a user who runs both frontends to share the
@@ -87,5 +125,11 @@ struct Bookmark: Codable, Identifiable, Hashable {
         case deemphasis
         case rrCategory = "rr_category"
         case agcType = "agc_type"
+        // Snake_case JSON keys that match the Linux
+        // `Bookmark` struct field names exactly so a
+        // `bookmarks.json` written by either frontend
+        // round-trips through the other unchanged. Per #490.
+        case scanEnabled = "scan_enabled"
+        case priority
     }
 }

--- a/apps/macos/SDRMac/Models/BookmarksStore.swift
+++ b/apps/macos/SDRMac/Models/BookmarksStore.swift
@@ -33,6 +33,19 @@ final class BookmarksStore {
     /// `SDRMacApp.defaultBookmarksPath()`.
     private let storagePath: URL
 
+    /// Fires after every successful `save()` (i.e., after any
+    /// add / remove / update / move / scan-toggle / priority-
+    /// toggle). The scene wires this to
+    /// `CoreModel.refreshScannerChannels()` so the engine's
+    /// scanner rotation tracks the bookmark list automatically.
+    /// Per #490.
+    ///
+    /// Stored as a closure rather than reaching into `CoreModel`
+    /// directly so this store stays decoupled from the engine —
+    /// makes the unit tests on the JSON round-trip / mutation
+    /// paths trivial without needing a `CoreModel` fixture.
+    var onChanged: (() -> Void)?
+
     init(storagePath: URL) {
         self.storagePath = storagePath
         load()
@@ -62,6 +75,28 @@ final class BookmarksStore {
 
     func move(fromOffsets source: IndexSet, toOffset destination: Int) {
         bookmarks.move(fromOffsets: source, toOffset: destination)
+        save()
+    }
+
+    /// Toggle a bookmark's `scanEnabled` flag in place. Doesn't
+    /// touch `updatedAt` — the timestamp tracks tuning-state
+    /// edits (frequency, demod, etc.), and a scanner-membership
+    /// flip isn't that. Avoids gratuitous re-sorts on the
+    /// flyout's "recent" view. Per #490.
+    func setScanEnabled(id: UUID, enabled: Bool) {
+        guard let i = bookmarks.firstIndex(where: { $0.id == id }) else { return }
+        bookmarks[i].scanEnabled = enabled
+        save()
+    }
+
+    /// Toggle a bookmark's priority tier — `true` writes `1`,
+    /// `false` clears to `nil` (so the JSON omits the key for
+    /// never-promoted bookmarks, matching the Linux serde
+    /// default shape). Same `updatedAt`-untouched policy as
+    /// `setScanEnabled` above. Per #490.
+    func setPriorityEnabled(id: UUID, enabled: Bool) {
+        guard let i = bookmarks.firstIndex(where: { $0.id == id }) else { return }
+        bookmarks[i].priorityEnabled = enabled
         save()
     }
 
@@ -107,6 +142,12 @@ final class BookmarksStore {
             try data.write(to: storagePath, options: .atomic)
         } catch {
             bookmarksLog.error("Failed to save bookmarks: \(error.localizedDescription)")
+            // Fall through — `onChanged` still fires below
+            // because the in-memory state did update; the
+            // on-disk state diverging on an IO error is a
+            // separate problem the logger has already
+            // surfaced.
         }
+        onChanged?()
     }
 }

--- a/apps/macos/SDRMac/Models/BookmarksStore.swift
+++ b/apps/macos/SDRMac/Models/BookmarksStore.swift
@@ -142,11 +142,16 @@ final class BookmarksStore {
             try data.write(to: storagePath, options: .atomic)
         } catch {
             bookmarksLog.error("Failed to save bookmarks: \(error.localizedDescription)")
-            // Fall through — `onChanged` still fires below
-            // because the in-memory state did update; the
-            // on-disk state diverging on an IO error is a
-            // separate problem the logger has already
-            // surfaced.
+            // Don't fire `onChanged` on a failed save —
+            // pushing scanner channels based on state that
+            // never made it to disk would leave the engine
+            // and `bookmarks.json` divergent until the next
+            // successful save (or a relaunch, where the load
+            // path would silently revert the engine to the
+            // last-on-disk state). Better to skip the
+            // notification and let the next mutation try
+            // again. Per `CodeRabbit` round 1 on PR #615.
+            return
         }
         onChanged?()
     }

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -1678,17 +1678,69 @@ final class CoreModel {
     //  Scanner — issue #447 (ABI 0.20)
     // ----------------------------------------------------------
 
+    /// Pull-style accessor the scanner-channel projection uses
+    /// to read the current bookmark list without owning a
+    /// strong reference to `BookmarksStore`. Set once at
+    /// startup by the app's scene (`SDRMacApp.task`) — the
+    /// closure captures the store weakly, so a future test
+    /// harness can substitute a fixture without going through
+    /// the live `BookmarksStore`. Per #490.
+    var bookmarksProvider: (() -> [Bookmark])?
+
     /// Toggle the scanner master switch. Optimistic — we flip
     /// `scannerEnabled` immediately so the UI doesn't lag, but
     /// the engine's `scannerStateChanged` reply is authoritative
-    /// for the resulting phase (`scannerState`). Until #490
-    /// lands the per-bookmark `scan_enabled` projection,
-    /// flipping this on with no scan-enabled bookmarks leaves
-    /// the engine in `.idle` (no rotation to drive), and the
-    /// panel's State row reflects that.
+    /// for the resulting phase (`scannerState`).
+    ///
+    /// On every flip we re-project the current scan-enabled
+    /// bookmarks and push the channel list — the engine clears
+    /// its rotation when the master switch goes off, and a
+    /// fresh start needs the channels in place before `Idle →
+    /// Retuning` can happen. Per #490 (paired with the schema
+    /// + UI + projection landing in the same PR).
     func setScannerEnabled(_ on: Bool) {
         scannerEnabled = on
         capture { try core?.setScannerEnabled(on) }
+        refreshScannerChannels()
+    }
+
+    /// Project the current scan-enabled bookmarks into the
+    /// scanner's `ScannerChannel` shape and push the list to
+    /// the engine. Mirrors the Linux
+    /// `project_and_push_scanner_channels` helper —
+    /// per-bookmark dwell/hang overrides are folded onto the
+    /// scanner default values held on the model.
+    ///
+    /// Bookmarks without a center frequency are skipped — a
+    /// scanner channel needs a tune target and there's nothing
+    /// sensible to fall back to. Bookmarks without a demod
+    /// mode default to NFM (the canonical scanner-voice mode);
+    /// bookmarks without an explicit bandwidth default to
+    /// 12.5 kHz (NFM voice channel width). These match the
+    /// Mac default-bandwidth-for-mode policy elsewhere in the
+    /// model and keep partial-recall bookmarks usable in the
+    /// scanner without forcing the user to fully populate
+    /// every field. Per #490.
+    func refreshScannerChannels() {
+        guard let core, let provider = bookmarksProvider else { return }
+        let bookmarks = provider()
+        let dwell = UInt32(scannerDefaultDwellMs)
+        let hang = UInt32(scannerDefaultHangMs)
+        let channels: [SdrCore.ScannerChannel] = bookmarks.compactMap { b in
+            guard b.scanEnabled == true, let freq = b.centerFrequencyHz else {
+                return nil
+            }
+            return SdrCore.ScannerChannel(
+                name: b.name,
+                frequencyHz: UInt64(freq.rounded()),
+                demodMode: b.demodMode ?? .nfm,
+                bandwidthHz: b.bandwidthHz ?? 12_500.0,
+                priority: b.priority ?? 0,
+                dwellMs: dwell,
+                hangMs: hang
+            )
+        }
+        capture { try core.setScannerChannels(channels) }
     }
 
     /// Lock out the channel currently latched (if any) for the
@@ -1732,6 +1784,10 @@ final class CoreModel {
         let clamped = min(max(ms, range.lowerBound), range.upperBound)
         scannerDefaultDwellMs = clamped
         UserDefaults.standard.set(clamped, forKey: Self.scannerDefaultDwellMsDefaultsKey)
+        // Re-push the channel list with the new fallback —
+        // any bookmark without a per-channel override picks
+        // up the new dwell on the next rotation. Per #490.
+        refreshScannerChannels()
     }
 
     /// Update the default hang time per-channel (ms). Same
@@ -1742,6 +1798,7 @@ final class CoreModel {
         let clamped = min(max(ms, range.lowerBound), range.upperBound)
         scannerDefaultHangMs = clamped
         UserDefaults.standard.set(clamped, forKey: Self.scannerDefaultHangMsDefaultsKey)
+        refreshScannerChannels()
     }
 
     /// `UserDefaults` key for the scanner default-dwell (ms).

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -1727,14 +1727,30 @@ final class CoreModel {
         let dwell = UInt32(scannerDefaultDwellMs)
         let hang = UInt32(scannerDefaultHangMs)
         let channels: [SdrCore.ScannerChannel] = bookmarks.compactMap { b in
-            guard b.scanEnabled == true, let freq = b.centerFrequencyHz else {
+            // Hard guards on every numeric field — `bookmarks.json`
+            // is user-editable and a hand-edited file with a
+            // negative / NaN / out-of-range frequency would
+            // otherwise trap on `UInt64(freq.rounded())`.
+            // `UInt64(exactly:)` returns nil for any value
+            // outside the type's range without trapping; the
+            // bandwidth guard rejects 0 / negative / NaN /
+            // infinity which the FFI would refuse anyway. Per
+            // `CodeRabbit` round 1 on PR #615.
+            guard b.scanEnabled == true,
+                  let freq = b.centerFrequencyHz,
+                  freq.isFinite,
+                  freq >= 0,
+                  let freqHz = UInt64(exactly: freq.rounded())
+            else {
                 return nil
             }
+            let bandwidth = b.bandwidthHz ?? 12_500.0
+            guard bandwidth.isFinite, bandwidth > 0 else { return nil }
             return SdrCore.ScannerChannel(
                 name: b.name,
-                frequencyHz: UInt64(freq.rounded()),
+                frequencyHz: freqHz,
                 demodMode: b.demodMode ?? .nfm,
-                bandwidthHz: b.bandwidthHz ?? 12_500.0,
+                bandwidthHz: bandwidth,
                 priority: b.priority ?? 0,
                 dwellMs: dwell,
                 hangMs: hang

--- a/apps/macos/SDRMac/SDRMacApp.swift
+++ b/apps/macos/SDRMac/SDRMacApp.swift
@@ -37,6 +37,31 @@ struct SDRMacApp: App {
                     // driver reaching into a nil core.
                     transcription.attach(core: core)
                     appDelegate.model = core
+                    // Wire scanner-channel projection (#490).
+                    // CoreModel pulls the current bookmark list
+                    // via this provider on every projection
+                    // tick; BookmarksStore notifies on every
+                    // save so the engine's rotation stays in
+                    // sync with the user's scan/priority
+                    // toggles + adds + deletes.
+                    //
+                    // `[weak bookmarks]` / `[weak core]` avoids
+                    // a strong reference cycle even though both
+                    // are scene-owned `@State` for the app's
+                    // lifetime — defensive against a future
+                    // refactor that scopes either differently.
+                    core.bookmarksProvider = { [weak bookmarks] in
+                        bookmarks?.bookmarks ?? []
+                    }
+                    bookmarks.onChanged = { [weak core] in
+                        core?.refreshScannerChannels()
+                    }
+                    // Initial sync: a previously-saved scan-
+                    // enabled bookmark should reach the engine
+                    // before the user touches anything, so the
+                    // scanner master switch behaves correctly
+                    // from the first toggle.
+                    core.refreshScannerChannels()
                 }
         }
         .windowToolbarStyle(.unified)

--- a/apps/macos/SDRMac/Views/BookmarksPanel.swift
+++ b/apps/macos/SDRMac/Views/BookmarksPanel.swift
@@ -407,6 +407,59 @@ struct BookmarkListRow: View {
             }
             .buttonStyle(.plain)
 
+            // Trailing scanner participation toggles — per
+            // #490 / Linux PR #375. Two icon-only buttons:
+            // "Scan" (radiowaves) opts the bookmark into
+            // scanner rotation; "Priority" (star) bumps it
+            // into the priority tier so the scanner state
+            // machine checks it more often. Both fields
+            // round-trip through `bookmarks.json` with
+            // matching Linux schema keys.
+            //
+            // Filled / outlined glyph is the "on / off" cue;
+            // colored fill on "on" matches the existing
+            // active-bookmark checkmark style above so the
+            // row's visual language stays consistent. Each
+            // button has both `.help` and
+            // `.accessibilityLabel` per the icon-only-button
+            // convention (PR #361 round 1).
+            Button {
+                let on = !(bookmark.scanEnabled ?? false)
+                store.setScanEnabled(id: bookmark.id, enabled: on)
+            } label: {
+                Image(systemName: (bookmark.scanEnabled ?? false)
+                    ? "radiowaves.left"
+                    : "radiowaves.left")
+                    .symbolVariant((bookmark.scanEnabled ?? false) ? .fill : .none)
+                    .foregroundStyle((bookmark.scanEnabled ?? false)
+                        ? Color.accentColor
+                        : .secondary)
+            }
+            .buttonStyle(.borderless)
+            .help((bookmark.scanEnabled ?? false)
+                ? "Remove from scanner rotation"
+                : "Add to scanner rotation")
+            .accessibilityLabel((bookmark.scanEnabled ?? false)
+                ? "Scanner enabled"
+                : "Scanner disabled")
+
+            Button {
+                store.setPriorityEnabled(id: bookmark.id,
+                                         enabled: !bookmark.priorityEnabled)
+            } label: {
+                Image(systemName: bookmark.priorityEnabled ? "star.fill" : "star")
+                    .foregroundStyle(bookmark.priorityEnabled
+                        ? Color.accentColor
+                        : .secondary)
+            }
+            .buttonStyle(.borderless)
+            .help(bookmark.priorityEnabled
+                ? "Remove priority"
+                : "Mark as priority channel")
+            .accessibilityLabel(bookmark.priorityEnabled
+                ? "Priority channel"
+                : "Normal priority")
+
             // Trailing per-row delete. Icon-only so it doesn't
             // crowd the row, with both a tooltip AND an
             // accessibility label — PR #361 round 1 flagged

--- a/crates/sdr-ffi/src/command.rs
+++ b/crates/sdr-ffi/src/command.rs
@@ -1281,6 +1281,159 @@ pub unsafe extern "C" fn sdr_core_unlock_scanner_channel(
     }
 }
 
+// ============================================================
+//  Scanner channel projection — #490 / ABI 0.22
+// ============================================================
+//
+//  The scanner state machine only rotates through channels
+//  pushed via `UiToDsp::UpdateScannerChannels`. The Linux UI
+//  builds these from each `Bookmark` row that has
+//  `scan_enabled = true`, folding per-bookmark dwell/hang
+//  overrides on top of the UI-side defaults; this FFI command
+//  exposes the same projection path to non-Rust hosts. Per
+//  #490, paired with the macOS `BookmarksStore`'s scan +
+//  priority toggles.
+
+/// C-layout mirror of `sdr_scanner::ScannerChannel` for the
+/// `sdr_core_update_scanner_channels` array argument. Each
+/// channel is identified by `(name_utf8, frequency_hz)` —
+/// matches the engine's `ChannelKey` shape — plus the
+/// retune-time tuning fields and the resolved dwell/hang
+/// timings the host folded from per-bookmark overrides.
+///
+/// CTCSS / voice-squelch overrides are intentionally not
+/// part of this v1 surface — neither has a Mac UI yet, and
+/// representing `Option<CtcssMode>` / `Option<VoiceSquelchMode>`
+/// at the C boundary would require adding two more enums to
+/// the header. When those Mac panels ship, the surface grows
+/// at the tail of this struct (additive, ABI minor bump).
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct SdrScannerChannel {
+    /// Bookmark name — borrowed for the duration of the
+    /// `sdr_core_update_scanner_channels` call. The engine
+    /// copies the bytes into its own `String` before returning,
+    /// so the host's storage can be freed/reused immediately.
+    pub name_utf8: *const c_char,
+    /// Channel frequency in Hz.
+    pub frequency_hz: u64,
+    /// Demod mode. Discriminant matches the existing
+    /// `SdrDemodMode` enum already in the header.
+    pub demod_mode: i32,
+    /// Channel filter bandwidth in Hz.
+    pub bandwidth_hz: f64,
+    /// Priority tier — `0` = normal, `>= 1` = priority.
+    pub priority: u8,
+    /// Resolved dwell time (ms) — the host has folded any
+    /// per-channel override on top of the scanner default
+    /// before pushing.
+    pub dwell_ms: u32,
+    /// Resolved hang time (ms) — same projection contract as
+    /// `dwell_ms`.
+    pub hang_ms: u32,
+}
+
+/// Replace the scanner's channel list. Routes to
+/// `UiToDsp::UpdateScannerChannels`. Pass an empty list
+/// (`channels = NULL` + `count = 0`) to clear — the scanner
+/// drops its rotation set and settles to `Idle` on the next
+/// state tick. Per #490 (ABI 0.22).
+///
+/// `channels` may be null only when `count == 0`. Non-null
+/// `channels` with `count == 0` is rejected as `InvalidArg`.
+/// Each entry's `name_utf8` must be a valid NUL-terminated
+/// UTF-8 string for the duration of the call; the engine
+/// clones it.
+///
+/// # Safety
+///
+/// `handle` must be either null or a pointer previously
+/// returned by `sdr_core_create`. `channels` must be either
+/// null (with `count == 0`) or a pointer to `count`
+/// contiguous `SdrScannerChannel` records, each with a valid
+/// `name_utf8` pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sdr_core_update_scanner_channels(
+    handle: *mut SdrCore,
+    channels: *const SdrScannerChannel,
+    count: usize,
+) -> i32 {
+    unsafe {
+        with_core(handle, |core| {
+            // Empty list → clear path. Both NULL+0 and
+            // non-NULL+0 ARE technically callable, but we
+            // require pointer-vs-count consistency so a buggy
+            // host with `count = 0` and a stale pointer can't
+            // mask the off-by-one against this surface.
+            if count == 0 {
+                if !channels.is_null() {
+                    set_last_error(
+                        "sdr_core_update_scanner_channels: count is 0 but channels is non-null",
+                    );
+                    return Err(SdrCoreError::InvalidArg);
+                }
+                send(core, UiToDsp::UpdateScannerChannels(Vec::new()))?;
+                return Ok(());
+            }
+            if channels.is_null() {
+                set_last_error("sdr_core_update_scanner_channels: channels is null but count > 0");
+                return Err(SdrCoreError::InvalidArg);
+            }
+            // SAFETY: caller contract — `count` contiguous
+            // records starting at `channels`.
+            let raw_slice = std::slice::from_raw_parts(channels, count);
+            let mut owned: Vec<sdr_scanner::ScannerChannel> = Vec::with_capacity(count);
+            for (idx, c) in raw_slice.iter().enumerate() {
+                if c.name_utf8.is_null() {
+                    set_last_error(format!(
+                        "sdr_core_update_scanner_channels: channel[{idx}].name_utf8 is null"
+                    ));
+                    return Err(SdrCoreError::InvalidArg);
+                }
+                let cstr = std::ffi::CStr::from_ptr(c.name_utf8);
+                let Ok(name) = cstr.to_str() else {
+                    set_last_error(format!(
+                        "sdr_core_update_scanner_channels: channel[{idx}].name_utf8 is not valid UTF-8"
+                    ));
+                    return Err(SdrCoreError::InvalidArg);
+                };
+                let Some(demod) = demod_mode_from_c(c.demod_mode) else {
+                    set_last_error(format!(
+                        "sdr_core_update_scanner_channels: channel[{idx}].demod_mode unknown ({})",
+                        c.demod_mode
+                    ));
+                    return Err(SdrCoreError::InvalidArg);
+                };
+                if !c.bandwidth_hz.is_finite() || c.bandwidth_hz <= 0.0 {
+                    set_last_error(format!(
+                        "sdr_core_update_scanner_channels: channel[{idx}].bandwidth_hz must be finite and positive, got {}",
+                        c.bandwidth_hz
+                    ));
+                    return Err(SdrCoreError::InvalidArg);
+                }
+                owned.push(sdr_scanner::ScannerChannel {
+                    key: sdr_scanner::ChannelKey {
+                        name: name.to_owned(),
+                        frequency_hz: c.frequency_hz,
+                    },
+                    demod_mode: demod,
+                    bandwidth: c.bandwidth_hz,
+                    // CTCSS / voice-squelch overrides are not
+                    // surfaced via this v1 FFI struct; both are
+                    // None for the Mac path until the matching
+                    // panels ship.
+                    ctcss: None,
+                    voice_squelch: None,
+                    priority: c.priority,
+                    dwell_ms: c.dwell_ms,
+                    hang_ms: c.hang_ms,
+                });
+            }
+            send(core, UiToDsp::UpdateScannerChannels(owned))
+        })
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -2573,6 +2726,163 @@ mod tests {
             unsafe { sdr_core_set_scanner_enabled(h, false) },
             SdrCoreError::Ok.as_int()
         );
+        destroy(h);
+    }
+
+    // ------------------------------------------------------
+    //  update_scanner_channels — ABI 0.22, issue #490
+    // ------------------------------------------------------
+
+    /// Fixture bandwidth used by the channel-projection tests.
+    /// 12.5 kHz is the canonical NFM voice channel width and
+    /// matches the `bandwidth` field on the actual NOAA-Weather
+    /// fixture name in use elsewhere in this module.
+    const TEST_SCANNER_BW_HZ: f64 = 12_500.0;
+    /// Fixture dwell — ms the host would resolve from the
+    /// scanner's default-dwell setting once per-bookmark
+    /// overrides are folded in. Just needs to be a finite,
+    /// realistic value for the projection-side tests.
+    const TEST_SCANNER_DWELL_MS: u32 = 100;
+    /// Fixture hang — same rationale as `TEST_SCANNER_DWELL_MS`.
+    const TEST_SCANNER_HANG_MS: u32 = 2_000;
+
+    #[test]
+    fn update_scanner_channels_rejects_null_handle() {
+        assert_eq!(
+            unsafe { sdr_core_update_scanner_channels(std::ptr::null_mut(), std::ptr::null(), 0) },
+            SdrCoreError::InvalidHandle.as_int()
+        );
+    }
+
+    #[test]
+    fn update_scanner_channels_empty_clears_rotation() {
+        // The empty-list path is how a host clears the
+        // scanner's rotation (e.g., user toggled scan_enabled
+        // off on every bookmark). Both null+0 callable; the
+        // engine accepts the empty Vec and the state machine
+        // settles to Idle on the next tick.
+        let h = make_handle();
+        assert_eq!(
+            unsafe { sdr_core_update_scanner_channels(h, std::ptr::null(), 0) },
+            SdrCoreError::Ok.as_int()
+        );
+        destroy(h);
+    }
+
+    #[test]
+    fn update_scanner_channels_count_zero_with_nonnull_pointer_is_invalid() {
+        // Catch a buggy host that has `count = 0` and a stale
+        // pointer — refuse rather than silently accept, so the
+        // off-by-one is caught at the boundary.
+        let h = make_handle();
+        let name = CString::new("Test").unwrap();
+        let ch = SdrScannerChannel {
+            name_utf8: name.as_ptr(),
+            frequency_hz: TEST_SCANNER_FREQ_HZ,
+            demod_mode: SDR_DEMOD_NFM,
+            bandwidth_hz: TEST_SCANNER_BW_HZ,
+            priority: 0,
+            dwell_ms: TEST_SCANNER_DWELL_MS,
+            hang_ms: TEST_SCANNER_HANG_MS,
+        };
+        let rc = unsafe { sdr_core_update_scanner_channels(h, &raw const ch, 0) };
+        assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+        destroy(h);
+    }
+
+    #[test]
+    fn update_scanner_channels_null_pointer_with_count_is_invalid() {
+        let h = make_handle();
+        let rc = unsafe { sdr_core_update_scanner_channels(h, std::ptr::null(), 1) };
+        assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+        destroy(h);
+    }
+
+    #[test]
+    fn update_scanner_channels_rejects_null_name_in_entry() {
+        let h = make_handle();
+        let ch = SdrScannerChannel {
+            name_utf8: std::ptr::null(),
+            frequency_hz: TEST_SCANNER_FREQ_HZ,
+            demod_mode: SDR_DEMOD_NFM,
+            bandwidth_hz: TEST_SCANNER_BW_HZ,
+            priority: 0,
+            dwell_ms: TEST_SCANNER_DWELL_MS,
+            hang_ms: TEST_SCANNER_HANG_MS,
+        };
+        let rc = unsafe { sdr_core_update_scanner_channels(h, &raw const ch, 1) };
+        assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+        destroy(h);
+    }
+
+    #[test]
+    fn update_scanner_channels_rejects_unknown_demod_mode() {
+        let h = make_handle();
+        let name = CString::new("Test").unwrap();
+        let ch = SdrScannerChannel {
+            name_utf8: name.as_ptr(),
+            frequency_hz: TEST_SCANNER_FREQ_HZ,
+            demod_mode: 99, // out of range — no `SDR_DEMOD_*` matches.
+            bandwidth_hz: TEST_SCANNER_BW_HZ,
+            priority: 0,
+            dwell_ms: TEST_SCANNER_DWELL_MS,
+            hang_ms: TEST_SCANNER_HANG_MS,
+        };
+        let rc = unsafe { sdr_core_update_scanner_channels(h, &raw const ch, 1) };
+        assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+        destroy(h);
+    }
+
+    #[test]
+    fn update_scanner_channels_rejects_non_positive_bandwidth() {
+        let h = make_handle();
+        let name = CString::new("Test").unwrap();
+        for bad_bw in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let ch = SdrScannerChannel {
+                name_utf8: name.as_ptr(),
+                frequency_hz: TEST_SCANNER_FREQ_HZ,
+                demod_mode: SDR_DEMOD_NFM,
+                bandwidth_hz: bad_bw,
+                priority: 0,
+                dwell_ms: TEST_SCANNER_DWELL_MS,
+                hang_ms: TEST_SCANNER_HANG_MS,
+            };
+            let rc = unsafe { sdr_core_update_scanner_channels(h, &raw const ch, 1) };
+            assert_eq!(rc, SdrCoreError::InvalidArg.as_int());
+        }
+        destroy(h);
+    }
+
+    #[test]
+    fn update_scanner_channels_happy_path_round_trip() {
+        // Two channels — one normal, one priority. Confirms
+        // the slice walk + dispatch round-trips for a typical
+        // host call.
+        let h = make_handle();
+        let name_a = CString::new("NOAA Weather").unwrap();
+        let name_b = CString::new("FRS Ch 1").unwrap();
+        let channels = [
+            SdrScannerChannel {
+                name_utf8: name_a.as_ptr(),
+                frequency_hz: TEST_SCANNER_FREQ_HZ,
+                demod_mode: SDR_DEMOD_NFM,
+                bandwidth_hz: TEST_SCANNER_BW_HZ,
+                priority: 1, // priority tier
+                dwell_ms: TEST_SCANNER_DWELL_MS,
+                hang_ms: TEST_SCANNER_HANG_MS,
+            },
+            SdrScannerChannel {
+                name_utf8: name_b.as_ptr(),
+                frequency_hz: 462_562_500,
+                demod_mode: SDR_DEMOD_NFM,
+                bandwidth_hz: TEST_SCANNER_BW_HZ,
+                priority: 0,
+                dwell_ms: TEST_SCANNER_DWELL_MS,
+                hang_ms: TEST_SCANNER_HANG_MS,
+            },
+        ];
+        let rc = unsafe { sdr_core_update_scanner_channels(h, channels.as_ptr(), channels.len()) };
+        assert_eq!(rc, SdrCoreError::Ok.as_int());
         destroy(h);
     }
 }

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -22,7 +22,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 21;
+pub const ABI_VERSION_MINOR: u32 = 22;
 
 /// Return the ABI version the library was built with.
 ///
@@ -369,7 +369,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 21);
+        assert!(ABI_VERSION_MINOR == 22);
     };
 
     #[test]

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -56,8 +56,35 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 21
+#define SDR_CORE_ABI_VERSION_MINOR 22
 /*
+ * 0.22 — exposes the scanner channel-list projection
+ * (`UiToDsp::UpdateScannerChannels`) at the FFI boundary so the
+ * macOS SwiftUI scanner panel finally has channels to rotate
+ * through — completes the half-wired surface from ABI 0.20
+ * (issue #447). Pairs with the macOS bookmarks layer growing
+ * `scan_enabled` / `priority` fields under issue #490.
+ *
+ * Additive surface (existing struct layouts and enum values
+ * unchanged):
+ *   - New struct `SdrScannerChannel` carrying name + freq +
+ *     demod + bandwidth + priority + dwell + hang. Reuses the
+ *     existing `SdrDemodMode` discriminants for the
+ *     `demod_mode` field. CTCSS / voice-squelch overrides
+ *     are not surfaced in this v1 — neither has a Mac UI yet,
+ *     and both grow at the tail of this struct in a future
+ *     minor bump when those panels ship.
+ *   - New command `sdr_core_update_scanner_channels(handle,
+ *     channels, count)`. Pass `channels = NULL, count = 0` to
+ *     clear the rotation; non-null + non-zero replaces the
+ *     full channel set. Each entry is validated (UTF-8 name,
+ *     known demod, finite + positive bandwidth) before the
+ *     dispatch reaches the DSP thread, so a bad host call
+ *     can't poison the engine's state.
+ *
+ * Pre-1.0 minor bumps are breaking by project convention — old
+ * 0.21 hosts must fail fast on the exact-match ABI check.
+ *
  * 0.21 — exposes the shared `sdr-config` JSON file at the FFI
  * boundary so the macOS SwiftUI host can round-trip sidebar
  * session state (#449) and other settings against the same
@@ -1695,6 +1722,69 @@ int32_t sdr_core_unlock_scanner_channel(
     SdrCore*    handle,
     const char* name_utf8,
     uint64_t    frequency_hz
+);
+
+/* --- Scanner channel-list projection (issue #490, ABI 0.22) --- */
+
+/*
+ * One entry in the array passed to
+ * `sdr_core_update_scanner_channels`. Each entry describes a
+ * fully-resolved scanner channel: name + freq for identity
+ * (`ChannelKey`), demod / bandwidth for the retune target, and
+ * the host-resolved dwell / hang timings (per-bookmark
+ * overrides folded onto the scanner default).
+ *
+ * `name_utf8` is borrowed for the duration of the call; the
+ * engine clones the bytes into its owned `String` before
+ * returning, so the host's storage can be freed/reused
+ * immediately.
+ *
+ * `demod_mode` reuses the existing `SdrDemodMode` discriminants
+ * (defined further up the header, near `sdr_core_set_demod_mode`).
+ *
+ * `priority` follows the `sdr_scanner::ScannerChannel.priority`
+ * convention: `0` = normal rotation, `>= 1` = priority tier
+ * (checked more often by the state machine).
+ *
+ * CTCSS / voice-squelch overrides are intentionally not part of
+ * this v1 surface — neither has a Mac UI yet. When those panels
+ * ship, the surface grows at the tail of this struct (additive
+ * minor bump).
+ */
+typedef struct SdrScannerChannel {
+    const char* name_utf8;
+    uint64_t    frequency_hz;
+    int32_t     demod_mode;
+    double      bandwidth_hz;
+    uint8_t     priority;
+    uint32_t    dwell_ms;
+    uint32_t    hang_ms;
+} SdrScannerChannel;
+
+/*
+ * Replace the scanner's channel list. Routes to
+ * `UiToDsp::UpdateScannerChannels`. Pass `channels = NULL` +
+ * `count = 0` to clear — the scanner drops its rotation set
+ * and settles to `Idle` on the next state tick.
+ *
+ * Per-entry validation: rejects null `name_utf8`, non-UTF-8
+ * names, unknown `demod_mode`, and non-finite or non-positive
+ * `bandwidth_hz` with `SDR_CORE_ERR_INVALID_ARG` before any
+ * dispatch reaches the DSP thread.
+ *
+ * `channels = NULL` with `count > 0` is rejected as InvalidArg.
+ * `channels != NULL` with `count == 0` is also rejected — the
+ * pointer-vs-count consistency check catches a buggy host with
+ * a stale pointer.
+ *
+ * Concurrency: the call walks the `count`-element array on the
+ * caller's thread and sends an owned `Vec` across the DSP mpsc
+ * channel; safe from any thread.
+ */
+int32_t sdr_core_update_scanner_channels(
+    SdrCore*                 handle,
+    const SdrScannerChannel* channels,
+    size_t                   count
 );
 
 /* --- Config — shared `sdr-config` JSON (issue #449, ABI 0.21) --- */


### PR DESCRIPTION
## Summary

Closes the last gap on the Mac sidebar redesign's scanner panel — the master switch from #447 finally has channels to rotate through. Adds scan + priority toggles to every bookmark row in the flyout, persists them in `bookmarks.json` with snake_case keys matching the Linux side, and projects scan-enabled bookmarks onto the engine's `UpdateScannerChannels` command on every mutation.

## Schema (Mac ↔ Linux round-trip)

`Bookmark` grows two fields:

- `scanEnabled: Bool?` (key `scan_enabled`) — `nil`/missing treated as `false`, same as Linux's `#[serde(default)]` default.
- `priority: UInt8?` (key `priority`) — **deviation from spec wording**: spec proposed `priority_enabled: Bool` (key `priority_enabled`), but Linux already uses `priority: u8` (`>= 1` is priority, with higher tiers reserved for the #365 priority-interrupt follow-up). Choosing `priority_enabled` would have broken the spec's stated round-trip requirement, so I went with cross-frontend parity. The bookmark-row toggle is a `Bool` view onto this via the computed `priorityEnabled` accessor — `true` reads `priority >= 1`; setting `true` writes `1`, setting `false` clears to `nil` so the JSON omits the key for never-promoted bookmarks (matches Linux serde-default shape).

`BookmarksStore` grows `setScanEnabled(id:enabled:)` and `setPriorityEnabled(id:enabled:)` mutators that don't bump `updatedAt` — the timestamp tracks tuning-state edits, not scanner-membership flips, so toggling scan/priority doesn't churn the flyout's recent sort.

## UI

`BookmarkListRow` grows two icon-only trailing buttons before the delete affordance:

- **Scan** — `radiowaves.left` filled (accent color) when on, outlined when off.
- **Priority** — `star.fill` / `star`, same color treatment.

Both have `.help` AND `.accessibilityLabel` per the icon-only-button convention (PR #361 round 1's lesson).

## ABI 0.22 — `sdr_core_update_scanner_channels`

New FFI surface for `UiToDsp::UpdateScannerChannels` (deliberately withheld from ABI 0.20 with a `#490` follow-up note in `command.rs`):

- **New struct `SdrScannerChannel`** — name + freq + demod + bandwidth + priority + dwell + hang. Reuses existing `SdrDemodMode` discriminants. CTCSS / voice-squelch overrides not surfaced (neither has a Mac UI yet); both grow at the tail in a future minor bump.
- **New command `sdr_core_update_scanner_channels(handle, channels, count)`**. Empty list clears the rotation; non-null replaces the full set. Per-entry validation rejects null/non-UTF-8 names, unknown demods, and non-positive bandwidths before any DSP dispatch happens. Pointer-vs-count consistency check catches a buggy host with a stale pointer + zero count.
- **8 new tests** covering null handle, empty-clear path, consistency rejections, per-entry validation arms, and a happy-path two-channel round-trip.

## Wiring

- `SdrCore.ScannerChannel` value type + `setScannerChannels(_:)` Swift wrapper. Names go via nested `withCString` / `withUnsafeBufferPointer` so lifetimes are correct through the FFI call.
- `CoreModel.refreshScannerChannels()` projects scan-enabled bookmarks into a `[SdrCore.ScannerChannel]`, folding `scannerDefaultDwellMs` / `scannerDefaultHangMs` as fallback timing (mirrors the Linux `project_and_push_scanner_channels` helper). Bookmarks without a center frequency are skipped; bookmarks without a demod default to NFM (canonical scanner-voice mode); bookmarks without explicit bandwidth default to 12.5 kHz (NFM voice channel width).
- Re-projection fires from: `setScannerEnabled` (both flips), `setScannerDefaultDwellMs` / `setScannerDefaultHangMs`, every `BookmarksStore.save()` via the new `onChanged` callback, and once at startup so previously-saved scan-enabled bookmarks reach the engine before first user interaction.
- `SDRMacApp` wires `core.bookmarksProvider` (pull) and `bookmarks.onChanged` (push) closures with `[weak …]` captures to keep the two stores decoupled (and trivially substitutable in a test harness).

## Spec acceptance (#490)

| | |
|---|---|
| Both toggles render on each bookmark row in the flyout | ✓ |
| Flipping a toggle persists immediately via `BookmarksStore.save` | ✓ |
| `bookmarks.json` written by the Mac round-trips on the Linux side unchanged | ✓ (snake_case keys + Linux-shape defaults) |
| Scanner rotation honors the scan flag (stretch) | ✓ — `refreshScannerChannels` filters on `scanEnabled == true`; engine pushes update on every mutation |

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --lib` — 206 sdr-ffi tests pass (8 new)
- [x] `make ffi-header-check` — hand-written and cbindgen agree
- [x] `make mac-app` — Mac app bundles successfully
- [x] Smoke tests:
  - Scan + priority icons render on every bookmark row
  - Toggle Scan on a bookmark → JSON has `"scan_enabled": true`; survives quit/relaunch
  - Toggle Priority on a bookmark → JSON has `"priority": 1`
  - With at least one scan-enabled bookmark, flipping the master switch on transitions the State row from "Off" → "Listening…" / "Retuning…"
  - Toggling scan off on the only enabled bookmark while running → State drops to "Off" within a tick
- [ ] CodeRabbit review

## Links

- Closes #490
- Unblocks #447's deferred bookmark→ScannerChannel projection (the scanner panel's master switch now actually rotates channels)
- Linux parallel: PR #375 (per-bookmark scan + priority on the GTK side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-bookmark scanner-rotation and per-bookmark priority toggles in the bookmarks panel
  * Bookmarks now drive the scanner channel list sent to the engine with an initial sync on launch
  * Changing global scanner defaults (dwell/hang) immediately updates scanner configuration

* **Bug Fixes**
  * Change notification is fired only after bookmarks are successfully saved
<!-- end of auto-generated comment: release notes by coderabbit.ai -->