### PR TITLE
chore(deps): bump slowrx 0.2.1 → 0.5.0; label new SSTV modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,9 +3679,9 @@ dependencies = [
 
 [[package]]
 name = "slowrx"
-version = "0.2.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a27e7dea5ae044a8592881559a27e039ef5d6cf7cfb1446b8c14071a8b3c3e"
+checksum = "4355b27327e8fd6ca705d6b80e58f32625f5a94b41d8dd410bc8a652c04b8307"
 dependencies = [
  "rustfft",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,7 +309,7 @@ tempfile = "3"
 # `slowrx::resample::MAX_INPUT_SAMPLE_RATE_HZ` and internally resamples to
 # 11_025 Hz. Both `rustfft` and `thiserror` that slowrx brings are already
 # in the workspace dep tree, so no new transitive deps are added.
-slowrx = "0.2.1"
+slowrx = "0.5.0"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -971,8 +971,8 @@ fn sstv_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_c
             }
             _ => {
                 // `SstvEvent` is `#[non_exhaustive]` — silently
-                // ignore future variants so a slowrx 0.2 update
-                // doesn't require a source change here.
+                // ignore future variants so a slowrx update doesn't
+                // require a source change here.
             }
         }
     }
@@ -993,6 +993,14 @@ fn sstv_mode_label(mode: slowrx::SstvMode) -> &'static str {
         slowrx::SstvMode::Pd120 => "PD120",
         slowrx::SstvMode::Pd180 => "PD180",
         slowrx::SstvMode::Pd240 => "PD240",
+        slowrx::SstvMode::Robot24 => "Robot 24",
+        slowrx::SstvMode::Robot36 => "Robot 36",
+        slowrx::SstvMode::Robot72 => "Robot 72",
+        slowrx::SstvMode::Scottie1 => "Scottie 1",
+        slowrx::SstvMode::Scottie2 => "Scottie 2",
+        slowrx::SstvMode::ScottieDx => "Scottie DX",
+        slowrx::SstvMode::Martin1 => "Martin 1",
+        slowrx::SstvMode::Martin2 => "Martin 2",
         _ => "SSTV",
     }
 }


### PR DESCRIPTION
## Summary

slowrx 0.5.0 adds eight new SSTV modes to the decoder (Robot 24/36/72 in V2.2, Scottie 1/2/DX in V2.3, Martin 1/2 in V2.4) on top of the V2.1 PD120/180/240 we were already on. Dispatch is mode-agnostic so the upgrade compiles + tests clean with no source changes; this PR adds explicit \`sstv_mode_label\` arms so the viewer header reads e.g. \"Scottie 1\" instead of the generic \"SSTV\" wildcard.

- \`Cargo.toml\`: \`slowrx = "0.2.1" → "0.5.0"\`
- \`controller.rs\`: 8 new \`sstv_mode_label\` arms for the new modes (display strings follow slowrx's \`modespec.rs\` rustdocs); refreshed a stale \"slowrx 0.2 update\" comment on the \`SstvEvent::_\` wildcard arm to be version-agnostic.

The wildcard fallback is kept since \`SstvMode\` is still \`#[non_exhaustive]\`.

## Test plan
- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` clean
- [x] \`cargo test --workspace --lib\` 418 passed
- [x] \`cargo check --workspace --locked\` clean (Cargo.lock not drifted)
- [x] \`cargo fmt --all -- --check\` clean
- [ ] Real-radio validation deferred until next ARISS event window — Robot/Scottie/Martin only show up during ham SSTV nets, not during ISS passes by themselves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated SSTV decoder library to version 0.5.0.

* **Improvements**
  * Enhanced SSTV mode identification—additional SSTV mode types (Robot24, Robot36, Robot72, Scottie1, Scottie2, ScottieDx, Martin1, Martin2) now display with specific labels instead of generic identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->