### PR TITLE
chore(sdr-rtlsdr): #626 visibility + doc pass

### DIFF
--- a/crates/sdr-rtlsdr/src/device/mod.rs
+++ b/crates/sdr-rtlsdr/src/device/mod.rs
@@ -63,6 +63,15 @@ pub struct RtlSdrDevice {
 }
 
 impl RtlSdrDevice {
+    /// USB bulk-IN endpoint address for IQ sample reads.
+    ///
+    /// Exposed as a public constant so callers using the
+    /// [`Self::usb_handle`] escape hatch to do their own raw
+    /// `rusb::DeviceHandle::read_bulk` calls (e.g. an `rtl_tcp`
+    /// server forwarding raw samples) don't need to hard-code the
+    /// magic number. Universal across all RTL-SDR variants.
+    pub const BULK_ENDPOINT: u8 = crate::constants::BULK_ENDPOINT;
+
     /// Open an RTL-SDR device by index.
     ///
     /// Ports `rtlsdr_open`. Initializes the baseband, probes the tuner,

--- a/crates/sdr-rtlsdr/src/lib.rs
+++ b/crates/sdr-rtlsdr/src/lib.rs
@@ -1,10 +1,80 @@
-//! Pure Rust port of librtlsdr — RTL2832U USB control and tuner drivers.
+//! Pure-Rust port of librtlsdr — RTL2832U USB control + tuner drivers.
 //!
-//! This crate provides direct USB communication with RTL-SDR dongles
-//! using the `rusb` crate, without requiring the C librtlsdr library.
+//! Talks to RTL-SDR dongles directly over USB via [`rusb`], without the
+//! C `librtlsdr` library or its headers. Covers all five tuner families
+//! shipped in real-world dongles (R820T / R820T2 / R828D, E4000,
+//! FC0012, FC0013, FC2580).
 //!
-//! Hardware register manipulation requires extensive integer casts that
-//! are inherent in a faithful port of C driver code.
+//! # Quick start
+//!
+//! ```no_run
+//! use sdr_rtlsdr::{RtlSdrDevice, RtlSdrError};
+//!
+//! # fn main() -> Result<(), RtlSdrError> {
+//! // Open the first dongle plugged in.
+//! let mut dev = RtlSdrDevice::open(0)?;
+//!
+//! // Tune to 100 MHz, 2.048 Msps.
+//! dev.set_center_freq(100_000_000)?;
+//! dev.set_sample_rate(2_048_000)?;
+//!
+//! // Manual gain at 14.4 dB (= 144 in tenths-of-dB).
+//! dev.set_tuner_gain_mode(true)?;
+//! dev.set_tuner_gain(144)?;
+//!
+//! // Read 64 KB of interleaved I/Q samples.
+//! dev.reset_buffer()?;
+//! let mut buf = vec![0u8; 65_536];
+//! let n = dev.read_sync(&mut buf)?;
+//! assert!(n > 0);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Public surface
+//!
+//! The committed surface is intentionally narrow:
+//!
+//! - [`RtlSdrDevice`] — the device handle. All control + streaming
+//!   methods live here. Open via [`RtlSdrDevice::open`].
+//! - Free enumeration helpers — [`get_device_count`],
+//!   [`get_device_name`], [`get_device_usb_strings`],
+//!   [`get_index_by_serial`].
+//! - [`RtlSdrError`] — the unified error type returned by every
+//!   fallible operation.
+//! - [`TunerType`] — the IC family identifier returned by
+//!   [`RtlSdrDevice::tuner_type`].
+//!
+//! Sample values are interleaved unsigned 8-bit I/Q pairs, the native
+//! RTL-SDR format. Convert to centred `i8` (or `f32` in `[-1, 1]`) at
+//! the consumer if needed; we don't impose a sample type on the read
+//! path.
+//!
+//! # USB context + threading
+//!
+//! [`RtlSdrDevice`] holds an `Arc<rusb::DeviceHandle>` internally so
+//! the device handle can be shared across threads safely. The control
+//! methods take `&mut self` and serialise on the caller; bulk reads
+//! via [`RtlSdrDevice::read_sync`] are concurrency-safe with separate
+//! control calls because rusb's bulk transfers are independent of the
+//! control endpoint.
+//!
+//! For raw bulk reads on a worker thread (e.g. an `rtl_tcp`-style
+//! server), call [`RtlSdrDevice::usb_handle`] to clone the underlying
+//! handle and use [`RtlSdrDevice::BULK_ENDPOINT`] for the endpoint
+//! address.
+//!
+//! # Faithful-port note
+//!
+//! The crate is a port of the C `librtlsdr` source — register
+//! addresses, magic constants, and per-tuner I2C tables are
+//! transcribed directly from the upstream code. Some internal items
+//! aren't currently called from Rust but are kept for completeness so
+//! future hardware-feature work is a register-table read away rather
+//! than a re-port. Hardware register manipulation requires extensive
+//! integer casts inherent in a faithful port of C driver code.
+//!
+//! [`rusb`]: https://docs.rs/rusb
 
 // Allow cast-heavy code throughout this crate (hardware register port)
 #![allow(
@@ -22,17 +92,32 @@
     clippy::manual_range_contains,
     clippy::needless_range_loop,
     clippy::implicit_saturating_sub,
-    clippy::doc_markdown
+    clippy::doc_markdown,
+    // Faithful port from librtlsdr's C source: register addresses,
+    // hardware constants, and tuner-IC enum variants are kept for
+    // completeness even when not currently called from Rust. The
+    // public surface of the crate (now scoped down — see
+    // `RtlSdrDevice` and the top-level re-exports) is what we're
+    // committing to; keeping the internals around makes future
+    // hardware-feature work a register-table read away rather than
+    // a re-port. Per #626 visibility audit.
+    dead_code
 )]
 
