### PR TITLE
Modernize Mac rtl_tcp server panel for ABI 0.19+ (closes #401 + #417)

### DIFF
--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrRtlTcpDiscovery.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrRtlTcpDiscovery.swift
@@ -32,6 +32,19 @@ public final class SdrRtlTcpAdvertiser: @unchecked Sendable {
         public var nickname: String
         public var txbufBytes: UInt64?
 
+        /// ABI 0.19 (#400) — codec mask the server is willing to
+        /// negotiate. `nil` omits the TXT key entirely (pre-0.19
+        /// behaviour); LZ4-aware clients that don't see the key
+        /// fall back to the legacy uncompressed format.
+        public var compression: SdrRtlTcpServer.Compression?
+
+        /// ABI 0.19 (#400) — whether the server requires
+        /// pre-shared-key auth. `nil` omits the TXT key
+        /// (servers without auth advertise nothing); `true`
+        /// publishes the bit so clients can stage a credential
+        /// prompt before connecting. Issue #417.
+        public var authRequired: Bool?
+
         public init(
             port: UInt16,
             instanceName: String,
@@ -40,7 +53,9 @@ public final class SdrRtlTcpAdvertiser: @unchecked Sendable {
             version: String,
             gains: UInt32,
             nickname: String = "",
-            txbufBytes: UInt64? = nil
+            txbufBytes: UInt64? = nil,
+            compression: SdrRtlTcpServer.Compression? = nil,
+            authRequired: Bool? = nil
         ) {
             self.port = port
             self.instanceName = instanceName
@@ -50,6 +65,8 @@ public final class SdrRtlTcpAdvertiser: @unchecked Sendable {
             self.gains = gains
             self.nickname = nickname
             self.txbufBytes = txbufBytes
+            self.compression = compression
+            self.authRequired = authRequired
         }
     }
 
@@ -83,17 +100,17 @@ public final class SdrRtlTcpAdvertiser: @unchecked Sendable {
                 options.tuner.withCString { tunerPtr in
                     options.version.withCString { versionPtr in
                         options.nickname.withCString { nicknamePtr -> Int32 in
-                            // ABI 0.19 (#400) appended four
-                            // opt-in TXT fields at the tail:
-                            // `has_codecs` / `codecs` /
-                            // `has_auth_required` /
-                            // `auth_required`. Mac-side UI for
-                            // any of these (compression toggle,
-                            // auth-required badge) follows in
-                            // #496; until then the wrapper
-                            // publishes neither key, matching
-                            // pre-0.19 advertisement behaviour
-                            // exactly.
+                            // ABI 0.19 (#400) opt-in TXT fields:
+                            //   - `has_codecs` / `codecs` —
+                            //     server's negotiable codec mask
+                            //   - `has_auth_required` /
+                            //     `auth_required` — whether the
+                            //     server demands a pre-shared
+                            //     key (#394).
+                            // Both default to "key omitted from
+                            // the TXT record" (pre-0.19 wire
+                            // form) when the matching Swift
+                            // option is `nil`. Issue #417.
                             var opts = SdrRtlTcpAdvertiseOptions(
                                 port: options.port,
                                 instance_name: instancePtr,
@@ -104,10 +121,10 @@ public final class SdrRtlTcpAdvertiser: @unchecked Sendable {
                                 nickname: nicknamePtr,
                                 has_txbuf: options.txbufBytes != nil,
                                 txbuf: options.txbufBytes ?? 0,
-                                has_codecs: false,
-                                codecs: 0,
-                                has_auth_required: false,
-                                auth_required: false
+                                has_codecs: options.compression != nil,
+                                codecs: options.compression?.rawValue ?? 0,
+                                has_auth_required: options.authRequired != nil,
+                                auth_required: options.authRequired ?? false
                             )
                             return withUnsafePointer(to: &opts) { optsPtr in
                                 sdr_rtltcp_advertiser_start(optsPtr, &rawHandle)
@@ -161,6 +178,19 @@ public final class SdrRtlTcpBrowser: @unchecked Sendable {
         public var nickname: String
         public var txbufBytes: UInt64?
         public var lastSeenSecsAgo: Double
+
+        /// ABI 0.19 (#400) — server's advertised codec mask.
+        /// `nil` when the server didn't publish the TXT key
+        /// (pre-0.19 servers, or servers explicitly omitting
+        /// it). LZ4-aware clients use this to gate "negotiate
+        /// LZ4" before the handshake. Issue #417.
+        public var compression: SdrRtlTcpServer.Compression?
+
+        /// ABI 0.19 (#400) — whether the server requires
+        /// pre-shared-key auth. `nil` when the server didn't
+        /// publish the TXT key. Clients use this to stage a
+        /// credential prompt before connecting. Issue #417.
+        public var authRequired: Bool?
     }
 
     public enum Event: Sendable, Equatable {
@@ -258,7 +288,11 @@ public final class SdrRtlTcpBrowser: @unchecked Sendable {
                     gains: announced.gains,
                     nickname: stringFromPtr(announced.nickname),
                     txbufBytes: announced.has_txbuf ? announced.txbuf : nil,
-                    lastSeenSecsAgo: announced.last_seen_secs_ago
+                    lastSeenSecsAgo: announced.last_seen_secs_ago,
+                    compression: announced.has_codecs
+                        ? SdrRtlTcpServer.Compression(rawValue: announced.codecs)
+                        : nil,
+                    authRequired: announced.has_auth_required ? announced.auth_required : nil
                 )
                 box.handler(.announced(ds))
             case Int32(SDR_RTLTCP_DISCOVERY_WITHDRAWN.rawValue):

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrRtlTcpServer.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrRtlTcpServer.swift
@@ -59,6 +59,29 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
         }
     }
 
+    /// Negotiated stream-codec mask (ABI 0.19, issue #400). Wire
+    /// bytes match `CodecMask::to_wire` on the Rust side.
+    ///
+    /// - `.noneOnly` (0x01) — vanilla rtl_tcp behaviour, every
+    ///   client streams uncompressed IQ. The default; LZ4-aware
+    ///   clients fall back to this when the server doesn't
+    ///   advertise the codecs TXT key.
+    /// - `.noneAndLz4` (0x03) — the server is willing to negotiate
+    ///   LZ4 compression with clients that ask. Clients that
+    ///   don't speak the RTLX extension still get uncompressed
+    ///   streams; the mask is a *capability*, not a requirement.
+    public enum Compression: UInt8, Sendable, CaseIterable, Codable {
+        case noneOnly   = 0x01
+        case noneAndLz4 = 0x03
+
+        public var label: String {
+            switch self {
+            case .noneOnly:   return "None (legacy-compatible)"
+            case .noneAndLz4: return "None + LZ4 (compression)"
+            }
+        }
+    }
+
     /// Configuration passed to `sdr_rtltcp_server_start`. Field
     /// defaults match the C API's "crate default" semantics:
     /// port `0` → 1234, buffer capacity `0` → crate default,
@@ -93,6 +116,13 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
         /// PR #360.
         public var initialDirectSampling: SdrCore.DirectSamplingMode
 
+        /// Stream-codec mask the server is willing to negotiate.
+        /// `.noneOnly` is the safe default — equivalent to the
+        /// pre-ABI-0.19 behaviour where the server didn't
+        /// advertise codecs at all and every client got
+        /// uncompressed IQ. Issue #417.
+        public var compression: Compression
+
         public init(
             bindAddress: BindAddress = .loopback,
             port: UInt16 = 1234,
@@ -103,7 +133,8 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
             initialGainTenthsDb: Int32 = 0,
             initialPpm: Int32 = 0,
             initialBiasTee: Bool = false,
-            initialDirectSampling: SdrCore.DirectSamplingMode = .off
+            initialDirectSampling: SdrCore.DirectSamplingMode = .off,
+            compression: Compression = .noneOnly
         ) {
             self.bindAddress = bindAddress
             self.port = port
@@ -115,23 +146,24 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
             self.initialPpm = initialPpm
             self.initialBiasTee = initialBiasTee
             self.initialDirectSampling = initialDirectSampling
+            self.compression = compression
         }
 
         fileprivate func toC() -> SdrRtlTcpServerConfig {
-            // ABI 0.16 (#392 / `listener_cap`), 0.17 (#394 /
-            // `auth_key` + `auth_key_len`), and 0.19 (#400 /
-            // `has_compression` + `compression`) appended fields
-            // at the tail. The Mac side hasn't surfaced auth /
-            // listener-cap / compression UI yet, so we pass the
-            // documented zero-init defaults that preserve pre-
-            // ABI-0.16 behaviour:
+            // ABI 0.16 (#392 / `listener_cap`) and 0.17 (#394 /
+            // `auth_key` + `auth_key_len`) both ship in the
+            // header but the Mac side hasn't surfaced UI for
+            // them yet. Pass documented zero-init defaults that
+            // preserve pre-ABI-0.16 behaviour:
             //   - listener_cap = 0     → crate default (10)
             //   - auth_key = NULL,
             //     auth_key_len = 0     → auth disabled (LAN trust)
-            //   - has_compression = false → CodecMask::NONE_ONLY
-            // When the Mac UI grows controls for any of these,
-            // promote the matching field to a typed Swift
-            // property and forward it from `Config`.
+            //
+            // ABI 0.19 (#400) compression IS surfaced as of #417:
+            // the picker writes `Config.compression`, which we
+            // forward here with `has_compression = true` so the
+            // server applies the mask explicitly rather than
+            // falling back to the omit-key default.
             SdrRtlTcpServerConfig(
                 bind_address: bindAddress.rawValue,
                 port: port,
@@ -146,8 +178,8 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
                 listener_cap: 0,
                 auth_key: nil,
                 auth_key_len: 0,
-                has_compression: false,
-                compression: 0
+                has_compression: true,
+                compression: compression.rawValue
             )
         }
     }
@@ -156,19 +188,16 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
     /// (multi-client) `SdrRtlTcpServerStats` shape — aggregates
     /// only — plus the tuner-name string output into one value.
     ///
-    /// **Per-client state lives elsewhere now.** Pre-#391 this
-    /// struct carried `hasClient` / `connectedClientAddr` /
-    /// `currentFreqHz` etc. for the single connected client.
-    /// The engine became multi-client in #391; that detail
-    /// moved into `SdrRtlTcpClientInfo` rows fetched through
-    /// `sdr_rtltcp_server_client_list`. The Mac SwiftUI surface
-    /// for that list (per-client rows in the panel + the
-    /// `clientList()` Swift wrapper) lands in #496 — until
-    /// then the panel renders aggregates only.
+    /// **Per-client state lives in `ClientInfo` rows.** Pre-#391
+    /// this struct carried `hasClient` / `connectedClientAddr` /
+    /// `currentFreqHz` etc. for the single connected client. The
+    /// engine became multi-client in #391; that detail moved
+    /// into `SdrRtlTcpClientInfo` rows fetched through
+    /// `clientList()` (issue #401, this PR).
     public struct Stats: Sendable, Equatable {
         /// Number of clients connected at the moment of the
-        /// snapshot. Membership may change between this read
-        /// and a follow-up `clientList()` call (#496).
+        /// snapshot. Membership may change between this read and
+        /// a follow-up `clientList()` call.
         public var connectedCount: UInt32
         /// Cumulative bytes fanned out across all clients over
         /// the server's lifetime. Monotonic.
@@ -183,6 +212,89 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
         public var tunerName: String
         /// Number of discrete gain steps the tuner advertises.
         public var gainCount: UInt32
+    }
+
+    /// Role the server granted a connected client. Mirrors the
+    /// Rust `Role` wire byte (`sdr_server_rtltcp::extension`).
+    /// Vanilla rtl_tcp clients always land as `.control` — the
+    /// server only admits them when the control slot is free
+    /// (#392). Listener clients receive the IQ stream but the
+    /// server drops any commands they send.
+    public enum ClientRole: UInt8, Sendable, CaseIterable {
+        case control  = 0
+        case listener = 1
+
+        public var label: String {
+            switch self {
+            case .control:  return "Controller"
+            case .listener: return "Listener"
+            }
+        }
+    }
+
+    /// Per-client state snapshot. Returned in oldest-first order
+    /// by `clientList()`. The `id` is stable across snapshots
+    /// for cross-poll correlation; everything else is a
+    /// snapshot-time read.
+    public struct ClientInfo: Sendable, Equatable, Identifiable {
+        /// Stable, monotonic identifier assigned at accept time.
+        /// Never reused.
+        public let id: UInt64
+        /// Peer socket address as `"ip:port"`. IPv6 literals
+        /// arrive in bracketed form (`[fe80::…]:1234`).
+        public var peerAddress: String
+        /// Seconds since this client's handshake completed.
+        public var uptimeSecs: Double
+        /// Negotiated stream codec for this session. Pre-#400
+        /// servers always report `.noneOnly` (the legacy wire
+        /// format).
+        public var codec: Compression
+        /// Bytes written to this client's TCP socket since
+        /// accept. Post-compression — LZ4 sessions report the
+        /// compressed-on-wire byte count, NOT the underlying IQ
+        /// volume. Per-client only; the server's
+        /// `Stats.totalBytesSent` is a separate lifetime
+        /// aggregate that includes contributions from
+        /// disconnected clients.
+        public var bytesSent: UInt64
+        /// Buffer drops on this client's broadcaster channel
+        /// (server saw `TrySendError::Full`).
+        public var buffersDropped: UInt64
+        /// Most recent client-issued centre frequency, Hz. `nil`
+        /// before the client has sent `SetCenterFreq` for the
+        /// first time.
+        public var currentFreqHz: UInt32?
+        /// Most recent client-issued sample rate, Hz. Same `nil`
+        /// semantics as `currentFreqHz`.
+        public var currentSampleRateHz: UInt32?
+        /// Most recent tuner-gain request in 0.1 dB. `nil` until
+        /// the client has issued at least one `SetTunerGain`.
+        public var currentGainTenthsDb: Int32?
+        /// `true` when the client's last gain-mode request was
+        /// auto; `false` when manual; `nil` until they've issued
+        /// a `SetGainMode`. Tracked separately from the gain
+        /// value because `SetGainMode(auto)` and `SetTunerGain`
+        /// can fire independently.
+        public var currentGainAuto: Bool?
+        /// Number of entries currently in this client's
+        /// recent-commands ring (an entry count, not a byte
+        /// count). Useful for "N commands since connect" hints.
+        public var recentCommandsCount: UInt32
+        /// Wire byte of the client's most recently dispatched
+        /// command — matches the `rtl_tcp.c` opcodes
+        /// (SetCenterFreq=0x01, SetSampleRate=0x02, …,
+        /// SetBiasTee=0x0e). `nil` until they've issued any
+        /// command this session.
+        public var lastCommandOp: UInt8?
+        /// Seconds elapsed between the client's most recent
+        /// command and this snapshot. Snapshot-time only — NOT
+        /// monotonic across polls; a fresh command resets it.
+        /// All entries in a single `clientList()` call reference
+        /// one snapshot clock so cross-client comparisons within
+        /// a snapshot are consistent.
+        public var lastCommandAgeSecs: Double?
+        /// Role the server granted this client.
+        public var role: ClientRole
     }
 
     // ----------------------------------------------------------
@@ -237,8 +349,25 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
     /// `sdr_rtltcp_server_stats`. 64 bytes comfortably fits any
     /// RTL-SDR tuner family name. The pre-#391 single-client
     /// peer-address output buffer is gone — peer addresses live
-    /// on per-client `SdrRtlTcpClientInfo` rows now (#496).
+    /// on per-client `SdrRtlTcpClientInfo` rows now (issue #401).
     private static let statsTunerNameBufferLen = 64
+
+    /// Initial capacity for the per-poll client-list buffer. The
+    /// server's `listener_cap` defaults to 10 (#392) and we keep
+    /// the listener slot count small even at the high end, so 16
+    /// entries is plenty for the steady-state read. The retry
+    /// path inside `clientList()` doubles when the actual count
+    /// exceeds capacity.
+    private static let clientListInitialCapacity = 16
+
+    /// Length of the `peer_addr` C-array tail in
+    /// `SdrRtlTcpClientInfo`. Mirrors `SDR_RTLTCP_CLIENT_PEER_LEN`
+    /// in `include/sdr_core.h`. The C header value is a `#define`
+    /// macro and Swift's importer doesn't surface those as
+    /// constants — re-stating the literal here is the clean way
+    /// to use it. Anchored against the header in
+    /// `SdrCoreTests.testClientInfoPeerLengthMatchesHeader`.
+    private static let clientPeerAddressLen = 64
 
     /// Capture a server-wide stats snapshot. Throws
     /// `SdrCoreError` on a stopped server or other FFI error.
@@ -248,9 +377,8 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
     /// same pattern as the engine's own handle wrappers.
     ///
     /// Per-client state (peer address, current tuning, recent
-    /// commands) is no longer in this snapshot — fetch it via
-    /// the upcoming `clientList()` / per-client recent-commands
-    /// surface (#496).
+    /// commands) is fetched via `clientList()` — `connectedCount`
+    /// here is the size hint to pass that call.
     public func stats() throws -> Stats {
         let result: Stats? = try handleBox.withHandle { handle -> Stats in
             var cStats = SdrRtlTcpServerStats()
@@ -277,5 +405,119 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
             throw SdrCoreError(code: .notRunning, message: "server already stopped")
         }
         return stats
+    }
+
+    /// Snapshot every connected client's state. Returned in
+    /// oldest-first order; identifiers are stable across
+    /// snapshots so a UI can correlate rows (e.g. preserve
+    /// expand/collapse state per row) without re-keying on
+    /// changing peer addresses.
+    ///
+    /// Throws `SdrCoreError` on a stopped server.
+    ///
+    /// The FFI surface uses a "size-then-fill" pattern: we
+    /// allocate `clientListInitialCapacity` slots, call
+    /// `sdr_rtltcp_server_client_list`, and check the returned
+    /// `out_count` against capacity. If `out_count > capacity`
+    /// the snapshot grew between the call and our buffer sizing
+    /// (a new client connected mid-call), so we re-allocate and
+    /// retry once. Two iterations is plenty in practice — the
+    /// per-poll cadence is 1 Hz; the chance of two consecutive
+    /// connects landing inside one snapshot is vanishingly
+    /// small. Issue #401.
+    public func clientList() throws -> [ClientInfo] {
+        let result: [ClientInfo]? = try handleBox.withHandle { handle -> [ClientInfo] in
+            var capacity = Self.clientListInitialCapacity
+            // Single retry on buffer-too-small. Loop is bounded
+            // to avoid pathological "every snapshot adds a
+            // client" scenarios — even then capacity doubles
+            // each pass, so the bound here is generous.
+            for _ in 0..<3 {
+                var buf = [SdrRtlTcpClientInfo](
+                    repeating: SdrRtlTcpClientInfo(),
+                    count: capacity
+                )
+                var outCount: size_t = 0
+                let rc = buf.withUnsafeMutableBufferPointer { ptr in
+                    sdr_rtltcp_server_client_list(
+                        handle,
+                        ptr.baseAddress,
+                        size_t(capacity),
+                        &outCount
+                    )
+                }
+                try checkRc(rc)
+                if Int(outCount) <= capacity {
+                    return (0..<Int(outCount)).map { Self.swiftClient(from: buf[$0]) }
+                }
+                // Outgrew the buffer — the engine wrote
+                // `capacity` entries (the first `capacity`
+                // clients) and the actual count is in `outCount`.
+                // Retry with capacity bumped to fit.
+                capacity = Int(outCount)
+            }
+            // Should never hit this — capacity grows
+            // monotonically and the engine returns the actual
+            // count on each call. Treat as a transient error so
+            // callers can retry on the next poll tick.
+            throw SdrCoreError(
+                code: .internal,
+                message: "clientList capacity grew unboundedly across retries"
+            )
+        }
+        guard let list = result else {
+            throw SdrCoreError(code: .notRunning, message: "server already stopped")
+        }
+        return list
+    }
+
+    /// Decode a single C `SdrRtlTcpClientInfo` into the Swift
+    /// `ClientInfo` shape. Pulled out as a static helper so the
+    /// retry loop in `clientList()` stays readable.
+    private static func swiftClient(from c: SdrRtlTcpClientInfo) -> ClientInfo {
+        // Peer address comes through as a C array of CChar via
+        // the swift bridge. Read as a tuple, build a fixed-size
+        // buffer the standard way.
+        var peerCopy = c
+        let peerString = withUnsafePointer(to: &peerCopy.peer_addr) { tuplePtr -> String in
+            tuplePtr.withMemoryRebound(
+                to: CChar.self,
+                capacity: clientPeerAddressLen
+            ) { cstrPtr in
+                String(cString: cstrPtr)
+            }
+        }
+
+        let codec = Compression(rawValue: c.codec) ?? .noneOnly
+        let role = ClientRole(rawValue: c.role) ?? .control
+
+        // The `current_*` fields are valid even before the
+        // client has issued a command — but they're 0 by the C
+        // contract. Map 0-when-never-set to nil so the UI can
+        // distinguish "0 Hz" from "no command yet".
+        let freq = c.current_freq_hz != 0 ? c.current_freq_hz : nil
+        let rate = c.current_sample_rate_hz != 0 ? c.current_sample_rate_hz : nil
+        let gainValue = c.has_current_gain_value ? c.current_gain_tenths_db : nil
+        let gainAuto  = c.has_current_gain_mode  ? c.current_gain_auto       : nil
+
+        let lastOp  = c.has_last_command ? c.last_command_op       : nil
+        let lastAge = c.has_last_command ? c.last_command_age_secs : nil
+
+        return ClientInfo(
+            id: c.id,
+            peerAddress: peerString,
+            uptimeSecs: c.uptime_secs,
+            codec: codec,
+            bytesSent: c.bytes_sent,
+            buffersDropped: c.buffers_dropped,
+            currentFreqHz: freq,
+            currentSampleRateHz: rate,
+            currentGainTenthsDb: gainValue,
+            currentGainAuto: gainAuto,
+            recentCommandsCount: c.recent_commands_count,
+            lastCommandOp: lastOp,
+            lastCommandAgeSecs: lastAge,
+            role: role
+        )
     }
 }

--- a/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrRtlTcpServer.swift
+++ b/apps/macos/Packages/SdrCoreKit/Sources/SdrCoreKit/SdrRtlTcpServer.swift
@@ -59,8 +59,11 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
         }
     }
 
-    /// Negotiated stream-codec mask (ABI 0.19, issue #400). Wire
-    /// bytes match `CodecMask::to_wire` on the Rust side.
+    /// Server-side **codec capability mask** (ABI 0.19, issue
+    /// #400). What the *server* is willing to negotiate. Wire
+    /// bytes match `CodecMask::to_wire` on the Rust side and
+    /// flow through `Config.compression`, the mDNS `codecs` TXT
+    /// field, and `DiscoveredServer.compression`.
     ///
     /// - `.noneOnly` (0x01) — vanilla rtl_tcp behaviour, every
     ///   client streams uncompressed IQ. The default; LZ4-aware
@@ -70,6 +73,12 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
     ///   LZ4 compression with clients that ask. Clients that
     ///   don't speak the RTLX extension still get uncompressed
     ///   streams; the mask is a *capability*, not a requirement.
+    ///
+    /// **Distinct from `NegotiatedCodec`** — that's the per-
+    /// client *result* (whether THIS specific connection
+    /// landed on uncompressed or LZ4), with a different wire
+    /// encoding (0/1, not 0x01/0x03). Mixing the two was a real
+    /// bug in this PR's first round; CodeRabbit caught it.
     public enum Compression: UInt8, Sendable, CaseIterable, Codable {
         case noneOnly   = 0x01
         case noneAndLz4 = 0x03
@@ -78,6 +87,25 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
             switch self {
             case .noneOnly:   return "None (legacy-compatible)"
             case .noneAndLz4: return "None + LZ4 (compression)"
+            }
+        }
+    }
+
+    /// Per-client **negotiated codec** — what THIS specific
+    /// connection actually settled on after handshake. Wire
+    /// bytes match the C `SdrRtlTcpClientInfo::codec` field
+    /// (header: 0 = None, 1 = LZ4). Distinct from
+    /// `Compression`, the server capability mask, which uses
+    /// 0x01/0x03 wire bytes — using one for the other reads
+    /// silently wrong (LZ4 clients showing as uncompressed).
+    public enum NegotiatedCodec: UInt8, Sendable, CaseIterable, Codable {
+        case none = 0
+        case lz4  = 1
+
+        public var label: String {
+            switch self {
+            case .none: return "None"
+            case .lz4:  return "LZ4"
             }
         }
     }
@@ -246,9 +274,10 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
         /// Seconds since this client's handshake completed.
         public var uptimeSecs: Double
         /// Negotiated stream codec for this session. Pre-#400
-        /// servers always report `.noneOnly` (the legacy wire
-        /// format).
-        public var codec: Compression
+        /// servers always report `.none` (the legacy wire
+        /// format). Distinct from `Compression` — see that
+        /// enum's docstring for the wire-encoding split.
+        public var codec: NegotiatedCodec
         /// Bytes written to this client's TCP socket since
         /// accept. Post-compression — LZ4 sessions report the
         /// compressed-on-wire byte count, NOT the underlying IQ
@@ -488,7 +517,13 @@ public final class SdrRtlTcpServer: @unchecked Sendable {
             }
         }
 
-        let codec = Compression(rawValue: c.codec) ?? .noneOnly
+        // The C field uses 0 = None / 1 = LZ4 (per
+        // `SdrRtlTcpClientInfo::codec` in the header), NOT the
+        // 0x01/0x03 capability-mask wire bytes. Decoding via
+        // `Compression(rawValue:)` was a real bug in this PR's
+        // first round — caught by CodeRabbit. Use the
+        // negotiated-codec enum.
+        let codec = NegotiatedCodec(rawValue: c.codec) ?? .none
         let role = ClientRole(rawValue: c.role) ?? .control
 
         // The `current_*` fields are valid even before the

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -417,16 +417,23 @@ final class CoreModel {
 
     /// Most-recent poll snapshot of server stats. `nil` while
     /// the server isn't running. Aggregates only — per-client
-    /// state moved to the multi-client surface in #391 and
-    /// lands on the Mac side in #496.
+    /// state lives in `rtlTcpServerClients` (issue #401, this
+    /// PR).
     var rtlTcpServerStats: SdrRtlTcpServer.Stats? = nil
 
-    // The pre-#391 single-client `rtlTcpRecentCommands` ring
-    // is gone — recent-commands tracking is per-client now and
-    // requires the multi-client list surface (#496) to map a
-    // client id back to its commands. The panel renders the
-    // server-wide aggregates `connectedCount` / `lifetimeAccepted`
-    // / `totalBytesSent` / `totalBuffersDropped` instead.
+    /// Per-client snapshot from `SdrRtlTcpServer.clientList()`.
+    /// Refreshed alongside `rtlTcpServerStats` on the 1 Hz poll
+    /// tick. Empty while the server isn't running, after a poll
+    /// error, or when no client is connected. Issue #401.
+    var rtlTcpServerClients: [SdrRtlTcpServer.ClientInfo] = []
+
+    // The pre-#391 single-client `rtlTcpRecentCommands` ring is
+    // gone — recent-commands tracking is per-client now. The
+    // panel renders the per-client list above plus server-wide
+    // aggregates (`connectedCount` / `lifetimeAccepted` /
+    // `totalBytesSent` / `totalBuffersDropped`). A future
+    // surface for the per-client recent-commands ring (drilling
+    // into one row to see its history) lands separately.
 
     /// Last error surfaced from a rtl_tcp server start or poll
     /// attempt. Cleared on successful start; mirrors into a
@@ -441,6 +448,27 @@ final class CoreModel {
     var rtlTcpServerPort: UInt16 = 1234
     var rtlTcpServerBindAddress: SdrRtlTcpServer.Config.BindAddress = .loopback
     var rtlTcpServerMdnsEnabled: Bool = true
+
+    /// Stream-codec mask the server advertises and negotiates.
+    /// `.noneOnly` keeps every client on uncompressed IQ — the
+    /// safe default; `.noneAndLz4` opts in to LZ4 for clients
+    /// that ask. Persisted via `UserDefaults`. Issue #417.
+    var rtlTcpServerCompression: SdrRtlTcpServer.Compression = .noneOnly
+
+    /// When `true`, the mDNS advertisement carries the
+    /// `auth_required` TXT bit so clients can stage a
+    /// credential prompt before connecting. Persisted via
+    /// `UserDefaults`.
+    ///
+    /// The actual auth-key enforcement on the server (forwarding
+    /// `auth_key` / `auth_key_len` to `SdrRtlTcpServerConfig`,
+    /// validating the client's `RTLX SetAuthKey` packet) is
+    /// tracked separately in #623 — until that lands, this
+    /// toggle governs the mDNS advertisement only and the
+    /// server still accepts every connection. Persisting the
+    /// flag now keeps the schema stable for the follow-up.
+    /// Issue #417.
+    var rtlTcpServerAuthRequired: Bool = false
 
     /// Center frequency the server applies on dongle open.
     /// Defaults to 100.000 MHz matching the engine's
@@ -990,6 +1018,20 @@ final class CoreModel {
                 Int32(UserDefaults.standard.integer(forKey: Self.rtlTcpServerInitialDirectSamplingKey))
             rtlTcpServerInitialDirectSampling =
                 SdrCore.DirectSamplingMode(rawValue: raw) ?? .off
+        }
+        if UserDefaults.standard.object(forKey: Self.rtlTcpServerCompressionKey) != nil {
+            let stored = UserDefaults.standard.integer(forKey: Self.rtlTcpServerCompressionKey)
+            // Stored as the wire byte (0x01 / 0x03) — clamp into
+            // the valid range so a hand-edited plist can't carry
+            // an unknown mask through the FFI.
+            if let raw = UInt8(exactly: stored),
+               let mask = SdrRtlTcpServer.Compression(rawValue: raw) {
+                rtlTcpServerCompression = mask
+            }
+        }
+        if UserDefaults.standard.object(forKey: Self.rtlTcpServerAuthRequiredKey) != nil {
+            rtlTcpServerAuthRequired =
+                UserDefaults.standard.bool(forKey: Self.rtlTcpServerAuthRequiredKey)
         }
 
         do {
@@ -2208,11 +2250,14 @@ final class CoreModel {
             initialGainTenthsDb: rtlTcpServerInitialGainTenthsDb,
             initialPpm: rtlTcpServerInitialPpm,
             initialBiasTee: rtlTcpServerInitialBiasTee,
-            initialDirectSampling: rtlTcpServerInitialDirectSampling
+            initialDirectSampling: rtlTcpServerInitialDirectSampling,
+            compression: rtlTcpServerCompression
         )
         let mdnsEnabled = rtlTcpServerMdnsEnabled
         let nickname = rtlTcpServerNickname
         let port = rtlTcpServerPort
+        let advertisedCompression = rtlTcpServerCompression
+        let advertisedAuthRequired = rtlTcpServerAuthRequired
         // App version for the mDNS TXT record. Sourced from
         // the bundle's `CFBundleShortVersionString` so the
         // advertised version tracks the installed release
@@ -2250,6 +2295,12 @@ final class CoreModel {
                 let instanceName = nickname.isEmpty
                     ? ProcessInfo.processInfo.hostName
                     : nickname
+                // ABI 0.19 (#417): publish the codec mask we
+                // negotiated through the server config so
+                // clients see the same story on mDNS and at
+                // handshake. `authRequired` mirrors the
+                // matching toggle; `nil` here means "omit the
+                // TXT key" — pre-0.19 wire form.
                 let opts = SdrRtlTcpAdvertiser.Options(
                     port: port,
                     instanceName: instanceName,
@@ -2257,7 +2308,9 @@ final class CoreModel {
                     tuner: tunerName,
                     version: appVersion,
                     gains: gainCount,
-                    nickname: nickname
+                    nickname: nickname,
+                    compression: advertisedCompression,
+                    authRequired: advertisedAuthRequired ? true : nil
                 )
                 advertiser = try? SdrRtlTcpAdvertiser(options: opts)
                 if advertiser == nil {
@@ -2340,6 +2393,7 @@ final class CoreModel {
         // Per `CodeRabbit` round 7 on PR #362.
         rtlTcpServerStopping = true
         rtlTcpServerStats = nil
+        rtlTcpServerClients = []
 
         let prior = rtlTcpServerLifecycleTask
         let task = Task { [weak self] in
@@ -2414,6 +2468,7 @@ final class CoreModel {
         // is released. Per `CodeRabbit` round 7 on PR #362.
         rtlTcpServerStopping = false
         rtlTcpServerStats = nil
+        rtlTcpServerClients = []
         advertiser?.stop()
         server?.stop()
     }
@@ -2451,17 +2506,20 @@ final class CoreModel {
             Int(rtlTcpServerInitialDirectSampling.rawValue),
             forKey: Self.rtlTcpServerInitialDirectSamplingKey
         )
+        UserDefaults.standard.set(
+            Int(rtlTcpServerCompression.rawValue),
+            forKey: Self.rtlTcpServerCompressionKey
+        )
+        UserDefaults.standard.set(
+            rtlTcpServerAuthRequired,
+            forKey: Self.rtlTcpServerAuthRequiredKey
+        )
     }
 
-    /// Background poller that refreshes `rtlTcpServerStats`
-    /// on a one-second tick. Runs on the main actor (the whole
-    /// `CoreModel` is `@MainActor`) which matches what
-    /// `@Observable` needs for writes.
-    ///
-    /// The pre-#391 per-client `rtlTcpRecentCommands` refresh
-    /// is gone — recent-commands tracking is per-client now and
-    /// returns under a separate poll keyed by `client.id` once
-    /// the multi-client surface lands (#496).
+    /// Background poller that refreshes `rtlTcpServerStats` and
+    /// `rtlTcpServerClients` on a one-second tick. Runs on the
+    /// main actor (the whole `CoreModel` is `@MainActor`) which
+    /// matches what `@Observable` needs for writes.
     private func startRtlTcpPoller() {
         rtlTcpPollTask = Task { [weak self] in
             // Tick cadence slow enough to be negligible on the
@@ -2476,6 +2534,13 @@ final class CoreModel {
                 guard let self, let server = self.rtlTcpServer else { return }
                 do {
                     self.rtlTcpServerStats = try server.stats()
+                    // Per-client snapshot — same lock-protected
+                    // FFI handle on the same poll tick so the
+                    // aggregate counters and the client list
+                    // describe the same moment in time. Failure
+                    // here goes through the same teardown path
+                    // as `stats()` failure. Issue #401.
+                    self.rtlTcpServerClients = try server.clientList()
                 } catch {
                     // Server has gone away (stopped externally,
                     // USB unplug, panic caught by the FFI). Tear
@@ -2507,6 +2572,10 @@ final class CoreModel {
     static let rtlTcpServerInitialPpmKey = "SDRMac.rtlTcpServer.initialPpm"
     static let rtlTcpServerInitialBiasTeeKey = "SDRMac.rtlTcpServer.initialBiasTee"
     static let rtlTcpServerInitialDirectSamplingKey = "SDRMac.rtlTcpServer.initialDirectSampling"
+    /// ABI 0.19 (#400 / #417) — persisted compression mask
+    /// (wire byte) and auth-required mDNS bit.
+    static let rtlTcpServerCompressionKey = "SDRMac.rtlTcpServer.compression"
+    static let rtlTcpServerAuthRequiredKey = "SDRMac.rtlTcpServer.authRequired"
 
     /// UserDefaults keys for the persisted rtl_tcp *client*
     /// favorites and last-connected snapshot. Namespaced to

--- a/apps/macos/SDRMac/Models/CoreModel.swift
+++ b/apps/macos/SDRMac/Models/CoreModel.swift
@@ -2473,6 +2473,76 @@ final class CoreModel {
         server?.stop()
     }
 
+    /// Stop the current mDNS advertiser and start a fresh one
+    /// that reflects the current observable state
+    /// (`rtlTcpServerCompression`, `rtlTcpServerAuthRequired`,
+    /// `rtlTcpServerNickname`). No-op when the server isn't
+    /// running or mDNS is disabled. Used by the panel when the
+    /// user flips an advertise-only field mid-session — server
+    /// config can't change mid-session (immutable on dongle
+    /// open), but the announcement can.
+    ///
+    /// Stays on the main actor — both `stop` and the construct-
+    /// new-advertiser hop are quick (sub-millisecond mDNS
+    /// daemon calls). Issue #417 / CodeRabbit on PR #624.
+    func reannounceMdnsAdvertisement() {
+        guard rtlTcpServerRunning else { return }
+        guard rtlTcpServerMdnsEnabled else { return }
+
+        // Snapshot tuner metadata from the existing stats so the
+        // new advertisement carries the same TXT fields the
+        // original announcement did. If stats aren't available
+        // yet (server still starting on first poll tick), fall
+        // back to the same "unknown" placeholders the start path
+        // uses.
+        let tunerName: String
+        let gainCount: UInt32
+        if let s = rtlTcpServerStats, !s.tunerName.isEmpty {
+            tunerName = s.tunerName
+            gainCount = s.gainCount
+        } else {
+            tunerName = "unknown"
+            gainCount = 0
+        }
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+            ?? "0.1.0"
+        let instanceName = rtlTcpServerNickname.isEmpty
+            ? ProcessInfo.processInfo.hostName
+            : rtlTcpServerNickname
+
+        let opts = SdrRtlTcpAdvertiser.Options(
+            port: rtlTcpServerPort,
+            instanceName: instanceName,
+            hostname: "",
+            tuner: tunerName,
+            version: appVersion,
+            gains: gainCount,
+            nickname: rtlTcpServerNickname,
+            compression: rtlTcpServerCompression,
+            authRequired: rtlTcpServerAuthRequired ? true : nil
+        )
+
+        // Stop the old advertiser BEFORE constructing the new
+        // one — the mDNS daemon dedups by service name, and
+        // overlapping registrations briefly publish the old TXT
+        // record. Stop is synchronous (it joins the dispatcher);
+        // the new `init(options:)` is also synchronous to first
+        // visibility, so the swap is atomic from the LAN's
+        // perspective barring a sub-second window. mDNS clients
+        // typically poll on ~1s cadence so this is fine.
+        rtlTcpAdvertiser?.stop()
+        rtlTcpAdvertiser = nil
+
+        do {
+            rtlTcpAdvertiser = try SdrRtlTcpAdvertiser(options: opts)
+        } catch {
+            // Best-effort — surface the failure so the panel
+            // can show a warning, same shape as the initial
+            // announce-failure path. Server keeps running.
+            rtlTcpServerError = "Re-announce failed: \(error)"
+        }
+    }
+
     /// Persist the rtl_tcp server config to UserDefaults so
     /// the same values seed the next launch. Called from the
     /// UI on field edits — start() reads from the persisted

--- a/apps/macos/SDRMac/Views/RtlTcpServerSection.swift
+++ b/apps/macos/SDRMac/Views/RtlTcpServerSection.swift
@@ -25,10 +25,12 @@ private let rtlSdrSampleRates: [UInt32] = [
     3_200_000,
 ]
 
-// Pre-#391 the panel rendered a per-client recent-commands
-// activity log capped at 50 rows; the multi-client list
-// surface that replaces it lands in #496. Until then the
-// status section below shows server-wide aggregates only.
+// Pre-#391 the panel rendered a single-client status block
+// with peer address, current freq/rate/gain, and a recent-
+// commands log. The post-#391 multi-client surface replaces
+// that with a per-client list (one row per connected client)
+// alongside the aggregate-only stats. Per-client recent-
+// commands drilldown is a separate follow-up. Issue #401.
 
 struct RtlTcpServerSection: View {
     @Environment(CoreModel.self) private var model
@@ -141,6 +143,50 @@ struct RtlTcpServerSection: View {
             }
         ))
         .disabled(model.rtlTcpServerRunning)
+
+        // Compression picker — wires through to both the server
+        // config (`has_compression` / `compression`) and the
+        // mDNS advertise options (`has_codecs` / `codecs`) so a
+        // discovering client sees the same story over the
+        // network and at handshake. Issue #417.
+        LabeledContent("Compression") {
+            Picker("", selection: Binding(
+                get: { model.rtlTcpServerCompression },
+                set: {
+                    model.rtlTcpServerCompression = $0
+                    model.persistRtlTcpServerConfig()
+                }
+            )) {
+                ForEach(SdrRtlTcpServer.Compression.allCases, id: \.self) { c in
+                    Text(c.label).tag(c)
+                }
+            }
+            .labelsHidden()
+        }
+        .disabled(model.rtlTcpServerRunning)
+        .help("Stream-codec mask the server advertises. None keeps every client on uncompressed IQ; LZ4 negotiates compression with capable clients.")
+
+        // Auth-required mDNS toggle (#417).
+        //
+        // The actual auth-key enforcement on the rtl_tcp server
+        // (forwarding `auth_key` / `auth_key_len` through
+        // `SdrRtlTcpServerConfig`, validating the client's
+        // `RTLX SetAuthKey` packet) isn't wired on the Mac side
+        // yet. This toggle currently only governs the mDNS
+        // advertisement so clients can stage a credential
+        // prompt before connecting; the server itself still
+        // accepts every connection. Tracked in #623 — shipping
+        // the toggle now keeps the schema stable for the
+        // auth-key plumbing follow-up.
+        Toggle("Advertise auth required", isOn: Binding(
+            get: { model.rtlTcpServerAuthRequired },
+            set: {
+                model.rtlTcpServerAuthRequired = $0
+                model.persistRtlTcpServerConfig()
+            }
+        ))
+        .disabled(model.rtlTcpServerRunning)
+        .help("Sets the mDNS auth-required TXT bit so discovering clients can prompt for a key. Auth-key enforcement on the server itself is a separate follow-up (#623).")
 
         // Collapsible device-defaults group. Most users keep
         // the defaults; expanding exposes the initial state the
@@ -276,13 +322,10 @@ struct RtlTcpServerSection: View {
     //  Status + activity log
     // ----------------------------------------------------------
 
-    /// Server-wide status rows. Aggregates only — per-client
-    /// detail (peer address, current freq/rate/gain, recent
-    /// commands) requires the multi-client list surface that
-    /// follows in #496. Until then the panel reports the count
-    /// of connected clients plus lifetime totals; clicking an
-    /// individual client to see its tuning state is the
-    /// follow-up.
+    /// Status rows: server-wide aggregates plus a per-client
+    /// list rendering one row per connected client (peer
+    /// address, codec, freq/rate/gain, bytes sent, drops).
+    /// Issue #401.
     @ViewBuilder
     private var statusRows: some View {
         let stats = model.rtlTcpServerStats
@@ -326,6 +369,14 @@ struct RtlTcpServerSection: View {
                 }
             }
         }
+
+        // Per-client list — one expandable row per connected
+        // client. Sourced from `clientList()` on the same poll
+        // tick as `stats` so the count above and the rows below
+        // describe the same snapshot. Issue #401.
+        ForEach(model.rtlTcpServerClients) { client in
+            ClientRow(client: client)
+        }
     }
 
     // ----------------------------------------------------------
@@ -345,6 +396,161 @@ struct RtlTcpServerSection: View {
     /// total grows fast at typical RTL-SDR rates (~16 Mbps for
     /// 2 Msps × 8 bits) so a plain "bytes" label gets unreadable
     /// in minutes.
+    private func formatBytes(_ bytes: UInt64) -> String {
+        let kib: UInt64 = 1_024
+        let mib: UInt64 = kib * 1_024
+        let gib: UInt64 = mib * 1_024
+        if bytes >= gib {
+            return String(format: "%.2f GiB", Double(bytes) / Double(gib))
+        }
+        if bytes >= mib {
+            return String(format: "%.2f MiB", Double(bytes) / Double(mib))
+        }
+        if bytes >= kib {
+            return String(format: "%.2f KiB", Double(bytes) / Double(kib))
+        }
+        return "\(bytes) B"
+    }
+}
+
+// ============================================================
+//  ClientRow — one expandable row per connected client
+//
+//  Renders the per-client snapshot returned by
+//  `SdrRtlTcpServer.clientList()` (#401). Header line shows
+//  the peer address + role badge + codec + uptime; the
+//  expandable disclosure body adds bytes sent, drops, the
+//  client's most recent tuning state, and the recent-command
+//  hint.
+//
+//  Identifiable on `ClientInfo.id` so SwiftUI preserves the
+//  expand/collapse state of an individual row across poll
+//  ticks even when the list reorders.
+// ============================================================
+
+private struct ClientRow: View {
+    let client: SdrRtlTcpServer.ClientInfo
+
+    @State private var expanded = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $expanded) {
+            // ---- Body: per-client detail rows ----
+            LabeledContent("Bytes sent") {
+                Text(formatBytes(client.bytesSent))
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            if client.buffersDropped > 0 {
+                LabeledContent("Dropped") {
+                    Text("\(client.buffersDropped) buffer(s)")
+                        .foregroundStyle(.orange)
+                }
+            }
+            LabeledContent("Frequency") {
+                if let hz = client.currentFreqHz {
+                    Text(String(format: "%.3f MHz", Double(hz) / 1_000_000.0))
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("—")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            LabeledContent("Sample rate") {
+                if let hz = client.currentSampleRateHz {
+                    Text(String(format: "%.3f Msps", Double(hz) / 1_000_000.0))
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("—")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            LabeledContent("Gain") {
+                Text(gainDisplay)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+            if client.recentCommandsCount > 0 {
+                LabeledContent("Recent commands") {
+                    Text(commandsDisplay)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } label: {
+            // ---- Header: peer address + role + codec + uptime
+            HStack(spacing: 8) {
+                Text(client.peerAddress.isEmpty ? "—" : client.peerAddress)
+                    .font(.body.monospaced())
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+                if client.role == .listener {
+                    Text(client.role.label)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 3)
+                                .stroke(.secondary.opacity(0.4))
+                        )
+                }
+                if client.codec == .noneAndLz4 {
+                    Text("LZ4")
+                        .font(.caption2)
+                        .foregroundStyle(.green)
+                }
+                Text(formatUptime(client.uptimeSecs))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // ----------------------------------------------------------
+    //  Display helpers
+    // ----------------------------------------------------------
+
+    private var gainDisplay: String {
+        if client.currentGainAuto == true {
+            return "Auto"
+        }
+        if let tenths = client.currentGainTenthsDb {
+            return String(format: "%.1f dB", Double(tenths) / 10.0)
+        }
+        return "—"
+    }
+
+    private var commandsDisplay: String {
+        let count = client.recentCommandsCount
+        let countLabel = "\(count) command\(count == 1 ? "" : "s")"
+        if let age = client.lastCommandAgeSecs {
+            return "\(countLabel) · last \(formatAge(age)) ago"
+        }
+        return countLabel
+    }
+
+    private func formatUptime(_ secs: Double) -> String {
+        let total = Int(secs.rounded())
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
+        if h > 0 { return String(format: "%dh %02dm", h, m) }
+        if m > 0 { return String(format: "%dm %02ds", m, s) }
+        return "\(s)s"
+    }
+
+    private func formatAge(_ secs: Double) -> String {
+        if secs < 1 { return "<1s" }
+        let total = Int(secs.rounded())
+        if total < 60 { return "\(total)s" }
+        let m = total / 60
+        let s = total % 60
+        return String(format: "%dm %02ds", m, s)
+    }
+
     private func formatBytes(_ bytes: UInt64) -> String {
         let kib: UInt64 = 1_024
         let mib: UInt64 = kib * 1_024

--- a/apps/macos/SDRMac/Views/RtlTcpServerSection.swift
+++ b/apps/macos/SDRMac/Views/RtlTcpServerSection.swift
@@ -39,7 +39,10 @@ private let rtlSdrSampleRates: [UInt32] = [
 /// typical RTL-SDR rates (~16 Mbps for 2 Msps × 8 bits) so a
 /// plain "bytes" label gets unreadable in minutes. Per
 /// CodeRabbit on PR #624.
-fileprivate func formatRtlTcpBytes(_ bytes: UInt64) -> String {
+///
+/// `private` (not `fileprivate`) — they're equivalent at top
+/// level in Swift 4+, and SwiftLint prefers `private`.
+private func formatRtlTcpBytes(_ bytes: UInt64) -> String {
     let kib: UInt64 = 1_024
     let mib: UInt64 = kib * 1_024
     let gib: UInt64 = mib * 1_024

--- a/apps/macos/SDRMac/Views/RtlTcpServerSection.swift
+++ b/apps/macos/SDRMac/Views/RtlTcpServerSection.swift
@@ -32,6 +32,29 @@ private let rtlSdrSampleRates: [UInt32] = [
 // alongside the aggregate-only stats. Per-client recent-
 // commands drilldown is a separate follow-up. Issue #401.
 
+/// Format a byte count as KiB / MiB / GiB. Both the server-
+/// wide `Total bytes sent` row and the per-client `Bytes sent`
+/// row format counters this way; pulled to file scope so they
+/// share one implementation. The lifetime total grows fast at
+/// typical RTL-SDR rates (~16 Mbps for 2 Msps × 8 bits) so a
+/// plain "bytes" label gets unreadable in minutes. Per
+/// CodeRabbit on PR #624.
+fileprivate func formatRtlTcpBytes(_ bytes: UInt64) -> String {
+    let kib: UInt64 = 1_024
+    let mib: UInt64 = kib * 1_024
+    let gib: UInt64 = mib * 1_024
+    if bytes >= gib {
+        return String(format: "%.2f GiB", Double(bytes) / Double(gib))
+    }
+    if bytes >= mib {
+        return String(format: "%.2f MiB", Double(bytes) / Double(mib))
+    }
+    if bytes >= kib {
+        return String(format: "%.2f KiB", Double(bytes) / Double(kib))
+    }
+    return "\(bytes) B"
+}
+
 struct RtlTcpServerSection: View {
     @Environment(CoreModel.self) private var model
 
@@ -358,7 +381,7 @@ struct RtlTcpServerSection: View {
                     .foregroundStyle(.secondary)
             }
             LabeledContent("Total bytes sent") {
-                Text(formatBytes(stats.totalBytesSent))
+                Text(formatRtlTcpBytes(stats.totalBytesSent))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
             }
@@ -392,25 +415,6 @@ struct RtlTcpServerSection: View {
         model.isRunning && model.sourceType == .rtlSdr
     }
 
-    /// Format a byte count as KiB / MiB / GiB. The lifetime
-    /// total grows fast at typical RTL-SDR rates (~16 Mbps for
-    /// 2 Msps × 8 bits) so a plain "bytes" label gets unreadable
-    /// in minutes.
-    private func formatBytes(_ bytes: UInt64) -> String {
-        let kib: UInt64 = 1_024
-        let mib: UInt64 = kib * 1_024
-        let gib: UInt64 = mib * 1_024
-        if bytes >= gib {
-            return String(format: "%.2f GiB", Double(bytes) / Double(gib))
-        }
-        if bytes >= mib {
-            return String(format: "%.2f MiB", Double(bytes) / Double(mib))
-        }
-        if bytes >= kib {
-            return String(format: "%.2f KiB", Double(bytes) / Double(kib))
-        }
-        return "\(bytes) B"
-    }
 }
 
 // ============================================================
@@ -437,7 +441,7 @@ private struct ClientRow: View {
         DisclosureGroup(isExpanded: $expanded) {
             // ---- Body: per-client detail rows ----
             LabeledContent("Bytes sent") {
-                Text(formatBytes(client.bytesSent))
+                Text(formatRtlTcpBytes(client.bytesSent))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
             }
@@ -497,7 +501,7 @@ private struct ClientRow: View {
                                 .stroke(.secondary.opacity(0.4))
                         )
                 }
-                if client.codec == .noneAndLz4 {
+                if client.codec == .lz4 {
                     Text("LZ4")
                         .font(.caption2)
                         .foregroundStyle(.green)
@@ -551,19 +555,4 @@ private struct ClientRow: View {
         return String(format: "%dm %02ds", m, s)
     }
 
-    private func formatBytes(_ bytes: UInt64) -> String {
-        let kib: UInt64 = 1_024
-        let mib: UInt64 = kib * 1_024
-        let gib: UInt64 = mib * 1_024
-        if bytes >= gib {
-            return String(format: "%.2f GiB", Double(bytes) / Double(gib))
-        }
-        if bytes >= mib {
-            return String(format: "%.2f MiB", Double(bytes) / Double(mib))
-        }
-        if bytes >= kib {
-            return String(format: "%.2f KiB", Double(bytes) / Double(kib))
-        }
-        return "\(bytes) B"
-    }
 }

--- a/apps/macos/SDRMac/Views/RtlTcpServerSection.swift
+++ b/apps/macos/SDRMac/Views/RtlTcpServerSection.swift
@@ -198,18 +198,29 @@ struct RtlTcpServerSection: View {
         // yet. This toggle currently only governs the mDNS
         // advertisement so clients can stage a credential
         // prompt before connecting; the server itself still
-        // accepts every connection. Tracked in #623 — shipping
-        // the toggle now keeps the schema stable for the
-        // auth-key plumbing follow-up.
+        // accepts every connection. Tracked in #623.
+        //
+        // Stays editable while the server is running because it
+        // ONLY affects the mDNS announcement — flipping it
+        // tears down and re-publishes the advertiser with the
+        // updated TXT record so listeners on the LAN see the
+        // change without a server restart. The Compression
+        // picker and the rest of the form stay disabled mid-
+        // session because they feed `SdrRtlTcpServerConfig`
+        // which the engine applies once on dongle open. Per
+        // CodeRabbit on PR #624.
         Toggle("Advertise auth required", isOn: Binding(
             get: { model.rtlTcpServerAuthRequired },
             set: {
                 model.rtlTcpServerAuthRequired = $0
                 model.persistRtlTcpServerConfig()
+                // Re-announce when the user toggles mid-session
+                // so the LAN immediately sees the new TXT bit.
+                // No-op when stopped; safe to call regardless.
+                model.reannounceMdnsAdvertisement()
             }
         ))
-        .disabled(model.rtlTcpServerRunning)
-        .help("Sets the mDNS auth-required TXT bit so discovering clients can prompt for a key. Auth-key enforcement on the server itself is a separate follow-up (#623).")
+        .help("Sets the mDNS auth-required TXT bit so discovering clients can prompt for a key. Updates the advertisement live while the server is running. Auth-key enforcement on the server itself is a separate follow-up (#623).")
 
         // Collapsible device-defaults group. Most users keep
         // the defaults; expanding exposes the initial state the
@@ -517,9 +528,31 @@ private struct ClientRow: View {
     //  Display helpers
     // ----------------------------------------------------------
 
+    /// Render the client's tuner-gain state. Three valid
+    /// states tracked separately on the C side:
+    ///
+    /// 1. `currentGainAuto == true` — client switched to auto.
+    ///    Show "Auto" (any held value is irrelevant in auto
+    ///    mode).
+    /// 2. `currentGainAuto == false` — client switched to
+    ///    manual. They may or may not have sent a `SetTunerGain`
+    ///    yet; show the value if present, else "Manual" so the
+    ///    row distinguishes "manual mode without a value yet"
+    ///    from "no gain command at all". Per CodeRabbit on PR
+    ///    #624.
+    /// 3. `currentGainAuto == nil` — client hasn't touched gain
+    ///    settings. May still have sent a stray `SetTunerGain`
+    ///    (the C struct tracks mode and value independently);
+    ///    show the value if present, else "—".
     private var gainDisplay: String {
         if client.currentGainAuto == true {
             return "Auto"
+        }
+        if client.currentGainAuto == false {
+            if let tenths = client.currentGainTenthsDb {
+                return String(format: "%.1f dB", Double(tenths) / 10.0)
+            }
+            return "Manual"
         }
         if let tenths = client.currentGainTenthsDb {
             return String(format: "%.1f dB", Double(tenths) / 10.0)


### PR DESCRIPTION
## Summary

Modernize the Mac rtl_tcp server panel to current ABI (0.24, originally landed at 0.19). Bundled because both tickets touch the same view + model + ABI surface.

### #401 — Per-client schema (post-#391)
- **`SdrRtlTcpServer.ClientInfo`** — Swift mirror of the C `SdrRtlTcpClientInfo` struct (id, peer, codec, role, bytes, freq/rate/gain, recent-commands hint).
- **`clientList()`** — wraps `sdr_rtltcp_server_client_list` with a size-then-fill retry that handles a client connecting between the size probe and the read.
- Poller fetches both `stats()` and `clientList()` on the same 1 Hz tick so the aggregate count and the per-client rows describe one snapshot.
- **`ClientRow`** view — one expandable row per connected client. Header: peer address (monospaced) + role badge + LZ4 badge + uptime; body: bytes / drops / freq / rate / gain / recent-command hint.

### #417 — Codecs + auth-required mDNS
- **`SdrRtlTcpServer.Compression`** enum (`.noneOnly = 0x01`, `.noneAndLz4 = 0x03`) — wire bytes match Rust `CodecMask`.
- **`Config.compression`** forwards to the C `has_compression` / `compression` fields explicitly (rather than relying on the omit-key default).
- **`SdrRtlTcpAdvertiser.Options`** gains `compression: Compression?` + `authRequired: Bool?` — `nil` omits the TXT key to preserve pre-0.19 wire form.
- **`DiscoveredServer`** parses both read-side TXT fields so future client UI can gate on capability signals.
- **Compression picker** + **"Advertise auth required" toggle** on the Server panel, persisted via UserDefaults under namespaced keys.

## Out of scope (deferred to #623)

Auth-key enforcement (`auth_key`/`auth_key_len` plumbing + Keychain-stored credential entry + gating server start on a non-empty key) is **not** in scope here. The toggle currently only flips the mDNS advertisement bit; the server still accepts every connection. Filed [#623](https://github.com/jasonherald/rtl-sdr/issues/623) — the panel `.help` caption points users at it so the partial state is honest.

## Test plan

- [x] `make swift-test` — all 51 tests pass
- [x] `make mac-app` — Release build clean
- [x] Smoke test: panel renders compression picker + auth toggle; per-client row appears when a client connects; expand reveals freq/rate/gain; LZ4 mode shows the badge in the row header

Closes #401
Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream compression option for the RTL‑TCP server with persisted setting; compression picker disabled while server runs.
  * "Advertise auth required" toggle exposed, persisted, and reannounced on change so LAN TXT updates immediately.
  * Per‑client monitoring: expandable client list refreshed regularly showing role/codec, uptime, bytes, stats and recent commands.
  * Improved server status byte formatting (KiB/MiB/GiB).

* **Bug Fixes**
  * Client list now reliably clears when the server stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->