### PR TITLE
feat(sdr-rtlsdr): #626 round 3a — Iterator + tokio Stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,8 +3276,10 @@ dependencies = [
 name = "sdr-rtlsdr"
 version = "0.1.0"
 dependencies = [
+ "futures-core",
  "rusb",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/sdr-rtlsdr/Cargo.toml
+++ b/crates/sdr-rtlsdr/Cargo.toml
@@ -11,5 +11,21 @@ rusb.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
+# Async-runtime integrations are opt-in. Each runtime gets its
+# own feature flag so consumers pull in only what they use; the
+# Iterator-based sync streaming path needs no features at all.
+# Round 3a (this crate) adds `tokio`; round 3b will add `async-std`
+# and `smol` with the same shape. Per #626.
+futures-core = { version = "0.3", optional = true }
+tokio = { version = "1", default-features = false, features = ["sync", "rt"], optional = true }
+
+[features]
+default = []
+# Enables `RtlSdrDevice::stream_samples_tokio` — a `Stream` impl
+# backed by `tokio::task::spawn_blocking` and `tokio::sync::mpsc`.
+# Pulls in `tokio` (sync + rt features only; no multi-thread
+# runtime dep) and `futures-core` for the `Stream` trait.
+tokio = ["dep:tokio", "dep:futures-core"]
+
 [lints]
 workspace = true

--- a/crates/sdr-rtlsdr/src/device/mod.rs
+++ b/crates/sdr-rtlsdr/src/device/mod.rs
@@ -20,9 +20,15 @@ pub use enumerate::{
     DeviceInfo, get_device_count, get_device_name, get_device_usb_strings, get_index_by_serial,
     list_devices,
 };
+pub use streaming::SampleIter;
 
 mod builder;
 pub use builder::RtlSdrDeviceBuilder;
+
+#[cfg(feature = "tokio")]
+mod streaming_tokio;
+#[cfg(feature = "tokio")]
+pub use streaming_tokio::SampleStream;
 
 use crate::constants::*;
 use crate::error::RtlSdrError;

--- a/crates/sdr-rtlsdr/src/device/streaming.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming.rs
@@ -104,6 +104,12 @@ impl RtlSdrDevice {
     /// 512-byte packet — `read_sync` returns the actual byte count
     /// — but multiples of 512 avoid short final transfers.
     ///
+    /// Passing `0` selects the librtlsdr-equivalent default
+    /// (256 KB) rather than requesting a zero-length buffer —
+    /// matches the upstream "pass 0 for the default" ergonomic
+    /// and prevents a typo from silently fusing the iterator on
+    /// the first call (which would look like EOF).
+    ///
     /// # Allocation
     ///
     /// Each yielded `Vec<u8>` is a fresh allocation. At the

--- a/crates/sdr-rtlsdr/src/device/streaming.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming.rs
@@ -79,6 +79,60 @@ impl RtlSdrDevice {
         }
     }
 
+    /// Iterate IQ samples as a sequence of owned byte buffers.
+    ///
+    /// Returns an `Iterator` whose [`Iterator::next`] blocks the
+    /// calling thread until one buffer's worth of samples is ready
+    /// (a single `read_sync` underneath), then yields a freshly-
+    /// allocated `Vec<u8>` of the actual byte count read. Each
+    /// item is `Result<Vec<u8>, RtlSdrError>` so transport errors
+    /// surface in-band; the iterator fuses (returns `None` from
+    /// then on) after the first error or a zero-length read.
+    ///
+    /// This is the foundation for both sync streaming (use
+    /// directly) and async streaming wrappers (the per-runtime
+    /// `stream_samples_*` methods drive this iterator inside a
+    /// blocking task).
+    ///
+    /// # Buffer size
+    ///
+    /// `buffer_size` is the bytes-per-yield target. The librtlsdr
+    /// default is 256 KB (16 × 32 × 512). Smaller buffers give
+    /// lower per-item latency but more allocator traffic; larger
+    /// buffers amortise USB overhead but increase per-buffer
+    /// latency. The size doesn't have to be a multiple of the USB
+    /// 512-byte packet — `read_sync` returns the actual byte count
+    /// — but multiples of 512 avoid short final transfers.
+    ///
+    /// # Allocation
+    ///
+    /// Each yielded `Vec<u8>` is a fresh allocation. At the
+    /// 256 KB / 65 ms cadence of typical RTL-SDR rates this is
+    /// negligible (~15 allocs/sec), but for tight loops or
+    /// embedded use prefer [`Self::read_sync`] directly with a
+    /// reused caller-owned buffer.
+    ///
+    /// ```no_run
+    /// # use sdr_rtlsdr::{RtlSdrDevice, RtlSdrError};
+    /// # fn main() -> Result<(), RtlSdrError> {
+    /// let dev = RtlSdrDevice::open(0)?;
+    /// dev.reset_buffer()?;
+    /// // Take the first 10 buffers — each ~65 ms at 2 Msps.
+    /// for chunk in dev.iter_samples(262_144).take(10) {
+    ///     let bytes = chunk?;
+    ///     // process `bytes`...
+    ///     # let _ = bytes;
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn iter_samples(&self, buffer_size: usize) -> SampleIter<'_> {
+        SampleIter {
+            device: Some(self),
+            buffer_size,
+        }
+    }
+
     /// Read IQ samples in a blocking loop, calling the callback for each buffer.
     ///
     /// This is a simplified port of `rtlsdr_read_async`. It blocks the calling