-pub mod constants;
+pub(crate) mod constants;
 pub mod device;
 pub mod error;
-pub mod reg;
+pub(crate) mod reg;
 pub mod tuner;
-pub mod usb;
+pub(crate) mod usb;
 
 pub use device::{
     RtlSdrDevice, get_device_count, get_device_name, get_device_usb_strings, get_index_by_serial,
 };
 pub use error::RtlSdrError;
+/// Tuner family identifier for the IC inside the dongle.
+///
+/// Returned by [`RtlSdrDevice::tuner_type`]. Useful for displaying
+/// "tuner: R820T2" in a UI or for branching gain-table queries
+/// since each tuner has its own discrete gain steps.
+pub use reg::TunerType;

--- a/crates/sdr-rtlsdr/src/lib.rs
+++ b/crates/sdr-rtlsdr/src/lib.rs
@@ -108,7 +108,15 @@ pub(crate) mod constants;
 pub mod device;
 pub mod error;
 pub(crate) mod reg;
-pub mod tuner;
+// `tuner` is the internal abstraction layer over the five tuner-IC
+// backends (R820T2 / E4000 / FC0012 / FC0013 / FC2580). The `Tuner`
+// trait takes raw `rusb::DeviceHandle` parameters because the per-IC
+// I2C transactions need direct USB control-transfer access — that's
+// not a shape we want in the committed semver surface. External
+// consumers control the tuner through `RtlSdrDevice` methods
+// (`set_tuner_gain`, `set_tuner_bandwidth`, etc.) which dispatch
+// internally to the right backend. Per #630 CR round 1.
+pub(crate) mod tuner;
 pub(crate) mod usb;
 
 pub use device::{

--- a/crates/sdr-rtlsdr/src/lib.rs
+++ b/crates/sdr-rtlsdr/src/lib.rs
@@ -53,16 +53,23 @@
 //! # USB context + threading
 //!
 //! [`RtlSdrDevice`] holds an `Arc<rusb::DeviceHandle>` internally so
-//! the device handle can be shared across threads safely. The control
-//! methods take `&mut self` and serialise on the caller; bulk reads
-//! via [`RtlSdrDevice::read_sync`] are concurrency-safe with separate
-//! control calls because rusb's bulk transfers are independent of the
-//! control endpoint.
+//! the device handle can be cloned across threads — `rusb::DeviceHandle`
+//! is `Sync`, which makes the type *shareable* between threads. The
+//! control methods on [`RtlSdrDevice`] take `&mut self` and serialise
+//! on the caller; that's the supported single-thread pattern.
 //!
 //! For raw bulk reads on a worker thread (e.g. an `rtl_tcp`-style
 //! server), call [`RtlSdrDevice::usb_handle`] to clone the underlying
 //! handle and use [`RtlSdrDevice::BULK_ENDPOINT`] for the endpoint
-//! address.
+//! address. **Note that `Sync` alone does not guarantee that
+//! concurrent bulk and control transfers on the same handle are
+//! safe** — `rusb`'s docs don't make that claim explicitly, and
+//! libusb's caveats restrict per-resource concurrent access. If you
+//! mix concurrent bulk and control on one handle, treat it as an
+//! unsupported design assumption you've verified against your
+//! libusb version + dongle hardware. The safer pattern is to
+//! quiesce control calls (or do them all from one thread) while a
+//! bulk-read worker is in flight.
 //!
 //! # Faithful-port note
 //!
@@ -92,21 +99,22 @@
     clippy::manual_range_contains,
     clippy::needless_range_loop,
     clippy::implicit_saturating_sub,
-    clippy::doc_markdown,
-    // Faithful port from librtlsdr's C source: register addresses,
-    // hardware constants, and tuner-IC enum variants are kept for
-    // completeness even when not currently called from Rust. The
-    // public surface of the crate (now scoped down — see
-    // `RtlSdrDevice` and the top-level re-exports) is what we're
-    // committing to; keeping the internals around makes future
-    // hardware-feature work a register-table read away rather than
-    // a re-port. Per #626 visibility audit.
-    dead_code
+    clippy::doc_markdown
 )]
 
