### PR TITLE
SwiftUI: VFO reset affordances + recenter-on-tune (closes #488 + #489)

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEnums.swift
@@ -52,6 +52,39 @@ public enum DemodMode: Int32, Sendable, CaseIterable, Codable {
         default: return nil
         }
     }
+
+    /// Default channel bandwidth in Hz for this mode. Mirrors
+    /// the `*_DEFAULT_BANDWIDTH` constants in
+    /// `crates/sdr-radio/src/demod/<mode>.rs` exactly so a UI
+    /// "reset to mode default" affordance lands at the same
+    /// width the engine would use on a fresh demod open.
+    ///
+    /// The Linux side calls `default_bandwidth_for_mode` in
+    /// `sdr-radio` for the same answer; on the Mac path #488
+    /// chose to keep this Swift-side instead of plumbing
+    /// another FFI command — the table is small, the values
+    /// are stable engine constants (changing one is a
+    /// deliberate cross-frontend act, not a frequent thing),
+    /// and skipping the FFI hop keeps the Reset-VFO button's
+    /// pre-condition check synchronous.
+    ///
+    /// **Cross-frontend invariant:** if a Rust-side
+    /// `*_DEFAULT_BANDWIDTH` ever moves, this table needs the
+    /// matching update or the Mac reset button will mis-click.
+    /// A Linux test pins the Rust constants individually, so
+    /// drift is loud.
+    public var defaultBandwidthHz: Double {
+        switch self {
+        case .wfm: return 150_000   // crates/sdr-radio/src/demod/wfm.rs
+        case .nfm: return 12_500    // crates/sdr-radio/src/demod/nfm.rs
+        case .am:  return 10_000    // crates/sdr-radio/src/demod/am.rs
+        case .usb: return 2_800     // crates/sdr-radio/src/demod/usb.rs
+        case .lsb: return 2_800     // crates/sdr-radio/src/demod/lsb.rs
+        case .dsb: return 4_600     // crates/sdr-radio/src/demod/dsb.rs
+        case .cw:  return 200       // crates/sdr-radio/src/demod/cw.rs
+        case .raw: return 48_000    // crates/sdr-radio/src/demod/raw.rs
+        }
+    }
 }
 
 /// FM de-emphasis mode. Matches `SdrDeemphasis` in the C header.

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
@@ -47,6 +47,7 @@ private let kScannerStateChanged          = Int32(SDR_EVT_SCANNER_STATE_CHANGED.
 private let kScannerActiveChannelChanged  = Int32(SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED.rawValue)
 private let kScannerEmptyRotation         = Int32(SDR_EVT_SCANNER_EMPTY_ROTATION.rawValue)
 private let kScannerMutexStopped          = Int32(SDR_EVT_SCANNER_MUTEX_STOPPED.rawValue)
+private let kVfoOffsetChanged             = Int32(SDR_EVT_VFO_OFFSET_CHANGED.rawValue)
 
 /// High-level event from the engine.
 ///
@@ -134,6 +135,14 @@ public enum SdrCoreEvent: Sendable, Equatable {
     /// Host shows a toast describing the transition. Per issue
     /// #447 (ABI 0.20).
     case scannerMutexStopped(ScannerMutexReason)
+
+    /// VFO offset changed. Engine echoes this for every offset
+    /// change — host commands AND engine-internal resets
+    /// (scanner retune, future per-VFO controls). Host updates
+    /// its observable `vfoOffsetHz` from this event so the
+    /// spectrum overlay stays in sync without polling. Per
+    /// issue #488 (ABI 0.23).
+    case vfoOffsetChanged(hz: Double)
 
     /// Translate a C `SdrEvent` into a Swift value.
     ///
@@ -285,6 +294,9 @@ public enum SdrCoreEvent: Sendable, Equatable {
                 return nil
             }
             return .scannerMutexStopped(reason)
+
+        case kVfoOffsetChanged:
+            return .vfoOffsetChanged(hz: payload.vfo_offset_hz)
 
         case kNetworkSinkStatus:
             let status = payload.network_sink_status

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrCoreEvent.swift
@@ -48,6 +48,7 @@ private let kScannerActiveChannelChanged  = Int32(SDR_EVT_SCANNER_ACTIVE_CHANNEL
 private let kScannerEmptyRotation         = Int32(SDR_EVT_SCANNER_EMPTY_ROTATION.rawValue)
 private let kScannerMutexStopped          = Int32(SDR_EVT_SCANNER_MUTEX_STOPPED.rawValue)
 private let kVfoOffsetChanged             = Int32(SDR_EVT_VFO_OFFSET_CHANGED.rawValue)
+private let kBandwidthChanged             = Int32(SDR_EVT_BANDWIDTH_CHANGED.rawValue)
 
 /// High-level event from the engine.
 ///
@@ -143,6 +144,16 @@ public enum SdrCoreEvent: Sendable, Equatable {
     /// spectrum overlay stays in sync without polling. Per
     /// issue #488 (ABI 0.23).
     case vfoOffsetChanged(hz: Double)
+
+    /// Channel bandwidth changed. Symmetric with
+    /// `vfoOffsetChanged` above — host commands AND engine-
+    /// internal changes (scanner retune to a channel with a
+    /// different bandwidth, future per-mode auto-pick). Host
+    /// updates its observable `bandwidthHz` so the bandwidth-
+    /// row reset icon's enabled state and the floating Reset-
+    /// VFO button's visibility track engine truth without
+    /// polling. Per `CodeRabbit` round 1 on PR #616 (ABI 0.24).
+    case bandwidthChanged(hz: Double)
 
     /// Translate a C `SdrEvent` into a Swift value.
     ///
@@ -297,6 +308,9 @@ public enum SdrCoreEvent: Sendable, Equatable {
 
         case kVfoOffsetChanged:
             return .vfoOffsetChanged(hz: payload.vfo_offset_hz)
+
+        case kBandwidthChanged:
+            return .bandwidthChanged(hz: payload.bandwidth_hz)
 
         case kNetworkSinkStatus:
             let status = payload.network_sink_status

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -1187,6 +1187,23 @@ final class CoreModel {
                 // panel sync; nothing extra here.
                 break
             }
+        case .vfoOffsetChanged(let hz):
+            // Engine-authoritative VFO offset. Fires for host-
+            // initiated `setVfoOffset` commands AND engine-
+            // internal resets (scanner retune to a new
+            // channel, future per-VFO controls). Update the
+            // observable field directly so the spectrum
+            // overlay + the Reset VFO button visibility track
+            // engine truth without polling. Per #488.
+            //
+            // Skip the write when the value already matches —
+            // the optimistic local update inside
+            // `setVfoOffset` would otherwise loop the field
+            // through one redundant @Observable invalidation
+            // on every drag tick.
+            if vfoOffsetHz != hz {
+                vfoOffsetHz = hz
+            }
         @unknown default:
             // Surface new engine event variants during
             // development. SdrCoreEvent is a non-frozen enum
@@ -1443,6 +1460,23 @@ final class CoreModel {
         }
         centerFrequencyHz = clamped
         capture { try core?.tune(clamped) }
+        // Recenter the VFO on every tune — the new tuner-center
+        // is the new VFO target, not the previous offset
+        // relative to the new center. Mirrors the Linux #378
+        // fix: without this, after manually tuning from
+        // 100 → 150 MHz with a +50 kHz offset, the engine
+        // continued demodulating at 150.05 MHz and the overlay
+        // looked frozen at the same screen position even though
+        // the spectrum's frequency labels had shifted. Per
+        // issue #489 (Mac parity audit confirmed the bug
+        // exists on this side too).
+        //
+        // Skip the engine round-trip when offset is already 0 —
+        // most tunes start from a centered VFO and the no-op
+        // setVfoOffset would just bounce the local field.
+        if vfoOffsetHz != 0 {
+            setVfoOffset(0)
+        }
     }
 
     func setSampleRate(_ hz: Double) {
@@ -1453,6 +1487,52 @@ final class CoreModel {
     func setVfoOffset(_ hz: Double) {
         vfoOffsetHz = hz
         capture { try core?.setVfoOffset(hz) }
+    }
+
+    /// `true` when the current bandwidth differs from the
+    /// active demod mode's default (within a 0.5 Hz tolerance
+    /// to defeat float round-trip noise from the engine echo).
+    /// Drives the bandwidth-row reset icon's enable state on
+    /// the Radio panel. Per #488.
+    var isBandwidthAtModeDefault: Bool {
+        abs(bandwidthHz - demodMode.defaultBandwidthHz) < 0.5
+    }
+
+    /// `true` when the VFO is at its default state — bandwidth
+    /// matches the mode default AND offset is zero. Drives the
+    /// floating Reset VFO button's visibility on the spectrum
+    /// overlay (button hides at default, appears when the user
+    /// has moved either knob). Per #488.
+    var isVfoAtDefault: Bool {
+        isBandwidthAtModeDefault && vfoOffsetHz == 0
+    }
+
+    /// One-click reset for both bandwidth AND offset. Routes
+    /// every change through the engine setters (no direct
+    /// observable mutation) so the engine echoes back via
+    /// `BandwidthChanged` / `VfoOffsetChanged` events — the
+    /// observable model stays the consumer of the engine's
+    /// authoritative state, not a parallel writer that could
+    /// drift. Per #488.
+    func resetVfo() {
+        let defaultBw = demodMode.defaultBandwidthHz
+        if abs(bandwidthHz - defaultBw) >= 0.5 {
+            setBandwidth(defaultBw)
+        }
+        if vfoOffsetHz != 0 {
+            setVfoOffset(0)
+        }
+    }
+
+    /// Reset bandwidth only. Used by the bandwidth-row trailing
+    /// reset icon on the Radio panel — leaves offset alone so
+    /// a user who wanted to keep their offset but normalize
+    /// the channel filter width can do exactly that. Per #488.
+    func resetBandwidthToModeDefault() {
+        let defaultBw = demodMode.defaultBandwidthHz
+        if abs(bandwidthHz - defaultBw) >= 0.5 {
+            setBandwidth(defaultBw)
+        }
     }
 
     /// Apply a cursor-centered zoom to the display viewport.

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -1204,6 +1204,17 @@ final class CoreModel {
             if vfoOffsetHz != hz {
                 vfoOffsetHz = hz
             }
+        case .bandwidthChanged(let hz):
+            // Symmetric with `vfoOffsetChanged` above —
+            // engine-authoritative bandwidth, fires for host
+            // commands AND engine-internal changes (scanner
+            // retune to a channel with a different bandwidth,
+            // future per-mode auto-pick). Same same-value
+            // guard rationale. Per `CodeRabbit` round 1 on
+            // PR #616.
+            if bandwidthHz != hz {
+                bandwidthHz = hz
+            }
         @unknown default:
             // Surface new engine event variants during
             // development. SdrCoreEvent is a non-frozen enum
@@ -1471,10 +1482,15 @@ final class CoreModel {
         // issue #489 (Mac parity audit confirmed the bug
         // exists on this side too).
         //
-        // Skip the engine round-trip when offset is already 0 —
-        // most tunes start from a centered VFO and the no-op
-        // setVfoOffset would just bounce the local field.
-        if vfoOffsetHz != 0 {
+        // Skip the engine round-trip when offset is already
+        // (within float-noise tolerance of) zero — most tunes
+        // start from a centered VFO and the no-op setVfoOffset
+        // would just bounce the local field. Tolerant compare
+        // because the offset is a `Double` round-tripping
+        // through the FFI; the engine echo can land at e.g.
+        // 1e-12 instead of exactly 0. Per `CodeRabbit` round 1
+        // on PR #616.
+        if abs(vfoOffsetHz) >= Self.vfoOffsetEpsilonHz {
             setVfoOffset(0)
         }
     }
@@ -1489,22 +1505,41 @@ final class CoreModel {
         capture { try core?.setVfoOffset(hz) }
     }
 
+    /// Tolerance for "is this at default?" comparisons on
+    /// `vfoOffsetHz` and `bandwidthHz`. Both are `Double`
+    /// values that round-trip through the FFI (and the engine
+    /// echo can land at, e.g., 1e-12 instead of exactly 0
+    /// after DSP-side resampling). Half a Hz is well below
+    /// any meaningful audible / spectral effect, so a
+    /// half-Hz tolerance lets every "at default" path agree
+    /// without misclassifying epsilon noise as a non-default
+    /// state — which would keep the floating Reset-VFO button
+    /// visible even though the user can't tell anything's off.
+    /// Per `CodeRabbit` round 1 on PR #616.
+    static let vfoOffsetEpsilonHz: Double = 0.5
+    /// Same tolerance for bandwidth-vs-default comparisons.
+    /// Aliased to the same value so the threshold stays
+    /// consistent across the affordance code paths.
+    static let bandwidthEpsilonHz: Double = 0.5
+
     /// `true` when the current bandwidth differs from the
-    /// active demod mode's default (within a 0.5 Hz tolerance
-    /// to defeat float round-trip noise from the engine echo).
-    /// Drives the bandwidth-row reset icon's enable state on
-    /// the Radio panel. Per #488.
+    /// active demod mode's default (within
+    /// `bandwidthEpsilonHz` tolerance to defeat float round-
+    /// trip noise from the engine echo). Drives the bandwidth-
+    /// row reset icon's enable state on the Radio panel.
+    /// Per #488.
     var isBandwidthAtModeDefault: Bool {
-        abs(bandwidthHz - demodMode.defaultBandwidthHz) < 0.5
+        abs(bandwidthHz - demodMode.defaultBandwidthHz) < Self.bandwidthEpsilonHz
     }
 
     /// `true` when the VFO is at its default state — bandwidth
-    /// matches the mode default AND offset is zero. Drives the
-    /// floating Reset VFO button's visibility on the spectrum
-    /// overlay (button hides at default, appears when the user
-    /// has moved either knob). Per #488.
+    /// matches the mode default AND offset is (within tolerance
+    /// of) zero. Drives the floating Reset VFO button's
+    /// visibility on the spectrum overlay (button hides at
+    /// default, appears when the user has moved either knob).
+    /// Per #488.
     var isVfoAtDefault: Bool {
-        isBandwidthAtModeDefault && vfoOffsetHz == 0
+        isBandwidthAtModeDefault && abs(vfoOffsetHz) < Self.vfoOffsetEpsilonHz
     }
 
     /// One-click reset for both bandwidth AND offset. Routes
@@ -1516,10 +1551,10 @@ final class CoreModel {
     /// drift. Per #488.
     func resetVfo() {
         let defaultBw = demodMode.defaultBandwidthHz
-        if abs(bandwidthHz - defaultBw) >= 0.5 {
+        if abs(bandwidthHz - defaultBw) >= Self.bandwidthEpsilonHz {
             setBandwidth(defaultBw)
         }
-        if vfoOffsetHz != 0 {
+        if abs(vfoOffsetHz) >= Self.vfoOffsetEpsilonHz {
             setVfoOffset(0)
         }
     }
@@ -1530,7 +1565,7 @@ final class CoreModel {
     /// the channel filter width can do exactly that. Per #488.
     func resetBandwidthToModeDefault() {
         let defaultBw = demodMode.defaultBandwidthHz
-        if abs(bandwidthHz - defaultBw) >= 0.5 {
+        if abs(bandwidthHz - defaultBw) >= Self.bandwidthEpsilonHz {
             setBandwidth(defaultBw)
         }
     }

--- a/apps/macos/SDRMac/Views/BandwidthEntry.swift
+++ b/apps/macos/SDRMac/Views/BandwidthEntry.swift
@@ -43,14 +43,27 @@ struct BandwidthEntry: View {
                 .focused($focused)
                 .onAppear { text = formatRate(hz) }
                 .onChange(of: hz) { _, new in
-                    if !focused { text = formatRate(new) }
+                    // External `hz` change — sync the displayed
+                    // text. Guarding on `!focused` (the previous
+                    // approach) blocked external resets when the
+                    // field still had focus from a prior commit:
+                    // the bandwidth-row reset button (#488)
+                    // changes `hz` from outside, `.onChange` fires
+                    // with the field still focused after the
+                    // user's last `Submit`, and the displayed
+                    // value would lag the model. Always sync —
+                    // the only churn this adds is a redundant
+                    // `text = formatRate(hz)` right after the
+                    // field's own `apply()` already wrote it,
+                    // which is harmless.
+                    text = formatRate(new)
                 }
                 .onChange(of: mode) { _, _ in
-                    // Mode switched — don't auto-pick a preset
-                    // (the engine handles that on its side), but
-                    // re-render in case units cross a threshold
-                    // after the model's bandwidth settles.
-                    if !focused { text = formatRate(hz) }
+                    // Mode switched — re-render in case units
+                    // cross a threshold after the model's
+                    // bandwidth settles. Same always-sync
+                    // policy as the `hz` handler above.
+                    text = formatRate(hz)
                 }
                 .onSubmit(commitFromField)
 

--- a/apps/macos/SDRMac/Views/CenterView.swift
+++ b/apps/macos/SDRMac/Views/CenterView.swift
@@ -34,21 +34,54 @@ struct CenterView: View {
 
     var body: some View {
         @Bindable var m = model
-        ZStack {
-            // 1. Metal spectrum + waterfall (bottom layer)
-            SpectrumWaterfallView(
-                model: model,
-                minDb: $m.minDb,
-                maxDb: $m.maxDb
-            )
-            // 2. Frequency / dB grid + labels. Non-hit-testing
-            //    so clicks pass through to the VFO overlay above.
-            SpectrumGridView(model: model)
-            // 3. VFO band + center tick + click-to-tune. On top
-            //    so its DragGesture captures clicks. The grid
-            //    underneath renders behind the translucent VFO
-            //    band — same layering as SDR++ / the GTK UI.
-            VfoOverlayView(model: model)
+        ZStack(alignment: .topTrailing) {
+            ZStack {
+                // 1. Metal spectrum + waterfall (bottom layer)
+                SpectrumWaterfallView(
+                    model: model,
+                    minDb: $m.minDb,
+                    maxDb: $m.maxDb
+                )
+                // 2. Frequency / dB grid + labels. Non-hit-testing
+                //    so clicks pass through to the VFO overlay above.
+                SpectrumGridView(model: model)
+                // 3. VFO band + center tick + click-to-tune. On top
+                //    so its DragGesture captures clicks. The grid
+                //    underneath renders behind the translucent VFO
+                //    band — same layering as SDR++ / the GTK UI.
+                VfoOverlayView(model: model)
+            }
+
+            // Floating "Reset VFO" button — top-right of the
+            // spectrum area. Visible only when the user has
+            // moved either knob away from the mode default
+            // (bandwidth ≠ default OR offset ≠ 0). One click
+            // resets both AND routes through the engine
+            // setters, so the engine echoes back via the
+            // `BandwidthChanged` / `VfoOffsetChanged` events
+            // and the observable model stays a consumer of
+            // engine truth (not a parallel writer that could
+            // drift). Per #488, mirrors the Linux PR #380
+            // floating-button behaviour.
+            //
+            // Conditional on `!model.isVfoAtDefault` so the
+            // button hides cleanly the moment a manual tune
+            // recenters the VFO (per #489's setCenter →
+            // setVfoOffset(0) cascade).
+            if !model.isVfoAtDefault {
+                Button {
+                    model.resetVfo()
+                } label: {
+                    Label("Reset VFO", systemImage: "arrow.counterclockwise")
+                        .labelStyle(.iconOnly)
+                        .padding(6)
+                }
+                .buttonStyle(.borderless)
+                .background(.regularMaterial, in: Circle())
+                .help("Reset VFO bandwidth and offset to mode defaults")
+                .accessibilityLabel("Reset VFO bandwidth and offset")
+                .padding(8)
+            }
         }
         .frame(minHeight: 300)
         // Pinch zoom — cross-platform via SwiftUI's gesture.

--- a/apps/macos/SDRMac/Views/Panels/RadioPanelView.swift
+++ b/apps/macos/SDRMac/Views/Panels/RadioPanelView.swift
@@ -45,12 +45,34 @@ private struct BandwidthSection: View {
     var body: some View {
         Section {
             LabeledContent("Bandwidth") {
-                @Bindable var m = model
-                BandwidthEntry(
-                    hz: $m.bandwidthHz,
-                    mode: model.demodMode
-                ) { hz in
-                    model.setBandwidth(hz)
+                HStack(spacing: 8) {
+                    @Bindable var m = model
+                    BandwidthEntry(
+                        hz: $m.bandwidthHz,
+                        mode: model.demodMode
+                    ) { hz in
+                        model.setBandwidth(hz)
+                    }
+                    // Trailing per-row reset to mode default.
+                    // Enabled only when the current bandwidth
+                    // differs from `demodMode.defaultBandwidthHz`
+                    // — switching demod modes re-evaluates so
+                    // the icon flips state automatically when
+                    // the user picks a new mode whose default
+                    // matches (or doesn't match) the current
+                    // bandwidth. Per #488. Routes through the
+                    // engine setter so the echo round-trips
+                    // through `BandwidthChanged` and the
+                    // observable model stays an event consumer.
+                    Button {
+                        model.resetBandwidthToModeDefault()
+                    } label: {
+                        Image(systemName: "arrow.counterclockwise")
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(model.isBandwidthAtModeDefault)
+                    .help("Reset bandwidth to \(model.demodMode.label) default")
+                    .accessibilityLabel("Reset bandwidth to mode default")
                 }
             }
         } header: {

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -63,6 +63,7 @@ pub const SDR_EVT_SCANNER_STATE_CHANGED: i32 = 14;
 pub const SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED: i32 = 15;
 pub const SDR_EVT_SCANNER_EMPTY_ROTATION: i32 = 16;
 pub const SDR_EVT_SCANNER_MUTEX_STOPPED: i32 = 17;
+pub const SDR_EVT_VFO_OFFSET_CHANGED: i32 = 18;
 
 // ============================================================
 //  Scanner phase discriminants — must match `SdrScannerState`
@@ -300,6 +301,7 @@ pub struct SdrEventScannerMutexStopped {
 /// | `SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED` | `scanner_active_channel.{name_utf8,frequency_hz}` |
 /// | `SDR_EVT_SCANNER_EMPTY_ROTATION`  | none                         |
 /// | `SDR_EVT_SCANNER_MUTEX_STOPPED`   | `scanner_mutex_stopped.reason` |
+/// | `SDR_EVT_VFO_OFFSET_CHANGED`      | `vfo_offset_hz`              |
 ///
 /// `_placeholder` exists so `SOURCE_STOPPED` events (which carry
 /// no payload) can still construct the struct with a meaningful
@@ -320,6 +322,12 @@ pub union SdrEventPayload {
     pub scanner_state: SdrEventScannerStateChanged,
     pub scanner_active_channel: SdrEventScannerActiveChannelChanged,
     pub scanner_mutex_stopped: SdrEventScannerMutexStopped,
+    /// Payload for `SDR_EVT_VFO_OFFSET_CHANGED` (#488 / ABI
+    /// 0.23). Engine echoes this whenever the VFO offset
+    /// changes — host commands AND engine-internal resets
+    /// (e.g., scanner retune to a new channel) — so the
+    /// observable model can stay in sync without polling.
+    pub vfo_offset_hz: f64,
     /// Placeholder for kinds that carry no payload (e.g.,
     /// `SDR_EVT_SOURCE_STOPPED`). Accessing this field is always
     /// valid as a zero-byte read.
@@ -594,16 +602,17 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         //     light up in the macOS UI whenever the CTCSS / voice-
         //     squelch panels get ported (no specific backlog issue
         //     yet — part of the full-parity backlog under #228).
-        //   - `BandwidthChanged` and `VfoOffsetChanged` are the
-        //     VFO-drag + "reset VFO" feedback-echo events
-        //     (#336 / #341). Linux-only for now; macOS SwiftUI
-        //     gets them when the equivalent VFO overlay +
-        //     reset affordances land on that side.
+        //   - `BandwidthChanged` is the VFO-drag bandwidth-
+        //     resize echo (#336). Linux-only for now; macOS
+        //     SwiftUI gets it when the bandwidth-drag affordance
+        //     lands on that side.
         //
         // Scanner Phase 1 UI events (`ScannerActiveChannelChanged`,
         // `ScannerStateChanged`, `ScannerEmptyRotation`,
         // `ScannerMutexStopped`) landed at the FFI boundary in ABI
         // 0.20 (#447) — see the dedicated arms above.
+        // `VfoOffsetChanged` landed in ABI 0.23 (#488) — also
+        // dedicated arm above.
         //
         // Adding any of these to the ABI is additive (new
         // `SDR_EVT_*` discriminant + new payload struct or reuse
@@ -753,10 +762,22 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
             }
         }
 
+        DspToUi::VfoOffsetChanged(hz) => SdrEvent {
+            // Engine-side echo of every VFO-offset change
+            // (host commands AND engine-internal resets like
+            // scanner retune). Host updates its observable
+            // `vfoOffsetHz` from this event so the spectrum
+            // overlay stays in sync without polling. Per #488
+            // (ABI 0.23).
+            kind: SDR_EVT_VFO_OFFSET_CHANGED,
+            payload: SdrEventPayload {
+                vfo_offset_hz: *hz,
+            },
+        },
+
         DspToUi::FftData(_)
         | DspToUi::DemodModeChanged(_)
         | DspToUi::BandwidthChanged(_)
-        | DspToUi::VfoOffsetChanged(_)
         | DspToUi::CtcssSustainedChanged(_)
         | DspToUi::VoiceSquelchOpenChanged(_)
         // APT lines (#482) aren't surfaced through the FFI layer
@@ -1056,6 +1077,7 @@ mod tests {
         assert_eq!(SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED, 15);
         assert_eq!(SDR_EVT_SCANNER_EMPTY_ROTATION, 16);
         assert_eq!(SDR_EVT_SCANNER_MUTEX_STOPPED, 17);
+        assert_eq!(SDR_EVT_VFO_OFFSET_CHANGED, 18);
     }
 
     #[test]
@@ -1664,21 +1686,22 @@ mod tests {
     }
 
     #[test]
-    fn vfo_offset_changed_is_intentionally_dropped_at_ffi() {
-        // Regression guard for the ABI-v1 "intentionally withheld"
-        // contract. `VfoOffsetChanged` is the VFO-reset feedback
-        // echo (#341) — Linux-only for now; macOS SwiftUI gets it
-        // when the equivalent VFO overlay + reset affordances
-        // land on that side. If a future refactor accidentally
-        // routes this variant through `translate_event`, the
-        // assertion below flips and the ABI change becomes
-        // visible at test time rather than at a downstream host
-        // that suddenly starts receiving an unknown event kind.
+    fn vfo_offset_changed_translates_to_event() {
+        // Pin the ABI 0.23 surface (#488). Replaces the prior
+        // "intentionally withheld" regression that asserted the
+        // variant was dropped — that was the v1 contract before
+        // the macOS VFO reset affordances landed.
         /// Representative non-zero VFO offset — 25 kHz is typical
         /// of what click-to-tune and drag flows emit in practice.
         const TEST_VFO_OFFSET_HZ: f64 = 25_000.0;
         use sdr_core::DspToUi;
-        assert!(translate_event(&DspToUi::VfoOffsetChanged(TEST_VFO_OFFSET_HZ)).is_none());
+        let (event, owned, _) = translate_event(&DspToUi::VfoOffsetChanged(TEST_VFO_OFFSET_HZ))
+            .expect("VfoOffsetChanged should translate to an event in ABI 0.23");
+        assert_eq!(event.kind, SDR_EVT_VFO_OFFSET_CHANGED);
+        // SAFETY: kind matches the union variant we wrote.
+        let payload = unsafe { event.payload.vfo_offset_hz };
+        assert!((payload - TEST_VFO_OFFSET_HZ).abs() < f64::EPSILON);
+        assert!(owned.is_none());
     }
 
     #[test]

--- a/crates/sdr-ffi/src/event.rs
+++ b/crates/sdr-ffi/src/event.rs
@@ -64,6 +64,7 @@ pub const SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED: i32 = 15;
 pub const SDR_EVT_SCANNER_EMPTY_ROTATION: i32 = 16;
 pub const SDR_EVT_SCANNER_MUTEX_STOPPED: i32 = 17;
 pub const SDR_EVT_VFO_OFFSET_CHANGED: i32 = 18;
+pub const SDR_EVT_BANDWIDTH_CHANGED: i32 = 19;
 
 // ============================================================
 //  Scanner phase discriminants — must match `SdrScannerState`
@@ -302,6 +303,7 @@ pub struct SdrEventScannerMutexStopped {
 /// | `SDR_EVT_SCANNER_EMPTY_ROTATION`  | none                         |
 /// | `SDR_EVT_SCANNER_MUTEX_STOPPED`   | `scanner_mutex_stopped.reason` |
 /// | `SDR_EVT_VFO_OFFSET_CHANGED`      | `vfo_offset_hz`              |
+/// | `SDR_EVT_BANDWIDTH_CHANGED`       | `bandwidth_hz`               |
 ///
 /// `_placeholder` exists so `SOURCE_STOPPED` events (which carry
 /// no payload) can still construct the struct with a meaningful
@@ -328,6 +330,13 @@ pub union SdrEventPayload {
     /// (e.g., scanner retune to a new channel) — so the
     /// observable model can stay in sync without polling.
     pub vfo_offset_hz: f64,
+    /// Payload for `SDR_EVT_BANDWIDTH_CHANGED` (#488 / ABI
+    /// 0.24). Engine echoes this whenever the channel
+    /// bandwidth changes — host commands AND engine-internal
+    /// changes (scanner retune, future per-mode auto-pick).
+    /// Symmetric with `vfo_offset_hz` above; same observable-
+    /// stays-in-sync rationale.
+    pub bandwidth_hz: f64,
     /// Placeholder for kinds that carry no payload (e.g.,
     /// `SDR_EVT_SOURCE_STOPPED`). Accessing this field is always
     /// valid as a zero-byte read.
@@ -602,17 +611,13 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
         //     light up in the macOS UI whenever the CTCSS / voice-
         //     squelch panels get ported (no specific backlog issue
         //     yet — part of the full-parity backlog under #228).
-        //   - `BandwidthChanged` is the VFO-drag bandwidth-
-        //     resize echo (#336). Linux-only for now; macOS
-        //     SwiftUI gets it when the bandwidth-drag affordance
-        //     lands on that side.
-        //
         // Scanner Phase 1 UI events (`ScannerActiveChannelChanged`,
         // `ScannerStateChanged`, `ScannerEmptyRotation`,
         // `ScannerMutexStopped`) landed at the FFI boundary in ABI
         // 0.20 (#447) — see the dedicated arms above.
-        // `VfoOffsetChanged` landed in ABI 0.23 (#488) — also
-        // dedicated arm above.
+        // `VfoOffsetChanged` landed in ABI 0.23 (#488) and
+        // `BandwidthChanged` followed in ABI 0.24 (#616 /
+        // CodeRabbit) — also dedicated arms above.
         //
         // Adding any of these to the ABI is additive (new
         // `SDR_EVT_*` discriminant + new payload struct or reuse
@@ -775,9 +780,25 @@ fn translate_event(msg: &DspToUi) -> Option<(SdrEvent, Option<CString>, Option<V
             },
         },
 
+        DspToUi::BandwidthChanged(hz) => SdrEvent {
+            // Symmetric with the VFO-offset echo above —
+            // host commands AND engine-internal bandwidth
+            // changes (scanner retune to a channel with a
+            // different bandwidth, future per-mode auto-
+            // pick). Host updates its observable
+            // `bandwidthHz` so the bandwidth-row reset icon's
+            // enabled state and the floating Reset-VFO
+            // button's visibility track engine truth without
+            // polling. Per `CodeRabbit` round 1 on PR #616
+            // (ABI 0.24).
+            kind: SDR_EVT_BANDWIDTH_CHANGED,
+            payload: SdrEventPayload {
+                bandwidth_hz: *hz,
+            },
+        },
+
         DspToUi::FftData(_)
         | DspToUi::DemodModeChanged(_)
-        | DspToUi::BandwidthChanged(_)
         | DspToUi::CtcssSustainedChanged(_)
         | DspToUi::VoiceSquelchOpenChanged(_)
         // APT lines (#482) aren't surfaced through the FFI layer
@@ -1078,6 +1099,7 @@ mod tests {
         assert_eq!(SDR_EVT_SCANNER_EMPTY_ROTATION, 16);
         assert_eq!(SDR_EVT_SCANNER_MUTEX_STOPPED, 17);
         assert_eq!(SDR_EVT_VFO_OFFSET_CHANGED, 18);
+        assert_eq!(SDR_EVT_BANDWIDTH_CHANGED, 19);
     }
 
     #[test]
@@ -1701,6 +1723,27 @@ mod tests {
         // SAFETY: kind matches the union variant we wrote.
         let payload = unsafe { event.payload.vfo_offset_hz };
         assert!((payload - TEST_VFO_OFFSET_HZ).abs() < f64::EPSILON);
+        assert!(owned.is_none());
+    }
+
+    #[test]
+    fn bandwidth_changed_translates_to_event() {
+        // Pin the ABI 0.24 surface (#616 / CodeRabbit round 1).
+        // The `vfo_offset_changed` symmetric event landed in
+        // 0.23; this test guards the matching bandwidth path
+        // so the macOS bandwidth-row reset icon's enabled
+        // state doesn't go stale on engine-internal changes.
+        /// Representative NFM voice channel width — exercises
+        /// the round-trip with a realistic value rather than
+        /// a magic round number.
+        const TEST_BANDWIDTH_HZ: f64 = 12_500.0;
+        use sdr_core::DspToUi;
+        let (event, owned, _) = translate_event(&DspToUi::BandwidthChanged(TEST_BANDWIDTH_HZ))
+            .expect("BandwidthChanged should translate to an event in ABI 0.24");
+        assert_eq!(event.kind, SDR_EVT_BANDWIDTH_CHANGED);
+        // SAFETY: kind matches the union variant we wrote.
+        let payload = unsafe { event.payload.bandwidth_hz };
+        assert!((payload - TEST_BANDWIDTH_HZ).abs() < f64::EPSILON);
         assert!(owned.is_none());
     }
 

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -22,7 +22,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 22;
+pub const ABI_VERSION_MINOR: u32 = 23;
 
 /// Return the ABI version the library was built with.
 ///
@@ -369,7 +369,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 22);
+        assert!(ABI_VERSION_MINOR == 23);
     };
 
     #[test]

--- a/crates/sdr-ffi/src/lifecycle.rs
+++ b/crates/sdr-ffi/src/lifecycle.rs
@@ -22,7 +22,7 @@ use crate::handle::SdrCore;
 /// time `const _` in the test module below asserts the two stay
 /// consistent.
 pub const ABI_VERSION_MAJOR: u32 = 0;
-pub const ABI_VERSION_MINOR: u32 = 23;
+pub const ABI_VERSION_MINOR: u32 = 24;
 
 /// Return the ABI version the library was built with.
 ///
@@ -369,7 +369,7 @@ mod tests {
     /// build here rather than drifting silently.
     const _: () = {
         assert!(ABI_VERSION_MAJOR == 0);
-        assert!(ABI_VERSION_MINOR == 23);
+        assert!(ABI_VERSION_MINOR == 24);
     };
 
     #[test]

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -56,8 +56,25 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 22
+#define SDR_CORE_ABI_VERSION_MINOR 23
 /*
+ * 0.23 — exposes the `VfoOffsetChanged` engine event at the FFI
+ * boundary (#488) so the macOS SwiftUI host's observable
+ * `vfoOffsetHz` can stay in sync with engine-internal resets
+ * (scanner retune to a new channel, future per-VFO controls)
+ * without polling.
+ *
+ * Additive surface (existing struct layouts and enum values
+ * unchanged):
+ *   - `SdrEventKind` gains `SDR_EVT_VFO_OFFSET_CHANGED = 18`.
+ *   - `SdrEventPayload` gains a new `vfo_offset_hz: f64` union
+ *     member. No new payload struct — the offset is a single
+ *     primitive, same shape as `sample_rate_hz` and
+ *     `display_bandwidth_hz` already in the union.
+ *
+ * Pre-1.0 minor bumps are breaking by project convention — old
+ * 0.22 hosts must fail fast on the exact-match ABI check.
+ *
  * 0.22 — exposes the scanner channel-list projection
  * (`UiToDsp::UpdateScannerChannels`) at the FFI boundary so the
  * macOS SwiftUI scanner panel finally has channels to rotate
@@ -1955,6 +1972,7 @@ typedef enum SdrEventKind {
     SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED = 15, /* ABI 0.20 — issue #447 */
     SDR_EVT_SCANNER_EMPTY_ROTATION        = 16, /* ABI 0.20 — issue #447 */
     SDR_EVT_SCANNER_MUTEX_STOPPED         = 17, /* ABI 0.20 — issue #447 */
+    SDR_EVT_VFO_OFFSET_CHANGED            = 18, /* ABI 0.23 — issue #488 */
 } SdrEventKind;
 
 /* Scanner phase. Discriminant for the `state` field of
@@ -2178,6 +2196,7 @@ typedef struct SdrEventScannerMutexStopped {
  * SDR_EVT_SCANNER_ACTIVE_CHANNEL_CHANGED scanner_active_channel.{name_utf8,frequency_hz}
  * SDR_EVT_SCANNER_EMPTY_ROTATION         none (all-zero payload)
  * SDR_EVT_SCANNER_MUTEX_STOPPED          scanner_mutex_stopped.reason
+ * SDR_EVT_VFO_OFFSET_CHANGED             vfo_offset_hz
  */
 typedef union SdrEventPayload {
     double sample_rate_hz;
@@ -2193,6 +2212,12 @@ typedef union SdrEventPayload {
     SdrEventScannerStateChanged          scanner_state;
     SdrEventScannerActiveChannelChanged  scanner_active_channel;
     SdrEventScannerMutexStopped          scanner_mutex_stopped;
+    /* Payload for SDR_EVT_VFO_OFFSET_CHANGED (#488 / ABI 0.23).
+     * Engine echoes this whenever the VFO offset changes — host
+     * commands AND engine-internal resets (e.g., scanner retune
+     * to a new channel) — so the observable model can stay in
+     * sync without polling. */
+    double vfo_offset_hz;
     /* Placeholder so kinds with no payload (e.g., SOURCE_STOPPED)
      * have a well-defined zeroed payload representation. */
     uint64_t _placeholder;

--- a/include/sdr_core.h
+++ b/include/sdr_core.h
@@ -56,8 +56,26 @@ extern "C" {
 /* ================================================================ */
 
 #define SDR_CORE_ABI_VERSION_MAJOR 0
-#define SDR_CORE_ABI_VERSION_MINOR 23
+#define SDR_CORE_ABI_VERSION_MINOR 24
 /*
+ * 0.24 — completes the VFO event-echo pair started in 0.23 by
+ * exposing `BandwidthChanged` at the FFI boundary too (#616
+ * CodeRabbit round 1). Without it the macOS bandwidth-row
+ * reset icon's enabled state and the floating Reset-VFO
+ * button's visibility could go stale on engine-internal
+ * bandwidth changes (scanner retune to a channel with a
+ * different bandwidth, future per-mode auto-pick).
+ *
+ * Additive surface (existing struct layouts and enum values
+ * unchanged):
+ *   - `SdrEventKind` gains `SDR_EVT_BANDWIDTH_CHANGED = 19`.
+ *   - `SdrEventPayload` gains a new `bandwidth_hz: f64` union
+ *     member. Symmetric with `vfo_offset_hz` from 0.23 — same
+ *     primitive shape.
+ *
+ * Pre-1.0 minor bumps are breaking by project convention — old
+ * 0.23 hosts must fail fast on the exact-match ABI check.
+ *
  * 0.23 — exposes the `VfoOffsetChanged` engine event at the FFI
  * boundary (#488) so the macOS SwiftUI host's observable
  * `vfoOffsetHz` can stay in sync with engine-internal resets
@@ -1973,6 +1991,7 @@ typedef enum SdrEventKind {
     SDR_EVT_SCANNER_EMPTY_ROTATION        = 16, /* ABI 0.20 — issue #447 */
     SDR_EVT_SCANNER_MUTEX_STOPPED         = 17, /* ABI 0.20 — issue #447 */
     SDR_EVT_VFO_OFFSET_CHANGED            = 18, /* ABI 0.23 — issue #488 */
+    SDR_EVT_BANDWIDTH_CHANGED             = 19, /* ABI 0.24 — #616 CodeRabbit */
 } SdrEventKind;
 
 /* Scanner phase. Discriminant for the `state` field of
@@ -2197,6 +2216,7 @@ typedef struct SdrEventScannerMutexStopped {
  * SDR_EVT_SCANNER_EMPTY_ROTATION         none (all-zero payload)
  * SDR_EVT_SCANNER_MUTEX_STOPPED          scanner_mutex_stopped.reason
  * SDR_EVT_VFO_OFFSET_CHANGED             vfo_offset_hz
+ * SDR_EVT_BANDWIDTH_CHANGED              bandwidth_hz
  */
 typedef union SdrEventPayload {
     double sample_rate_hz;
@@ -2218,6 +2238,11 @@ typedef union SdrEventPayload {
      * to a new channel) — so the observable model can stay in
      * sync without polling. */
     double vfo_offset_hz;
+    /* Payload for SDR_EVT_BANDWIDTH_CHANGED (#616 CodeRabbit /
+     * ABI 0.24). Symmetric with vfo_offset_hz above — host
+     * commands AND engine-internal bandwidth changes (scanner
+     * retune, future per-mode auto-pick). */
+    double bandwidth_hz;
     /* Placeholder so kinds with no payload (e.g., SOURCE_STOPPED)
      * have a well-defined zeroed payload representation. */
     uint64_t _placeholder;


### PR DESCRIPTION
## Summary

Two related Mac-parity tickets that share the VFO surface — bundling so the spectrum overlay + the Radio panel's Bandwidth row only churn once.

**#488** — Floating "Reset VFO" button on the spectrum + per-field bandwidth reset icon on the Radio panel.
**#489** — VFO recenter on every tuner change (Linux PR #378 parity).

## #488 — VFO reset affordances

- **Floating "Reset VFO" button** at top-right of the spectrum. Hidden when the VFO is at default state (bandwidth = mode default AND offset = 0); appears the moment the user moves either knob. One click resets both via the engine setters, so the engine's echo events (`BandwidthChanged` + the new `VfoOffsetChanged`) update the observable model and the button hides itself cleanly.
- **Per-field bandwidth reset icon** as a trailing affordance on the Bandwidth row. Enabled when current bandwidth differs from `demodMode.defaultBandwidthHz`; disabled (greyed) otherwise. Click resets bandwidth only — leaves offset alone, matches Linux PR #380.
- Both affordances have `.help` AND `.accessibilityLabel` per the icon-only-button convention.

### ABI 0.23 — `VfoOffsetChanged` event FFI

The Linux engine has emitted `DspToUi::VfoOffsetChanged(f64)` since #341, but the FFI translator silently dropped it (the "intentionally withheld" tail in `event.rs`). Surfacing it now so the macOS observable model stays in sync with engine-internal resets (scanner retune, future per-VFO controls) without polling.

- New `SDR_EVT_VFO_OFFSET_CHANGED = 18`.
- New `vfo_offset_hz: f64` union member in `SdrEventPayload` — primitive, same shape as `sample_rate_hz` / `display_bandwidth_hz`.
- Translation arm + new `vfo_offset_changed_translates_to_event` test (replaces the prior "intentionally dropped" guard).

### Swift wrappers

- `SdrCoreEvent.vfoOffsetChanged(hz:)` case + `fromC` dispatch arm.
- `CoreModel.handleEvent` consumes into `vfoOffsetHz` with a same-value guard so echoes on the optimistic local-update path don't add a redundant invalidation per drag tick.
- `DemodMode.defaultBandwidthHz` Swift-side helper — the table mirrors the Rust `*_DEFAULT_BANDWIDTH` constants in `crates/sdr-radio/src/demod/<mode>.rs`. Per the spec, lean Swift here (small + stable values) over plumbing another FFI command.
- `CoreModel`: new `isBandwidthAtModeDefault` / `isVfoAtDefault` properties + `resetVfo()` / `resetBandwidthToModeDefault()` — both affordances route through the same engine setters.

## #489 — VFO recenter on tuner change

Mac audit confirmed the same bug Linux #378 fixed: a non-zero VFO offset persisted across manual tunes and bookmark recalls. The overlay's screen position appeared to follow (the spectrum repaints centered on the new frequency), but the engine continued demodulating off-center.

Fix in `CoreModel.setCenter`: when offset is non-zero, also call `setVfoOffset(0)` so the new tuner-center becomes the new VFO target. Same engine-routing policy as #488 — no direct observable mutation, the engine's `VfoOffsetChanged` echo confirms. The no-op (offset already 0) is skipped to keep the common centered-tune path quiet.

## Drive-by

`BandwidthEntry`'s text field used to skip syncing its displayed value when focused — that perf guard blocked external resets when the field held focus from a prior commit (the new bandwidth-row reset icon writes `hz` from outside while the field is still focused after a Submit). Dropped the `!focused` guard in both `onChange(of: hz)` and `onChange(of: mode)`; the redundant write right after the field's own `apply()` is harmless.

## Spec acceptance

**#488:**

| | |
|---|---|
| Floating button: starts hidden; drag VFO off-center → appears | ✓ |
| Floating button: click resets both bandwidth and offset; button hides | ✓ |
| Bandwidth-field reset: change bandwidth → icon enables | ✓ |
| Bandwidth-field reset: click → snaps to mode default | ✓ |
| Bandwidth-field reset: switch demod → icon re-evaluates | ✓ |
| `.accessibilityLabel` + tooltip on both | ✓ |
| Button hides after manual frequency tune | ✓ (via #489's setCenter cascade) |

**#489:**

| | |
|---|---|
| Manual frequency tune → VFO follows | ✓ |
| Bookmark recall → VFO recenters on new tuned frequency | ✓ |
| Scanner rotation honors recenter | ✓ (engine echoes `VfoOffsetChanged` on retune; the new FFI surface lets the model consume it) |

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --lib` — all tests pass (1 new event-translation test)
- [x] `make ffi-header-check` — hand-written + cbindgen agree
- [x] `make mac-app` — builds cleanly
- [x] Smoke tests — all 7 spec rows above verified manually
- [ ] CodeRabbit review

## Links

Closes #488
Closes #489

Builds on the ABI 0.22 scanner work from #615 — the new `VfoOffsetChanged` event surface unblocks the scanner's per-channel retune from updating the observable VFO state, completing a small follow-up promise from #615's Mac-side scanner integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Reset VFO" floating button in the spectrum to quickly recenter VFO
  * Added "Reset Bandwidth" control in the radio panel to restore the mode-specific default bandwidth
  * Bandwidth defaults now vary by demodulation mode

* **Bug Fixes**
  * Bandwidth field always syncs with model updates (no longer blocked by focus)
  * Improved VFO recentering when changing center frequency; reset controls disable when already at defaults
<!-- end of auto-generated comment: release notes by coderabbit.ai -->