@@ -129,4 +183,71 @@ impl RtlSdrDevice {
 
         Ok(())
     }
+}
+
+/// Blocking iterator over IQ-sample buffers, returned by
+/// [`RtlSdrDevice::iter_samples`].
+///
+/// Each [`Iterator::next`] call performs one [`RtlSdrDevice::read_sync`]
+/// into a freshly-allocated `Vec<u8>` and yields it. The iterator
+/// fuses on the first error or zero-length read — once `next`
+/// returns `Some(Err(_))` (or `None` from a zero read), all
+/// subsequent calls return `None` so callers can use the standard
+/// `for chunk in iter { let chunk = chunk?; ... }` shape without
+/// worrying about post-error state.
+pub struct SampleIter<'a> {
+    /// `None` once the iterator has fused (error or zero read).
+    /// Borrows the device shared (`&`) because [`RtlSdrDevice::read_sync`]
+    /// is `&self` — the underlying USB bulk transfer doesn't need
+    /// mutable access.
+    device: Option<&'a RtlSdrDevice>,
+    buffer_size: usize,
+}
+
+impl Iterator for SampleIter<'_> {
+    type Item = Result<Vec<u8>, RtlSdrError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let device = self.device?;
+        let mut buf = vec![0u8; self.buffer_size];
+        match device.read_sync(&mut buf) {
+            Ok(0) => {
+                // Zero-length read — treat as end-of-stream so
+                // callers using `.take(N)` / `for ... in iter`
+                // don't spin forever on a degenerate device.
+                self.device = None;
+                None
+            }
+            Ok(n) => {
+                buf.truncate(n);
+                Some(Ok(buf))
+            }
+            Err(e) => {
+                // Fuse after first error so subsequent calls
+                // return `None` rather than re-yielding the
+                // same error indefinitely.
+                self.device = None;
+                Some(Err(e))
+            }
+        }
+    }
+}
+
+impl std::iter::FusedIterator for SampleIter<'_> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pin the trait-impl contract documented on `SampleIter` —
+    // standard `Iterator` + `FusedIterator` so consumers can rely
+    // on `for x in iter` shape AND on the post-fuse-returns-None
+    // contract without empirical testing. If a refactor ever
+    // changes the iterator shape, this fires at compile time.
+    const _: fn() = || {
+        fn assert_iter<T: Iterator>() {}
+        fn assert_fused<T: std::iter::FusedIterator>() {}
+        assert_iter::<SampleIter<'_>>();
+        assert_fused::<SampleIter<'_>>();
+    };
 }