+// Faithful-port modules: `constants` and `reg` transcribe register
+// addresses and hardware magic numbers from upstream `librtlsdr`'s C
+// source. We keep the full table around even when not currently
+// called from Rust so future hardware-feature work is a register-
+// table read away rather than a re-port. Scoped `dead_code` allow
+// (rather than crate-level) means accidental dead paths in `device`,
+// `error`, or any future addition still get caught by the lint. Per
+// #630 CR round 2.
+#[allow(dead_code)]
 pub(crate) mod constants;
 pub mod device;
 pub mod error;
+#[allow(dead_code)]
 pub(crate) mod reg;
 // `tuner` is the internal abstraction layer over the five tuner-IC
 // backends (R820T2 / E4000 / FC0012 / FC0013 / FC2580). The `Tuner`

--- a/crates/sdr-rtlsdr/src/tuner/mod.rs
+++ b/crates/sdr-rtlsdr/src/tuner/mod.rs
@@ -3,11 +3,11 @@
 //! Each tuner IC (R820T, E4000, FC0012, etc.) implements the `Tuner` trait,
 //! providing frequency, gain, and bandwidth control via I2C.
 
-pub mod e4k;
-pub mod fc0012;
-pub mod fc0013;
-pub mod fc2580;
-pub mod r82xx;
+pub(crate) mod e4k;
+pub(crate) mod fc0012;
+pub(crate) mod fc0013;
+pub(crate) mod fc2580;
+pub(crate) mod r82xx;
 
 use crate::error::RtlSdrError;
 

--- a/crates/sdr-rtlsdr/src/tuner/mod.rs
+++ b/crates/sdr-rtlsdr/src/tuner/mod.rs
@@ -3,9 +3,19 @@
 //! Each tuner IC (R820T, E4000, FC0012, etc.) implements the `Tuner` trait,
 //! providing frequency, gain, and bandwidth control via I2C.
 
+// Per-tuner backends carry the IC's I2C register tables transcribed
+// from upstream `librtlsdr`. Some entries aren't called from Rust
+// today but are kept for completeness so adding a hardware feature
+// later is a register-table read rather than a re-port. Scoped
+// `dead_code` allow per-module rather than crate-level so dead paths
+// in non-port code still get caught. Per #630 CR round 2.
+#[allow(dead_code)]
 pub(crate) mod e4k;
+#[allow(dead_code)]
 pub(crate) mod fc0012;
+#[allow(dead_code)]
 pub(crate) mod fc0013;
+#[allow(dead_code)]
 pub(crate) mod fc2580;
 pub(crate) mod r82xx;
 

--- a/crates/sdr-rtlsdr/src/tuner/r82xx/mod.rs
+++ b/crates/sdr-rtlsdr/src/tuner/r82xx/mod.rs
@@ -5,6 +5,10 @@
 //! - `i2c`: Shadow register I2C communication
 //! - `pll`: PLL frequency synthesis
 
+// R820T2/R828D register-table constants — same faithful-port
+// rationale as the sibling tuners (`tuner/mod.rs`). Per #630 CR
+// round 2.
+#[allow(dead_code)]
 pub mod constants;
 mod i2c;
 mod pll;

--- a/crates/sdr-server-rtltcp/src/dispatch.rs
+++ b/crates/sdr-server-rtltcp/src/dispatch.rs
@@ -5,7 +5,7 @@
 //! Errors are logged but do not abort the command loop (matches upstream,
 //! which ignores each call's return code inside the `switch`).
 
-use sdr_rtlsdr::device::RtlSdrDevice;
+use sdr_rtlsdr::RtlSdrDevice;
 
 use crate::protocol::{Command, CommandOp};
 

