### PR TITLE
feat(sdr-rtlsdr): #626 round 2 — ergonomic API additions

### DIFF
--- a/crates/sdr-rtlsdr/src/device/builder.rs
+++ b/crates/sdr-rtlsdr/src/device/builder.rs
@@ -93,9 +93,12 @@ impl RtlSdrDeviceBuilder {
     /// # Errors
     ///
     /// - [`RtlSdrError::DeviceNotFound`] when the index is out of
-    ///   range OR the serial doesn't match any plugged-in dongle.
-    /// - [`RtlSdrError::InvalidParameter`] when no devices are
-    ///   plugged in but a serial selector was set.
+    ///   range OR no devices are plugged in at all (the
+    ///   underlying [`super::enumerate::get_index_by_serial`]
+    ///   returns this when its enumerate sees zero devices).
+    /// - [`RtlSdrError::InvalidParameter`] when devices are
+    ///   present but no plugged-in dongle's serial matches the
+    ///   one supplied.
     /// - Any [`RtlSdrError`] [`RtlSdrDevice::open`] would return on
     ///   the resolved index (USB transport errors, baseband-init
     ///   failure, unknown tuner, etc.).
@@ -109,20 +112,13 @@ impl RtlSdrDeviceBuilder {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::panic,
-    reason = "tests use panic!() for descriptive assertion failures"
-)]
 mod tests {
     use super::*;
 
     #[test]
     fn default_builder_uses_index_zero() {
         let b = RtlSdrDeviceBuilder::default();
-        match b.selector {
-            Selector::Index(0) => {}
-            other => panic!("expected Index(0), got {other:?}"),
-        }
+        assert!(matches!(b.selector, Selector::Index(0)));
     }
 
     #[test]
@@ -131,16 +127,10 @@ mod tests {
             .index(2)
             .serial("ABCD")
             .index(5);
-        match b.selector {
-            Selector::Index(5) => {}
-            other => panic!("expected Index(5), got {other:?}"),
-        }
+        assert!(matches!(b.selector, Selector::Index(5)));
 
         let b = RtlSdrDeviceBuilder::default().index(7).serial("WXYZ");
-        match b.selector {
-            Selector::Serial(ref s) if s == "WXYZ" => {}
-            other => panic!("expected Serial(\"WXYZ\"), got {other:?}"),
-        }
+        assert!(matches!(b.selector, Selector::Serial(ref s) if s == "WXYZ"));
     }
 
     #[test]

--- a/crates/sdr-rtlsdr/src/device/builder.rs
+++ b/crates/sdr-rtlsdr/src/device/builder.rs
@@ -1,0 +1,152 @@
+//! Builder for [`RtlSdrDevice::open`] with named selectors.
+
+use crate::error::RtlSdrError;
+
+use super::RtlSdrDevice;
+use super::enumerate::get_index_by_serial;
+
+/// Selector for which dongle to open.
+#[derive(Debug, Clone)]
+enum Selector {
+    /// Open the dongle at this enumeration index.
+    Index(u32),
+    /// Open the dongle whose USB serial-number descriptor matches.
+    Serial(String),
+}
+
+impl Default for Selector {
+    fn default() -> Self {
+        // Matches `RtlSdrDevice::open(0)` — first dongle plugged in.
+        Self::Index(0)
+    }
+}
+
+/// Builder for [`RtlSdrDevice::open`] / [`RtlSdrDevice::builder`].
+///
+/// Lets callers express device selection by serial without
+/// threading [`super::enumerate::get_index_by_serial`] into their
+/// own code:
+///
+/// ```no_run
+/// # use sdr_rtlsdr::{RtlSdrDevice, RtlSdrError};
+/// # fn main() -> Result<(), RtlSdrError> {
+/// // Open by index (default — same as RtlSdrDevice::open(0)):
+/// let dev = RtlSdrDevice::builder().open()?;
+///
+/// // Open by index explicitly:
+/// let dev = RtlSdrDevice::builder().index(1).open()?;
+///
+/// // Open by serial (multi-dongle setups):
+/// let dev = RtlSdrDevice::builder().serial("00000001").open()?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// When neither selector is set, the builder defaults to
+/// `index(0)` — picking the first dongle plugged in. The last
+/// selector wins; e.g. `.index(0).serial("X")` opens by serial.
+///
+/// The builder is `Clone` so callers staging open-attempts (retry
+/// loops, fallback paths) can fork a partially-configured builder
+/// without rebuilding from scratch.
+#[derive(Debug, Clone, Default)]
+pub struct RtlSdrDeviceBuilder {
+    selector: Selector,
+}
+
+impl RtlSdrDeviceBuilder {
+    /// Open the dongle at the given enumeration index.
+    ///
+    /// Same value space as [`RtlSdrDevice::open`] / the free
+    /// [`super::enumerate::get_device_count`] return value. The
+    /// builder defaults to `index(0)`, so calling this is only
+    /// necessary when you want a specific other dongle by
+    /// position (or for self-documenting clarity).
+    #[must_use]
+    pub fn index(mut self, index: u32) -> Self {
+        self.selector = Selector::Index(index);
+        self
+    }
+
+    /// Open the dongle whose USB serial-number descriptor matches.
+    ///
+    /// Resolved at [`Self::open`] time via
+    /// [`super::enumerate::get_index_by_serial`] — the resolution
+    /// is one USB descriptor read per dongle until the match is
+    /// found. The serial string is the same one
+    /// [`super::enumerate::get_device_usb_strings`] /
+    /// [`super::enumerate::list_devices`] return; most RTL-SDR
+    /// dongles ship with a non-empty serial preprogrammed at the
+    /// factory.
+    ///
+    /// `serial` accepts anything `Into<String>` so you can pass a
+    /// `&str`, `String`, or borrowed config value without an
+    /// explicit conversion at the call site.
+    #[must_use]
+    pub fn serial(mut self, serial: impl Into<String>) -> Self {
+        self.selector = Selector::Serial(serial.into());
+        self
+    }
+
+    /// Open the device with the configured selector.
+    ///
+    /// # Errors
+    ///
+    /// - [`RtlSdrError::DeviceNotFound`] when the index is out of
+    ///   range OR the serial doesn't match any plugged-in dongle.
+    /// - [`RtlSdrError::InvalidParameter`] when no devices are
+    ///   plugged in but a serial selector was set.
+    /// - Any [`RtlSdrError`] [`RtlSdrDevice::open`] would return on
+    ///   the resolved index (USB transport errors, baseband-init
+    ///   failure, unknown tuner, etc.).
+    pub fn open(self) -> Result<RtlSdrDevice, RtlSdrError> {
+        let index = match self.selector {
+            Selector::Index(i) => i,
+            Selector::Serial(s) => get_index_by_serial(&s)?,
+        };
+        RtlSdrDevice::open(index)
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::panic,
+    reason = "tests use panic!() for descriptive assertion failures"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_builder_uses_index_zero() {
+        let b = RtlSdrDeviceBuilder::default();
+        match b.selector {
+            Selector::Index(0) => {}
+            other => panic!("expected Index(0), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn last_selector_wins() {
+        let b = RtlSdrDeviceBuilder::default()
+            .index(2)
+            .serial("ABCD")
+            .index(5);
+        match b.selector {
+            Selector::Index(5) => {}
+            other => panic!("expected Index(5), got {other:?}"),
+        }
+
+        let b = RtlSdrDeviceBuilder::default().index(7).serial("WXYZ");
+        match b.selector {
+            Selector::Serial(ref s) if s == "WXYZ" => {}
+            other => panic!("expected Serial(\"WXYZ\"), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn builder_is_clone() {
+        let b = RtlSdrDeviceBuilder::default().serial("base");
+        let _b2 = b.clone();
+        let _b3 = b.clone().index(3);
+    }
+}

--- a/crates/sdr-rtlsdr/src/device/enumerate.rs
+++ b/crates/sdr-rtlsdr/src/device/enumerate.rs
@@ -2,9 +2,89 @@
 //!
 //! Ports `rtlsdr_get_device_count`, `rtlsdr_get_device_name`,
 //! `rtlsdr_get_device_usb_strings`, `rtlsdr_get_index_by_serial`.
+//!
+//! Plus [`list_devices`] — a Rust-idiomatic collected enumeration
+//! that returns one [`DeviceInfo`] per dongle in a single call.
 
 use crate::constants::find_known_device;
 use crate::error::RtlSdrError;
+
+/// One entry returned by [`list_devices`] / [`crate::RtlSdrDevice::list`].
+///
+/// Carries the four pieces of information you can read about a
+/// dongle without opening it: its enumeration index, the
+/// human-friendly device name from the USB known-devices table
+/// (e.g. "Generic RTL2832U OEM"), and the USB descriptor strings
+/// (manufacturer / product / serial). The serial string is what
+/// you'd hand to [`crate::RtlSdrDevice::builder`] /
+/// [`get_index_by_serial`] to open a specific dongle when more
+/// than one is plugged in.
+///
+/// USB string fields fall back to an empty `String` when the
+/// descriptor read fails (e.g. permissions, transient bus error)
+/// — the entry still appears so you can see something is plugged
+/// in even if the strings aren't readable from this process.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DeviceInfo {
+    /// Zero-based enumeration index — the same value you'd pass to
+    /// [`crate::RtlSdrDevice::open`].
+    pub index: u32,
+    /// Human-friendly device name from the known-devices table
+    /// (e.g. "Realtek RTL2838UHIDIR"). Equivalent to
+    /// [`get_device_name`] but already populated on the entry.
+    pub name: String,
+    /// USB manufacturer descriptor string. May be empty if the
+    /// descriptor read failed.
+    pub manufacturer: String,
+    /// USB product descriptor string. May be empty if the
+    /// descriptor read failed.
+    pub product: String,
+    /// USB serial-number descriptor string. May be empty if the
+    /// descriptor read failed (rare in practice — most RTL-SDR
+    /// flashes ship with a unique serial). Use
+    /// [`crate::RtlSdrDevice::builder`]`.serial(...)` to open by
+    /// serial when more than one dongle is plugged in.
+    pub serial: String,
+}
+
+/// Enumerate all connected RTL-SDR dongles in one call.
+///
+/// More ergonomic than the count + per-index pair when the caller
+/// just wants "tell me what's plugged in." Internally this is
+/// [`get_device_count`] plus per-index [`get_device_name`] +
+/// [`get_device_usb_strings`], collected into a `Vec`. The
+/// returned slice is in enumeration-index order, so
+/// `list_devices()[i].index == i as u32` for any `i` in range.
+///
+/// Returns an empty `Vec` when no devices are present (matches
+/// the implicit "count is 0" path of the underlying enumerate).
+///
+/// # Performance
+///
+/// This walks the USB device tree and, for each match, *opens*
+/// the device briefly to read its USB descriptor strings —
+/// strings aren't cached in the bus topology, the kernel has to
+/// be asked. Roughly `O(n_dongles)` USB control transfers. Cheap
+/// for the common 1-or-2-dongle case but not something to call
+/// in a tight loop. Cache the result.
+#[must_use]
+pub fn list_devices() -> Vec<DeviceInfo> {
+    let count = get_device_count();
+    (0..count)
+        .map(|index| {
+            let name = get_device_name(index);
+            let (manufacturer, product, serial) = get_device_usb_strings(index)
+                .unwrap_or_else(|_| (String::new(), String::new(), String::new()));
+            DeviceInfo {
+                index,
+                name,
+                manufacturer,
+                product,
+                serial,
+            }
+        })
+        .collect()
+}
 
 /// Get the number of connected RTL-SDR devices.
 ///

--- a/crates/sdr-rtlsdr/src/device/mod.rs
+++ b/crates/sdr-rtlsdr/src/device/mod.rs
@@ -564,11 +564,17 @@ impl Drop for RtlSdrDevice {
 /// Ties go to the lower step (deterministic `min_by_key` —
 /// stable iterator order means the first equally-distant entry
 /// in the table wins, and tables are stored in ascending order).
+///
+/// The distance is computed in `i64` to avoid `i32` overflow on
+/// extreme inputs — `(g - desired).abs()` panics in debug builds
+/// when the subtraction overflows (e.g. `desired == i32::MIN`)
+/// and silently wraps in release. Real callers won't pass such
+/// values, but the algorithm shouldn't be a footgun.
 fn closest_gain_in(gains: &[i32], desired: i32) -> i32 {
     gains
         .iter()
         .copied()
-        .min_by_key(|&g| (g - desired).abs())
+        .min_by_key(|&g| (i64::from(g) - i64::from(desired)).abs())
         .unwrap_or(0)
 }
 
@@ -584,7 +590,7 @@ const _: fn() = || {
 };
 
 #[cfg(test)]
-mod closest_gain_tests {
+mod tests {
     use super::closest_gain_in;
 
     // R820T2 gain table (29 steps, tenths of dB) — pinned here
@@ -642,5 +648,16 @@ mod closest_gain_tests {
         // equally-distant entry wins → 0.
         let table = &[0, 100];
         assert_eq!(closest_gain_in(table, 50), 0);
+    }
+
+    #[test]
+    fn i32_min_does_not_overflow() {
+        // Regression: `(g - desired).abs()` in `i32` panics in
+        // debug / wraps in release when `desired == i32::MIN`,
+        // because `0 - i32::MIN` and `i32::MIN.abs()` both
+        // overflow. The fix promotes the distance to `i64` —
+        // pin it so we don't regress. Per #631 CR round 1.
+        assert_eq!(closest_gain_in(R820T2_GAINS, i32::MIN), 0);
+        assert_eq!(closest_gain_in(R820T2_GAINS, i32::MAX), 496);
     }
 }

--- a/crates/sdr-rtlsdr/src/device/mod.rs
+++ b/crates/sdr-rtlsdr/src/device/mod.rs
@@ -17,8 +17,12 @@ mod sampling;
 mod streaming;
 
 pub use enumerate::{
-    get_device_count, get_device_name, get_device_usb_strings, get_index_by_serial,
+    DeviceInfo, get_device_count, get_device_name, get_device_usb_strings, get_index_by_serial,
+    list_devices,
 };
+
+mod builder;
+pub use builder::RtlSdrDeviceBuilder;
 
 use crate::constants::*;
 use crate::error::RtlSdrError;
@@ -31,6 +35,22 @@ use crate::usb;
 ///
 /// Ports `struct rtlsdr_dev` from librtlsdr. Manages the USB connection,
 /// baseband configuration, and tuner driver.
+///
+/// # Send + Sync
+///
+/// `RtlSdrDevice` is [`Send`] — you can move it across thread
+/// boundaries (e.g. into a `std::thread::spawn` worker that owns
+/// the device exclusively). It is **not** [`Sync`] — the inner
+/// per-tuner driver behind a `Box<dyn Tuner + Send>` doesn't
+/// require `Sync`, so sharing `&RtlSdrDevice` between threads
+/// would be unsound.
+///
+/// The supported pattern is single-owner: one thread holds the
+/// `RtlSdrDevice` and serialises every control method call.
+/// For background bulk reads on a worker thread without giving
+/// up `&mut` on the main thread, see [`Self::usb_handle`] /
+/// [`Self::BULK_ENDPOINT`] and the threading caveats in the
+/// crate-level docs.
 pub struct RtlSdrDevice {
     pub(crate) handle: std::sync::Arc<rusb::DeviceHandle<rusb::GlobalContext>>,
     pub(crate) tuner_type: TunerType,
@@ -71,6 +91,31 @@ impl RtlSdrDevice {
     /// server forwarding raw samples) don't need to hard-code the
     /// magic number. Universal across all RTL-SDR variants.
     pub const BULK_ENDPOINT: u8 = crate::constants::BULK_ENDPOINT;
+
+    /// Start a [`RtlSdrDeviceBuilder`] for opening with named
+    /// selectors (index or serial).
+    ///
+    /// See [`RtlSdrDeviceBuilder`] for usage. `RtlSdrDevice::open`
+    /// remains the lowest-overhead path for the "open the first
+    /// dongle" / "open by known index" cases; the builder is for
+    /// when you want to address a specific dongle by serial in a
+    /// multi-device setup.
+    #[must_use]
+    pub fn builder() -> RtlSdrDeviceBuilder {
+        RtlSdrDeviceBuilder::default()
+    }
+
+    /// Enumerate all connected RTL-SDR dongles in one call.
+    ///
+    /// Convenience shortcut for [`list_devices`] for callers that
+    /// already have `RtlSdrDevice` in scope and don't want to
+    /// import the free function separately. See
+    /// [`list_devices`]'s docs for the performance note (one USB
+    /// descriptor read per dongle — cache the result).
+    #[must_use]
+    pub fn list() -> Vec<DeviceInfo> {
+        enumerate::list_devices()
+    }
 
     /// Open an RTL-SDR device by index.
     ///
@@ -350,6 +395,43 @@ impl RtlSdrDevice {
         self.tuner_type.gains()
     }
 
+    /// Find the closest available tuner gain to a desired value.
+    ///
+    /// `desired_tenths_db` is the target gain in tenths-of-dB (the
+    /// same unit [`Self::set_tuner_gain`] takes). Returns the
+    /// gain step from [`Self::tuner_gains`] that's nearest to the
+    /// requested value. Ties go to the lower step (deterministic
+    /// `min_by_key` behaviour). Useful when an app's UI lets the
+    /// user pick a "rough" dB value (slider, dropdown of round
+    /// numbers) and you want the actual closest hardware-accepted
+    /// step without rolling your own search over the gain table.
+    ///
+    /// Each tuner family has its own discrete gain table — the
+    /// R820T2 has 29 steps from 0.0 to 49.6 dB, the E4000 has 14
+    /// steps from -1 to 49 dB, etc. The result is always one of
+    /// those exact values, never an interpolation.
+    ///
+    /// Returns `0` (a no-op gain) when the tuner has no gain table
+    /// at all — in practice only the `Unknown` tuner type, which
+    /// means the device hasn't been probed or the IC isn't in our
+    /// known-tuners list.
+    ///
+    /// ```no_run
+    /// # use sdr_rtlsdr::{RtlSdrDevice, RtlSdrError};
+    /// # fn main() -> Result<(), RtlSdrError> {
+    /// let mut dev = RtlSdrDevice::open(0)?;
+    /// dev.set_tuner_gain_mode(true)?;
+    /// // User picked "around 15 dB" in the UI; pick the actual step.
+    /// let step = dev.closest_gain(150);
+    /// dev.set_tuner_gain(step)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn closest_gain(&self, desired_tenths_db: i32) -> i32 {
+        closest_gain_in(self.tuner_gains(), desired_tenths_db)
+    }
+
     /// Get device manufacturer string.
     pub fn manufacturer(&self) -> &str {
         &self.manufact
@@ -471,5 +553,94 @@ impl Drop for RtlSdrDevice {
         if self.driver_active {
             let _ = self.handle.attach_kernel_driver(0);
         }
+    }
+}
+
+/// Find the closest entry in a tuner-gain table to `desired`,
+/// returning `0` for an empty table. Pulled out of
+/// [`RtlSdrDevice::closest_gain`] so the algorithm can be unit-
+/// tested without constructing a live device.
+///
+/// Ties go to the lower step (deterministic `min_by_key` —
+/// stable iterator order means the first equally-distant entry
+/// in the table wins, and tables are stored in ascending order).
+fn closest_gain_in(gains: &[i32], desired: i32) -> i32 {
+    gains
+        .iter()
+        .copied()
+        .min_by_key(|&g| (g - desired).abs())
+        .unwrap_or(0)
+}
+
+// Pin the `Send`-but-not-`Sync` contract documented on the
+// `RtlSdrDevice` struct. If a future field change ever adds a
+// non-`Send` member (e.g. a `Cell<…>` or `Rc<…>`), this assertion
+// fires at compile time so we notice before semver-breaking
+// downstream consumers who relied on moving the device into a
+// worker thread.
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<RtlSdrDevice>();
+};
+
+#[cfg(test)]
+mod closest_gain_tests {
+    use super::closest_gain_in;
+
+    // R820T2 gain table (29 steps, tenths of dB) — pinned here
+    // rather than imported so the test exercises a known-real
+    // table shape independent of any future tuner-table edits.
+    const R820T2_GAINS: &[i32] = &[
+        0, 9, 14, 27, 37, 77, 87, 125, 144, 157, 166, 197, 207, 229, 254, 280, 297, 328, 338, 364,
+        372, 386, 402, 421, 434, 439, 445, 480, 496,
+    ];
+
+    #[test]
+    fn empty_table_returns_zero() {
+        assert_eq!(closest_gain_in(&[], 250), 0);
+        assert_eq!(closest_gain_in(&[], 0), 0);
+        assert_eq!(closest_gain_in(&[], -100), 0);
+    }
+
+    #[test]
+    fn exact_match_returns_self() {
+        for &g in R820T2_GAINS {
+            assert_eq!(
+                closest_gain_in(R820T2_GAINS, g),
+                g,
+                "exact value {g} should round to itself"
+            );
+        }
+    }
+
+    #[test]
+    fn rounds_to_nearest_step() {
+        // 150 is between 144 and 157 — closer to 157 (Δ=7) than
+        // to 144 (Δ=6). Wait — that's |150-144|=6 vs |150-157|=7,
+        // so 144 wins.
+        assert_eq!(closest_gain_in(R820T2_GAINS, 150), 144);
+
+        // 152 is exactly between 144 (Δ=8) and 157 (Δ=5) → 157.
+        assert_eq!(closest_gain_in(R820T2_GAINS, 152), 157);
+
+        // 100 is between 87 (Δ=13) and 125 (Δ=25) → 87.
+        assert_eq!(closest_gain_in(R820T2_GAINS, 100), 87);
+    }
+
+    #[test]
+    fn out_of_range_clamps_to_endpoint() {
+        // Below the minimum: clamp to first entry.
+        assert_eq!(closest_gain_in(R820T2_GAINS, -1000), 0);
+        // Above the maximum: clamp to last entry.
+        assert_eq!(closest_gain_in(R820T2_GAINS, 10_000), 496);
+    }
+
+    #[test]
+    fn ties_resolve_deterministically() {
+        // Symmetric gap: 50 is exactly between 0 and 100. With
+        // `min_by_key` over a stable iterator, the first
+        // equally-distant entry wins → 0.
+        let table = &[0, 100];
+        assert_eq!(closest_gain_in(table, 50), 0);
     }
 }


### PR DESCRIPTION
## Summary

Round 2 of the spin-out prep per #626 — round 1 (#630) locked down the public surface; this round adds the ergonomic API shapes that came out of the survey. All additive, no behavioural changes to existing methods.

## What's new

- **\`DeviceInfo\` struct + \`list_devices()\`**: collected enumeration in one call. Re-exported at crate root and as a \`RtlSdrDevice::list()\` shortcut.
- **\`RtlSdrDeviceBuilder\`** via \`RtlSdrDevice::builder()\`: open by index OR by USB serial. Last selector wins. Builder is \`Clone\` for retry / fallback paths. 3 unit tests pin selector semantics.
- **\`RtlSdrDevice::closest_gain(desired_tenths_db) -> i32\`**: returns the closest entry in the tuner's discrete gain table to the requested value. Implementation delegates to a free helper for testability — 5 unit tests covering exact match, rounding, out-of-range clamping, ties, and empty-table fallback (using the real R820T2 gain table as fixture, no live device needed).
- **\`Send\` + \`Sync\` documentation pass**: added a \`# Send + Sync\` section to \`RtlSdrDevice\` explicitly documenting \`Send\` ✓ / \`Sync\` ✗. Pinned with a compile-time assertion at module bottom so a future non-\`Send\` field addition fires at compile time.

## Out of scope (round 3)

- Async-friendly streaming wrapper — separate PR (design discussion: \`futures::Stream\` vs blocking \`Iterator\` vs both behind features).
- PPM correction round-trip integration test — needs a live device or a mock-rusb harness; deferred.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` clean
- [x] \`cargo test -p sdr-rtlsdr --lib\` 101 passed (was 93; +8 new)
- [x] \`cargo check --workspace --locked\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps -p sdr-rtlsdr\` clean
- [x] \`cargo test --doc -p sdr-rtlsdr\` (3 doctests) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device enumeration: discover and list connected RTL‑SDR dongles with descriptive info (index, name, vendor, product, serial).
  * Builder-style device opening: select and open a device by index or serial, with sensible defaults.
  * Convenience helpers: quick access to device list and a simple entry point to start the builder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->