--- a/crates/sdr-rtlsdr/src/device/streaming.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming.rs
@@ -127,6 +127,19 @@ impl RtlSdrDevice {
     /// # }
     /// ```
     pub fn iter_samples(&self, buffer_size: usize) -> SampleIter<'_> {
+        // Normalise zero to the librtlsdr-equivalent default
+        // (256 KB). A `buffer_size == 0` typo would otherwise
+        // hand `read_sync` an empty slice, which the USB
+        // backend treats as an immediate zero-length read —
+        // the iterator's zero-fuse path triggers, and the
+        // caller sees an empty `for chunk in iter { … }` that
+        // looks like EOF rather than a configuration mistake.
+        // Per #632 CR round 1.
+        let buffer_size = if buffer_size == 0 {
+            DEFAULT_BUF_LENGTH as usize
+        } else {
+            buffer_size
+        };
         SampleIter {
             device: Some(self),
             buffer_size,

--- a/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
@@ -35,10 +35,10 @@ use crate::error::RtlSdrError;
 use super::RtlSdrDevice;
 
 /// Number of buffers the tokio mpsc channel holds before the
-/// reader thread blocks. Picked to give the consumer ~1 second
-/// of slack at typical RTL-SDR rates (4 × 256 KB ≈ 1 MB ≈ 0.4 s
-/// at 2 Msps × 2 bytes/sample, so 4 buffers ≈ 260 ms — enough
-/// to absorb a slow tick on the consumer without dropping a
+/// reader thread blocks. Picked to give the consumer ~250 ms
+/// of slack at typical RTL-SDR rates (4 × 256 KB ≈ 1 MB ≈
+/// 0.25 s at 2 Msps × 2 bytes/sample = 4 MB/s — enough to
+/// absorb a slow tick on the consumer without dropping a
 /// transfer, not so much that latency-sensitive consumers
 /// observe a long queue).
 const STREAM_BACKPRESSURE_DEPTH: usize = 4;

--- a/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
@@ -77,7 +77,11 @@ impl RtlSdrDevice {
     ///
     /// let dev = RtlSdrDevice::open(0)?;
     /// dev.reset_buffer()?;
-    /// let stream = dev.stream_samples_tokio(262_144)?;
+    /// // `stream_samples_tokio` returns the device back on
+    /// // preflight failure (e.g. no tokio runtime active);
+    /// // `.map_err(|boxed| boxed.0)` discards the device and
+    /// // surfaces the underlying `RtlSdrError` so `?` works.
+    /// let stream = dev.stream_samples_tokio(262_144).map_err(|boxed| boxed.0)?;
     /// let mut stream: Pin<Box<dyn Stream<Item = _>>> = Box::pin(stream);
     /// // futures_util::StreamExt::next() — left to the consumer's choice of helper crate.
     /// # Ok(())
@@ -115,18 +119,57 @@ impl RtlSdrDevice {
     ///
     /// # Errors
     ///
-    /// - [`RtlSdrError::InvalidParameter`] if no tokio runtime
-    ///   is active when this method is called.
-    pub fn stream_samples_tokio(self, buffer_size: usize) -> Result<SampleStream, RtlSdrError> {
-        // Preflight runtime check. `tokio::task::spawn_blocking`
+    /// On preflight failure (no tokio runtime active) the
+    /// returned `Err` carries both the diagnostic
+    /// [`RtlSdrError`] and the unconsumed [`RtlSdrDevice`]
+    /// back to the caller — the configured frequency, gain,
+    /// tuner state, etc. survive so the caller can enter a
+    /// runtime and retry without re-opening:
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "tokio")]
+    /// # async fn example() -> Result<(), sdr_rtlsdr::RtlSdrError> {
+    /// # use sdr_rtlsdr::RtlSdrDevice;
+    /// let dev = RtlSdrDevice::open(0)?;
+    /// // dev.set_center_freq(...) etc. ...
+    /// let stream = match dev.stream_samples_tokio(0) {
+    ///     Ok(stream) => stream,
+    ///     Err(boxed) => {
+    ///         let (err, _device) = *boxed;
+    ///         return Err(err);
+    ///     }
+    /// };
+    /// # let _ = stream;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Pattern matches the std-library "error preserves the
+    /// resource" idiom (see `Vec::push_within_capacity`,
+    /// `mpsc::Sender::send`'s `SendError<T>`). The `Err` is
+    /// boxed because [`RtlSdrDevice`] is a sizeable struct and
+    /// returning it inline would inflate every `Result` on the
+    /// happy path (clippy's `result_large_err` lint).
+    pub fn stream_samples_tokio(
+        self,
+        buffer_size: usize,
+    ) -> Result<SampleStream, Box<(RtlSdrError, Self)>> {
+        // Preflight runtime check BEFORE consuming `self`'s
+        // resources into the worker. `tokio::task::spawn_blocking`
         // doesn't document its outside-runtime behaviour but
-        // panics in practice; library code shouldn't panic, so
-        // detect explicitly via `try_current` and return an
-        // `RtlSdrError`. Per #632 CR round 1.
+        // panics in practice; library code shouldn't panic.
+        // Returning the device on the error path means a caller
+        // who forgot to enter a runtime can retry without losing
+        // their configured frequency / gain / tuner state. Per
+        // #632 CR round 2 (round 1 added the check; round 2 fixed
+        // the device-loss-on-error bug).
         if tokio::runtime::Handle::try_current().is_err() {
-            return Err(RtlSdrError::InvalidParameter(
-                "stream_samples_tokio must be called from within a Tokio runtime".to_string(),
-            ));
+            return Err(Box::new((
+                RtlSdrError::InvalidParameter(
+                    "stream_samples_tokio must be called from within a Tokio runtime".to_string(),
+                ),
+                self,
+            )));
         }
 
         let (tx, rx) = tokio::sync::mpsc::channel(STREAM_BACKPRESSURE_DEPTH);

--- a/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
@@ -77,7 +77,7 @@ impl RtlSdrDevice {
     ///
     /// let dev = RtlSdrDevice::open(0)?;
     /// dev.reset_buffer()?;
-    /// let stream = dev.stream_samples_tokio(262_144);
+    /// let stream = dev.stream_samples_tokio(262_144)?;
     /// let mut stream: Pin<Box<dyn Stream<Item = _>>> = Box::pin(stream);
     /// // futures_util::StreamExt::next() — left to the consumer's choice of helper crate.
     /// # Ok(())
@@ -93,39 +93,87 @@ impl RtlSdrDevice {
     ///
     /// Must be called from inside a tokio runtime context (the
     /// implementation calls [`tokio::task::spawn_blocking`]
-    /// internally). Calling outside a runtime panics with the
-    /// usual tokio "no reactor running" message — caller
-    /// responsibility to ensure the calling task is on a tokio
-    /// runtime before invoking.
-    #[must_use]
-    pub fn stream_samples_tokio(self, buffer_size: usize) -> SampleStream {
+    /// internally). Returns
+    /// [`RtlSdrError::InvalidParameter`] when called outside a
+    /// runtime — checked via
+    /// [`tokio::runtime::Handle::try_current`] before any task
+    /// spawn so the failure mode is a clean error instead of
+    /// the runtime's own panic.
+    ///
+    /// # Drop semantics
+    ///
+    /// When the consumer drops the [`SampleStream`], the worker
+    /// observes the closed channel **between** USB reads and
+    /// exits cleanly — typical drop latency is one read cadence
+    /// (~65 ms at 2 Msps with the default 256 KB buffer). On a
+    /// stalled device the worst case is one read timeout (5 s
+    /// per [`RtlSdrDevice::read_sync`]). For sub-millisecond
+    /// cancellation of an in-flight bulk transfer we'd need
+    /// libusb's async-submit + cancel API rather than the
+    /// blocking read; that's tracked as #633 rather than done
+    /// here. Per #632 CR round 1.
+    ///
+    /// # Errors
+    ///
+    /// - [`RtlSdrError::InvalidParameter`] if no tokio runtime
+    ///   is active when this method is called.
+    pub fn stream_samples_tokio(self, buffer_size: usize) -> Result<SampleStream, RtlSdrError> {
+        // Preflight runtime check. `tokio::task::spawn_blocking`
+        // doesn't document its outside-runtime behaviour but
+        // panics in practice; library code shouldn't panic, so
+        // detect explicitly via `try_current` and return an
+        // `RtlSdrError`. Per #632 CR round 1.
+        if tokio::runtime::Handle::try_current().is_err() {
+            return Err(RtlSdrError::InvalidParameter(
+                "stream_samples_tokio must be called from within a Tokio runtime".to_string(),
+            ));
+        }
+
         let (tx, rx) = tokio::sync::mpsc::channel(STREAM_BACKPRESSURE_DEPTH);
 
         // The blocking task owns the device for the duration
         // of the stream — no `Arc<Mutex<…>>`, no shared
         // mutable access. When the consumer drops the
-        // `SampleStream`, `tx.blocking_send` returns `Err`
-        // and we exit; tokio's runtime drops the task's stack
-        // including the device, which runs `Drop` and
-        // releases the USB interface cleanly.
+        // `SampleStream` the channel closes; we observe that
+        // via `tx.is_closed()` between reads (so a healthy
+        // streaming device exits within one buffer cadence)
+        // and via `tx.blocking_send` returning `Err` after the
+        // read (so a still-completing read isn't wasted). On
+        // exit, tokio's runtime drops the task's stack
+        // including the device, which runs `Drop` and releases
+        // the USB interface cleanly.
         tokio::task::spawn_blocking(move || {
             let dev = self;
-            for chunk in dev.iter_samples(buffer_size) {
-                let is_err = chunk.is_err();
-                if tx.blocking_send(chunk).is_err() {
-                    // Consumer dropped — exit silently.
+            let mut iter = dev.iter_samples(buffer_size);
+            loop {
+                // Pre-read drop check: catches the common case
+                // of a consumer dropping the stream during the
+                // brief window between reads. For an in-flight
+                // read we still wait for it to return (see
+                // method-level "Drop semantics" docs).
+                if tx.is_closed() {
                     return;
                 }
-                if is_err {
-                    // Iterator fuses on error; yielding once
-                    // here matches the documented "yields the
-                    // error, then `None`" contract.
-                    return;
+                match iter.next() {
+                    Some(chunk) => {
+                        let is_err = chunk.is_err();
+                        if tx.blocking_send(chunk).is_err() {
+                            return;
+                        }
+                        if is_err {
+                            // Iterator fuses on error; yielding
+                            // once matches the documented
+                            // "yields the error, then `None`"
+                            // contract.
+                            return;
+                        }
+                    }
+                    None => return,
                 }
             }
         });
 
-        SampleStream { rx }
+        Ok(SampleStream { rx })
     }
 }
 

--- a/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
@@ -1,0 +1,168 @@
+//! Tokio `Stream` adapter for IQ-sample reads.
+//!
+//! Gated on `feature = "tokio"`. Bridges the synchronous USB
+//! bulk-read path into an async `Stream` consumable from any
+//! tokio runtime context, without blocking the executor.
+//!
+//! # Implementation
+//!
+//! `tokio::task::spawn_blocking` runs the underlying
+//! [`super::SampleIter`] loop on tokio's blocking-task thread
+//! pool, pushing each yielded buffer through a
+//! `tokio::sync::mpsc` channel. The returned [`SampleStream`]
+//! drains the receiver as a `Stream`.
+//!
+//! Bounded channel (depth = [`STREAM_BACKPRESSURE_DEPTH`])
+//! provides back-pressure: if the consumer falls behind the
+//! reader thread blocks on `blocking_send` rather than dropping
+//! samples. For SDR, sample drops are usually fatal (gaps in
+//! the stream) — the back-pressure default is correct. Tune
+//! the consumer (or scale up to a faster runtime) rather than
+//! widening the channel.
+//!
+//! When the consumer drops the `Stream`, the channel closes and
+//! the worker exits on the next `blocking_send` failure. On
+//! transport error the worker pushes the error and exits; the
+//! `Stream` yields the error, then `None`.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+
+use crate::error::RtlSdrError;
+
+use super::RtlSdrDevice;
+
+/// Number of buffers the tokio mpsc channel holds before the
+/// reader thread blocks. Picked to give the consumer ~1 second
+/// of slack at typical RTL-SDR rates (4 × 256 KB ≈ 1 MB ≈ 0.4 s
+/// at 2 Msps × 2 bytes/sample, so 4 buffers ≈ 260 ms — enough
+/// to absorb a slow tick on the consumer without dropping a
+/// transfer, not so much that latency-sensitive consumers
+/// observe a long queue).
+const STREAM_BACKPRESSURE_DEPTH: usize = 4;
+
+impl RtlSdrDevice {
+    /// Stream IQ samples as a tokio-friendly async `Stream`.
+    ///
+    /// Consumes the device. The returned [`SampleStream`] owns
+    /// the [`RtlSdrDevice`] inside a blocking task — there's no
+    /// way to drive both the stream and other control methods
+    /// concurrently against the same handle without giving up
+    /// the `Send`-but-not-`Sync` guarantees we documented on
+    /// the device. Configure the device (frequency, bandwidth,
+    /// gain, etc.) before calling this.
+    ///
+    /// # Errors / termination
+    ///
+    /// Each yielded item is `Result<Vec<u8>, RtlSdrError>`. The
+    /// stream ends (`Poll::Ready(None)`) when:
+    /// - The reader observed a transport error and yielded it
+    ///   on the previous `poll_next` call. Standard
+    ///   error-then-fuse contract.
+    /// - The underlying `read_sync` returned zero bytes (rare,
+    ///   degenerate-device case).
+    /// - The consumer drops the stream — the worker observes
+    ///   the closed channel and exits cleanly.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "tokio")]
+    /// # async fn example() -> Result<(), sdr_rtlsdr::RtlSdrError> {
+    /// use futures_core::Stream;
+    /// use std::pin::Pin;
+    /// use sdr_rtlsdr::RtlSdrDevice;
+    ///
+    /// let dev = RtlSdrDevice::open(0)?;
+    /// dev.reset_buffer()?;
+    /// let stream = dev.stream_samples_tokio(262_144);
+    /// let mut stream: Pin<Box<dyn Stream<Item = _>>> = Box::pin(stream);
+    /// // futures_util::StreamExt::next() — left to the consumer's choice of helper crate.
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// `buffer_size` follows the same guidance as
+    /// [`Self::iter_samples`] — 256 KB / 64 KB are typical good
+    /// values; smaller for lower latency, larger to amortise
+    /// USB overhead.
+    ///
+    /// # Runtime requirement
+    ///
+    /// Must be called from inside a tokio runtime context (the
+    /// implementation calls [`tokio::task::spawn_blocking`]
+    /// internally). Calling outside a runtime panics with the
+    /// usual tokio "no reactor running" message — caller
+    /// responsibility to ensure the calling task is on a tokio
+    /// runtime before invoking.
+    #[must_use]
+    pub fn stream_samples_tokio(self, buffer_size: usize) -> SampleStream {
+        let (tx, rx) = tokio::sync::mpsc::channel(STREAM_BACKPRESSURE_DEPTH);
+
+        // The blocking task owns the device for the duration
+        // of the stream — no `Arc<Mutex<…>>`, no shared
+        // mutable access. When the consumer drops the
+        // `SampleStream`, `tx.blocking_send` returns `Err`
+        // and we exit; tokio's runtime drops the task's stack
+        // including the device, which runs `Drop` and
+        // releases the USB interface cleanly.
+        tokio::task::spawn_blocking(move || {
+            let dev = self;
+            for chunk in dev.iter_samples(buffer_size) {
+                let is_err = chunk.is_err();
+                if tx.blocking_send(chunk).is_err() {
+                    // Consumer dropped — exit silently.
+                    return;
+                }
+                if is_err {
+                    // Iterator fuses on error; yielding once
+                    // here matches the documented "yields the
+                    // error, then `None`" contract.
+                    return;
+                }
+            }
+        });
+
+        SampleStream { rx }
+    }
+}
+
+/// Async `Stream` wrapping the tokio mpsc receiver fed by
+/// [`RtlSdrDevice::stream_samples_tokio`]'s blocking worker.
+///
+/// Owns the receiver end of the channel; the worker task on
+/// the other end terminates when this stream is dropped (next
+/// blocking-send fails). No additional cleanup is required
+/// from the consumer.
+pub struct SampleStream {
+    rx: tokio::sync::mpsc::Receiver<Result<Vec<u8>, RtlSdrError>>,
+}
+
+impl Stream for SampleStream {
+    type Item = Result<Vec<u8>, RtlSdrError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx.poll_recv(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pin the trait-impl + marker contract documented on
+    // `SampleStream`: it implements `Stream` (so consumers can
+    // use `StreamExt`) and is `Send` (so it can cross `await`
+    // boundaries on multi-threaded executors). If a future
+    // refactor changes the receiver type or adds non-`Send`
+    // state, the assertion fires at compile time before
+    // breaking downstream consumers.
+    const _: fn() = || {
+        fn assert_stream<T: Stream>() {}
+        fn assert_send<T: Send>() {}
+        assert_stream::<SampleStream>();
+        assert_send::<SampleStream>();
+    };
+}


### PR DESCRIPTION
## Summary

Round 3a of the spin-out per #626: streaming wrappers for the existing synchronous \`read_sync\` USB bulk-read path. Round 3b will add \`async-std\` + \`smol\` impls with the same shape.

## What's new

- **\`RtlSdrDevice::iter_samples(buffer_size) -> SampleIter\`** (always available, no features). Foundation \`Iterator\` over IQ-sample buffers. Implements \`FusedIterator\` — fuses on first error or zero-length read. Re-exported at the device module root for discoverability.
- **\`RtlSdrDevice::stream_samples_tokio(buffer_size) -> SampleStream\`** (gated on \`feature = "tokio"\`). Bridges the blocking USB read into a \`futures_core::Stream\` via \`tokio::task::spawn_blocking\` + bounded \`tokio::sync::mpsc\`. Back-pressure default (channel depth 4); on consumer drop the worker exits cleanly.

Method-per-runtime naming so round 3b can add \`stream_samples_async_std\` / \`stream_samples_smol\` without collisions; consumers may enable multiple simultaneously.

## Cargo manifest

Two optional deps added directly to \`crates/sdr-rtlsdr\` (not workspace.dependencies — only land here on this crate's spin-out path):

\`\`\`toml
futures-core = { version = "0.3", optional = true }
tokio = { version = "1", default-features = false, features = ["sync", "rt"], optional = true }

[features]
default = []
tokio = ["dep:tokio", "dep:futures-core"]
\`\`\`

## Test plan

Both default and \`--features tokio\` configurations validated:

- [x] \`cargo build --workspace\` clean (default features)
- [x] \`cargo build -p sdr-rtlsdr --features tokio\` clean
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` clean (default)
- [x] \`cargo clippy -p sdr-rtlsdr --all-targets --features tokio -- -D warnings\` clean
- [x] \`cargo test --workspace --lib\` 418 passed (default)
- [x] \`cargo test -p sdr-rtlsdr --features tokio --lib\` 102 passed
- [x] \`cargo check --workspace --locked\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps -p sdr-rtlsdr [--features tokio]\` clean both configs
- [x] \`cargo test --doc -p sdr-rtlsdr [--features tokio]\` passed both configs

Real-streaming tests live in the smoke harness (the user's NOAA-pass workflow once the app is wired to the new API). Compile-time trait + marker assertions catch refactor regressions on \`SampleIter\` (\`Iterator\` + \`FusedIterator\`) and \`SampleStream\` (\`Stream\` + \`Send\`).

## Out of scope (round 3b)

- \`stream_samples_async_std\` (gated on \`feature = "async-std"\`)
- \`stream_samples_smol\` (gated on \`feature = "smol"\`)

## Out of scope (after both rounds land)

- Wire the app's \`sdr-source-rtlsdr\` to use \`stream_samples_tokio\` (or keep \`read_sync\` and let consumers pick) — separate PR, depends on this crate's tokio runtime story.
- PPM correction round-trip integration test — needs a hardware-in-loop suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blocking iterator for streaming IQ samples — iterate sample buffers with standard for-loops.
  * Tokio-based async sample stream for non-blocking consumption with back-pressure.
  * Optional tokio/futures feature to enable the async runtime path.

* **Tests**
  * Compile-time checks ensuring the async stream implements Stream and is Send.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->