--- a/crates/sdr-server-rtltcp/src/protocol.rs
+++ b/crates/sdr-server-rtltcp/src/protocol.rs
@@ -19,7 +19,7 @@
 //! Both are big-endian on the wire. Layout is fixed and must not change;
 //! interop with GQRX/SDR++/SoapySDR depends on exact byte compatibility.
 
-use sdr_rtlsdr::reg::TunerType;
+use sdr_rtlsdr::TunerType;
 
 /// The 4-byte magic prefix in `dongle_info_t`.
 pub const DONGLE_MAGIC: [u8; 4] = *b"RTL0";

--- a/crates/sdr-server-rtltcp/src/server.rs
+++ b/crates/sdr-server-rtltcp/src/server.rs
@@ -43,7 +43,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-use sdr_rtlsdr::device::RtlSdrDevice;
+use sdr_rtlsdr::RtlSdrDevice;
 
 use crate::broadcaster::{ClientRegistry, ClientSlot, RoleDecision};
 use crate::codec::{Codec, CodecMask, Encoder};
@@ -2266,11 +2266,7 @@ fn broadcaster_worker(
     let mut ticks_since_prune: u32 = 0;
 
     while !shutdown.load(Ordering::Relaxed) {
-        match handle.read_bulk(
-            sdr_rtlsdr::constants::BULK_ENDPOINT,
-            &mut scratch,
-            USB_READ_TIMEOUT,
-        ) {
+        match handle.read_bulk(RtlSdrDevice::BULK_ENDPOINT, &mut scratch, USB_READ_TIMEOUT) {
             Ok(n) if n > 0 => {
                 registry.broadcast(&scratch[..n]);
                 ticks_since_prune = ticks_since_prune.saturating_add(1);

--- a/crates/sdr-source-rtlsdr/src/lib.rs
+++ b/crates/sdr-source-rtlsdr/src/lib.rs
@@ -282,8 +282,7 @@ impl Source for RtlSdrSource {
                         break;
                     };
 
-                    match handle.read_bulk(sdr_rtlsdr::constants::BULK_ENDPOINT, &mut data, timeout)
-                    {
+                    match handle.read_bulk(RtlSdrDevice::BULK_ENDPOINT, &mut data, timeout) {
                         Ok(n) if n > 0 => {
                             slot.len.store(n, Ordering::Relaxed);
                             slot.state.store(1, Ordering::Release); // mark full


### PR DESCRIPTION
## Summary

First step toward spinning out \`sdr-rtlsdr\` per #626: lock down the public API surface, retire the over-public modules, write a crate-level doc that reads like a published Rust crate's front page.

## What's changing

- **\`pub\` → \`pub(crate)\`**: \`mod constants\`, \`mod reg\`, \`mod usb\`, and the per-tuner submodules under \`mod tuner\` (e4k, fc0012, fc0013, fc2580, r82xx). All implementation detail.
- **New stable surface for the two items real callers needed**:
  - \`pub use reg::TunerType\` at crate root → \`sdr_rtlsdr::TunerType\`.
  - \`RtlSdrDevice::BULK_ENDPOINT: u8\` associated const for callers using the \`usb_handle()\` escape hatch.
- **Crate-level doc rewrite**: quick-start example (compiles as \`no_run\` doctest), public-surface enumeration, USB / threading note, faithful-port note.
- **\`dead_code\` allow**: ~260 hardware-register / tuner-IC items we ported from C but don't currently call from Rust. Kept for completeness so future hardware-feature work is a register-table read away rather than a re-port.
- **Caller fixes**: 4 internal callsites updated to the new stable paths (sdr-server-rtltcp, sdr-source-rtlsdr).

## Out of scope

This is visibility + docs only — no new features, no behaviour changes. The next round (per #626) tackles gap features from the survey: collected \`list()\` enumeration, builder for \`open\`, async-friendly streaming, \`closest_gain\` helper, etc.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` clean
- [x] \`cargo test --workspace --lib\` 418 passed
- [x] \`cargo check --workspace --locked\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps -p sdr-rtlsdr\` clean
- [x] \`cargo test --doc -p sdr-rtlsdr\` (1 doctest) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded crate documentation with a Quick Start, USB context, and porting notes.

* **New Features**
  * Made BULK_ENDPOINT accessible as a public constant for direct use.

* **Refactor**
  * Reduced public surface by making several internal modules crate-private.
  * Added a public re-export for TunerType to simplify imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->