### PR TITLE
feat(sdr-rtlsdr): #626 round 3b — async-std + smol Streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,10 +125,21 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
 ]
 
 [[package]]
@@ -169,6 +180,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,7 +218,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -214,14 +240,14 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-lite",
  "rustix",
 ]
@@ -253,6 +279,32 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -362,7 +414,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -870,6 +922,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -885,7 +943,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener",
+ "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -1256,6 +1314,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "glow"
@@ -1909,6 +1979,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,6 +2145,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2469,6 +2551,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -3276,6 +3364,9 @@ dependencies = [
 name = "sdr-rtlsdr"
 version = "0.1.0"
 dependencies = [
+ "async-channel 2.5.0",
+ "async-std",
+ "blocking",
  "futures-core",
  "rusb",
  "thiserror 2.0.18",
@@ -3701,7 +3792,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
 dependencies = [
- "async-channel",
+ "async-channel 2.5.0",
  "async-executor",
  "async-fs",
  "async-io",
@@ -4264,6 +4355,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -5126,7 +5223,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener",
+ "event-listener 5.4.1",
  "futures-core",
  "futures-lite",
  "hex",

--- a/crates/sdr-rtlsdr/Cargo.toml
+++ b/crates/sdr-rtlsdr/Cargo.toml
@@ -18,6 +18,16 @@ tracing.workspace = true
 # and `smol` with the same shape. Per #626.
 futures-core = { version = "0.3", optional = true }
 tokio = { version = "1", default-features = false, features = ["sync", "rt"], optional = true }
+# `async-channel` provides a runtime-agnostic mpsc whose `Receiver`
+# already implements `Stream`. Both async-std and smol streaming
+# paths use it; tokio sticks with `tokio::sync::mpsc` for tokio-
+# native ergonomics + zero new deps for tokio-only consumers.
+async-channel = { version = "2", optional = true }
+async-std = { version = "1", optional = true }
+# `blocking` is the foundation crate smol uses for `unblock` —
+# pulling it directly avoids dragging the whole `smol` crate in
+# for one function. Same crate `smol::unblock` re-exports.
+blocking = { version = "1", optional = true }
 
 [features]
 default = []
@@ -26,6 +36,24 @@ default = []
 # Pulls in `tokio` (sync + rt features only; no multi-thread
 # runtime dep) and `futures-core` for the `Stream` trait.
 tokio = ["dep:tokio", "dep:futures-core"]
+# Enables `RtlSdrDevice::stream_samples_async_std` — same shape
+# as the tokio variant but using `async_std::task::spawn_blocking`
+# and `async-channel` for the mpsc bridge.
+async-std = ["dep:async-std", "dep:async-channel", "dep:futures-core"]
+# Enables `RtlSdrDevice::stream_samples_smol` — same shape but
+# using `blocking::unblock` (smol's foundation for offloading
+# blocking work) and `async-channel`.
+smol = ["dep:blocking", "dep:async-channel", "dep:futures-core"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+# Build docs.rs's rendering with all runtime features enabled so
+# the per-runtime streaming methods all show up in the published
+# docs. Per-feature local builds (`cargo doc --features tokio`,
+# etc.) still work — cross-runtime references in module docs use
+# plain code spans (`super::streaming_tokio`) rather than
+# intra-doc links so they don't break when only one feature is
+# active.
+all-features = true

--- a/crates/sdr-rtlsdr/src/device/mod.rs
+++ b/crates/sdr-rtlsdr/src/device/mod.rs
@@ -28,7 +28,17 @@ pub use builder::RtlSdrDeviceBuilder;
 #[cfg(feature = "tokio")]
 mod streaming_tokio;
 #[cfg(feature = "tokio")]
-pub use streaming_tokio::SampleStream;
+pub use streaming_tokio::TokioSampleStream;
+
+#[cfg(feature = "async-std")]
+mod streaming_async_std;
+#[cfg(feature = "async-std")]
+pub use streaming_async_std::AsyncStdSampleStream;
+
+#[cfg(feature = "smol")]
+mod streaming_smol;
+#[cfg(feature = "smol")]
+pub use streaming_smol::SmolSampleStream;
 
 use crate::constants::*;
 use crate::error::RtlSdrError;

--- a/crates/sdr-rtlsdr/src/device/streaming_async_std.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming_async_std.rs
@@ -1,0 +1,160 @@
+//! async-std `Stream` adapter for IQ-sample reads.
+//!
+//! Gated on `feature = "async-std"`. Bridges the synchronous USB
+//! bulk-read path into a `Stream` consumable from an async-std
+//! executor without blocking it.
+//!
+//! # Implementation
+//!
+//! Mirrors the tokio variant (`super::streaming_tokio`) with
+//! two differences:
+//!
+//! - **Blocking offload** uses [`async_std::task::spawn_blocking`]
+//!   instead of `tokio::task::spawn_blocking`.
+//! - **mpsc bridge** uses the runtime-agnostic [`async_channel`]
+//!   crate, whose `Receiver` already implements `Stream` natively
+//!   — no manual `poll_next` impl needed; we wrap the receiver in
+//!   a newtype to keep the public type name runtime-tagged.
+//!
+//! Same back-pressure-by-default channel depth
+//! ([`STREAM_BACKPRESSURE_DEPTH`]) as the tokio variant — sample
+//! drops are usually fatal for SDR (gaps in the stream).
+//!
+//! # Drop semantics
+//!
+//! Same trade-off as the tokio path: between-reads drops exit
+//! within one buffer cadence (~65 ms typical at 2 Msps); a drop
+//! while a USB read is in flight waits up to one read timeout
+//! (~5 s on a stalled device). True in-flight cancellation needs
+//! libusb's async-submit + cancel API and is tracked as #633.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+
+use crate::error::RtlSdrError;
+
+use super::RtlSdrDevice;
+
+/// Channel depth — see `super::streaming_tokio` for the
+/// derivation (4 × 256 KB ≈ 1 MB ≈ 250 ms at 2 Msps × 2 bytes/
+/// sample = 4 MB/s). Matched here so async-std consumers see
+/// the same back-pressure shape as tokio consumers.
+const STREAM_BACKPRESSURE_DEPTH: usize = 4;
+
+/// Type alias for the boxed-pinned async-channel receiver used
+/// inside [`AsyncStdSampleStream`]. Pulled out to keep the
+/// struct definition readable (and to satisfy clippy's
+/// `type_complexity` lint).
+type BoxedReceiver = Pin<Box<async_channel::Receiver<Result<Vec<u8>, RtlSdrError>>>>;
+
+impl RtlSdrDevice {
+    /// Stream IQ samples as an async-std-friendly `Stream`.
+    ///
+    /// Same shape as `Self::stream_samples_tokio` (only present
+    /// when the `tokio` feature is enabled) — consumes the
+    /// device, returns the device on the error path so the
+    /// caller can recover its configured state. This method
+    /// differs only in which runtime drives the blocking
+    /// offload.
+    ///
+    /// # Errors
+    ///
+    /// Currently never fails at the preflight stage —
+    /// `async_std::task::spawn_blocking` works without an
+    /// active executor (queues the closure for the next
+    /// poll). The error type is kept as
+    /// `Box<(RtlSdrError, Self)>` for shape parity with the
+    /// other runtime variants in case a future error path
+    /// (e.g. allocator failure on the channel construction)
+    /// surfaces.
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "async-std")]
+    /// # async fn example() -> Result<(), sdr_rtlsdr::RtlSdrError> {
+    /// use futures_core::Stream;
+    /// use std::pin::Pin;
+    /// use sdr_rtlsdr::RtlSdrDevice;
+    ///
+    /// let dev = RtlSdrDevice::open(0)?;
+    /// dev.reset_buffer()?;
+    /// let stream = dev.stream_samples_async_std(262_144).map_err(|boxed| boxed.0)?;
+    /// let mut stream: Pin<Box<dyn Stream<Item = _>>> = Box::pin(stream);
+    /// // futures_util::StreamExt::next() — left to the consumer's choice of helper crate.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn stream_samples_async_std(
+        self,
+        buffer_size: usize,
+    ) -> Result<AsyncStdSampleStream, Box<(RtlSdrError, Self)>> {
+        let (tx, rx) = async_channel::bounded(STREAM_BACKPRESSURE_DEPTH);
+
+        // Spawn the blocking iterator-driver onto async-std's
+        // blocking thread pool. Unlike tokio, async-std's
+        // `spawn_blocking` doesn't require an active runtime
+        // context — it manages its own pool — so no preflight
+        // check needed here.
+        async_std::task::spawn_blocking(move || {
+            let dev = self;
+            let mut iter = dev.iter_samples(buffer_size);
+            loop {
+                if tx.is_closed() {
+                    return;
+                }
+                match iter.next() {
+                    Some(chunk) => {
+                        let is_err = chunk.is_err();
+                        if tx.send_blocking(chunk).is_err() {
+                            return;
+                        }
+                        if is_err {
+                            return;
+                        }
+                    }
+                    None => return,
+                }
+            }
+        });
+
+        Ok(AsyncStdSampleStream { rx: Box::pin(rx) })
+    }
+}
+
+/// async-std's `Stream` over IQ-sample buffers, returned by
+/// [`RtlSdrDevice::stream_samples_async_std`].
+///
+/// Wraps a pinned, boxed [`async_channel::Receiver`] whose
+/// `Stream` impl drives `poll_next`. The receiver is `!Unpin`
+/// (carries a `PhantomPinned` to keep its internal event-listener
+/// in place), so storing it as `Pin<Box<…>>` lets us pin-project
+/// safely without unsafe code or a `pin-project` macro dep. The
+/// single heap allocation happens once at stream construction.
+///
+/// Newtype'd so consumers don't need to import `async_channel` to
+/// name the stream type.
+pub struct AsyncStdSampleStream {
+    rx: BoxedReceiver,
+}
+
+impl Stream for AsyncStdSampleStream {
+    type Item = Result<Vec<u8>, RtlSdrError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx.as_mut().poll_next(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Same trait + marker contract as the tokio variant.
+    const _: fn() = || {
+        fn assert_stream<T: Stream>() {}
+        fn assert_send<T: Send>() {}
+        assert_stream::<AsyncStdSampleStream>();
+        assert_send::<AsyncStdSampleStream>();
+    };
+}

--- a/crates/sdr-rtlsdr/src/device/streaming_smol.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming_smol.rs
@@ -1,0 +1,155 @@
+//! smol `Stream` adapter for IQ-sample reads.
+//!
+//! Gated on `feature = "smol"`. Bridges the synchronous USB
+//! bulk-read path into a `Stream` consumable from a smol-family
+//! executor (smol, async-executor, async-global-executor) without
+//! blocking it.
+//!
+//! # Implementation
+//!
+//! Mirrors the async-std variant (`super::streaming_async_std`)
+//! with one difference: the blocking offload uses
+//! [`blocking::unblock`] from the `blocking` crate (which is what
+//! `smol::unblock` re-exports under the hood) rather than
+//! async-std's spawn_blocking. Same
+//! [`async_channel`] mpsc bridge, same back-pressure shape, same
+//! drop semantics (~65 ms typical, up to one read timeout on a
+//! stalled device — see #633 for the libusb-cancel follow-up).
+//!
+//! Pulling in `blocking` directly rather than the full `smol`
+//! crate keeps the dep tree minimal — `smol` re-exports
+//! `blocking::unblock` as `smol::unblock`, so the public surface
+//! is the same regardless.
+//!
+//! # Returning the Task
+//!
+//! [`blocking::unblock`] returns a [`blocking::Task`] which the
+//! runtime drives forward when polled. Unlike tokio's
+//! `spawn_blocking` (fire-and-forget) or async-std's
+//! `spawn_blocking` (also fire-and-forget — its `JoinHandle`
+//! detaches automatically), `blocking::Task` cancels its
+//! underlying work if dropped without `.detach()`. We call
+//! `.detach()` so the worker continues running until the
+//! channel closes naturally on consumer drop, matching the
+//! semantics of the other two runtime variants.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+
+use crate::error::RtlSdrError;
+
+use super::RtlSdrDevice;
+
+/// Channel depth — same derivation as the other runtime
+/// variants; see `super::streaming_tokio`.
+const STREAM_BACKPRESSURE_DEPTH: usize = 4;
+
+/// Type alias for the boxed-pinned async-channel receiver used
+/// inside [`SmolSampleStream`] — keeps the struct readable and
+/// satisfies clippy's `type_complexity` lint.
+type BoxedReceiver = Pin<Box<async_channel::Receiver<Result<Vec<u8>, RtlSdrError>>>>;
+
+impl RtlSdrDevice {
+    /// Stream IQ samples as a smol-friendly `Stream`.
+    ///
+    /// Same shape as `Self::stream_samples_tokio` (only present
+    /// when the `tokio` feature is enabled) — consumes the
+    /// device, returns the device on the error path so the
+    /// caller can recover its configured state. This method
+    /// differs only in which runtime drives the blocking
+    /// offload.
+    ///
+    /// # Errors
+    ///
+    /// Currently never fails at the preflight stage —
+    /// [`blocking::unblock`] runs on its own internal thread
+    /// pool independent of any active executor. The error type
+    /// is kept as `Box<(RtlSdrError, Self)>` for shape parity
+    /// with the other runtime variants.
+    ///
+    /// ```no_run
+    /// # #[cfg(feature = "smol")]
+    /// # async fn example() -> Result<(), sdr_rtlsdr::RtlSdrError> {
+    /// use futures_core::Stream;
+    /// use std::pin::Pin;
+    /// use sdr_rtlsdr::RtlSdrDevice;
+    ///
+    /// let dev = RtlSdrDevice::open(0)?;
+    /// dev.reset_buffer()?;
+    /// let stream = dev.stream_samples_smol(262_144).map_err(|boxed| boxed.0)?;
+    /// let mut stream: Pin<Box<dyn Stream<Item = _>>> = Box::pin(stream);
+    /// // futures_util::StreamExt::next() — left to the consumer's choice of helper crate.
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn stream_samples_smol(
+        self,
+        buffer_size: usize,
+    ) -> Result<SmolSampleStream, Box<(RtlSdrError, Self)>> {
+        let (tx, rx) = async_channel::bounded(STREAM_BACKPRESSURE_DEPTH);
+
+        // `blocking::unblock` returns a `Task` that cancels its
+        // underlying work on drop. Detach so the worker runs to
+        // natural completion (channel closure on consumer drop)
+        // — matches the fire-and-forget shape of the tokio /
+        // async-std variants.
+        blocking::unblock(move || {
+            let dev = self;
+            let mut iter = dev.iter_samples(buffer_size);
+            loop {
+                if tx.is_closed() {
+                    return;
+                }
+                match iter.next() {
+                    Some(chunk) => {
+                        let is_err = chunk.is_err();
+                        if tx.send_blocking(chunk).is_err() {
+                            return;
+                        }
+                        if is_err {
+                            return;
+                        }
+                    }
+                    None => return,
+                }
+            }
+        })
+        .detach();
+
+        Ok(SmolSampleStream { rx: Box::pin(rx) })
+    }
+}
+
+/// smol's `Stream` over IQ-sample buffers, returned by
+/// [`RtlSdrDevice::stream_samples_smol`].
+///
+/// Same shape as `super::AsyncStdSampleStream` — wraps a
+/// pinned, boxed [`async_channel::Receiver`] (the receiver is
+/// `!Unpin`; pinning into a `Box` lets us project safely without
+/// unsafe code or a `pin-project` macro dep). One heap alloc at
+/// stream construction.
+pub struct SmolSampleStream {
+    rx: BoxedReceiver,
+}
+
+impl Stream for SmolSampleStream {
+    type Item = Result<Vec<u8>, RtlSdrError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx.as_mut().poll_next(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const _: fn() = || {
+        fn assert_stream<T: Stream>() {}
+        fn assert_send<T: Send>() {}
+        assert_stream::<SmolSampleStream>();
+        assert_send::<SmolSampleStream>();
+    };
+}

--- a/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
@@ -9,7 +9,7 @@
 //! `tokio::task::spawn_blocking` runs the underlying
 //! [`super::SampleIter`] loop on tokio's blocking-task thread
 //! pool, pushing each yielded buffer through a
-//! `tokio::sync::mpsc` channel. The returned [`SampleStream`]
+//! `tokio::sync::mpsc` channel. The returned [`TokioSampleStream`]
 //! drains the receiver as a `Stream`.
 //!
 //! Bounded channel (depth = [`STREAM_BACKPRESSURE_DEPTH`])
@@ -46,7 +46,7 @@ const STREAM_BACKPRESSURE_DEPTH: usize = 4;
 impl RtlSdrDevice {
     /// Stream IQ samples as a tokio-friendly async `Stream`.
     ///
-    /// Consumes the device. The returned [`SampleStream`] owns
+    /// Consumes the device. The returned [`TokioSampleStream`] owns
     /// the [`RtlSdrDevice`] inside a blocking task — there's no
     /// way to drive both the stream and other control methods
     /// concurrently against the same handle without giving up
@@ -106,7 +106,7 @@ impl RtlSdrDevice {
     ///
     /// # Drop semantics
     ///
-    /// When the consumer drops the [`SampleStream`], the worker
+    /// When the consumer drops the [`TokioSampleStream`], the worker
     /// observes the closed channel **between** USB reads and
     /// exits cleanly — typical drop latency is one read cadence
     /// (~65 ms at 2 Msps with the default 256 KB buffer). On a
@@ -153,7 +153,7 @@ impl RtlSdrDevice {
     pub fn stream_samples_tokio(
         self,
         buffer_size: usize,
-    ) -> Result<SampleStream, Box<(RtlSdrError, Self)>> {
+    ) -> Result<TokioSampleStream, Box<(RtlSdrError, Self)>> {
         // Preflight runtime check BEFORE consuming `self`'s
         // resources into the worker. `tokio::task::spawn_blocking`
         // doesn't document its outside-runtime behaviour but
@@ -177,7 +177,7 @@ impl RtlSdrDevice {
         // The blocking task owns the device for the duration
         // of the stream — no `Arc<Mutex<…>>`, no shared
         // mutable access. When the consumer drops the
-        // `SampleStream` the channel closes; we observe that
+        // `TokioSampleStream` the channel closes; we observe that
         // via `tx.is_closed()` between reads (so a healthy
         // streaming device exits within one buffer cadence)
         // and via `tx.blocking_send` returning `Err` after the
@@ -216,7 +216,7 @@ impl RtlSdrDevice {
             }
         });
 
-        Ok(SampleStream { rx })
+        Ok(TokioSampleStream { rx })
     }
 }
 
@@ -227,11 +227,11 @@ impl RtlSdrDevice {
 /// the other end terminates when this stream is dropped (next
 /// blocking-send fails). No additional cleanup is required
 /// from the consumer.
-pub struct SampleStream {
+pub struct TokioSampleStream {
     rx: tokio::sync::mpsc::Receiver<Result<Vec<u8>, RtlSdrError>>,
 }
 
-impl Stream for SampleStream {
+impl Stream for TokioSampleStream {
     type Item = Result<Vec<u8>, RtlSdrError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -244,7 +244,7 @@ mod tests {
     use super::*;
 
     // Pin the trait-impl + marker contract documented on
-    // `SampleStream`: it implements `Stream` (so consumers can
+    // `TokioSampleStream`: it implements `Stream` (so consumers can
     // use `StreamExt`) and is `Send` (so it can cross `await`
     // boundaries on multi-threaded executors). If a future
     // refactor changes the receiver type or adds non-`Send`
@@ -253,7 +253,7 @@ mod tests {
     const _: fn() = || {
         fn assert_stream<T: Stream>() {}
         fn assert_send<T: Send>() {}
-        assert_stream::<SampleStream>();
-        assert_send::<SampleStream>();
+        assert_stream::<TokioSampleStream>();
+        assert_send::<TokioSampleStream>();
     };
 }


### PR DESCRIPTION
## Summary

Round 3b finishes the per-runtime streaming suite per #626. Round 3a (#632) shipped Iterator + tokio; this round adds async-std and smol with the same shape.

## What's new

- **\`RtlSdrDevice::stream_samples_async_std(buffer_size)\`** (gated on \`feature = "async-std"\`). Backed by \`async_std::task::spawn_blocking\` + \`async-channel\` mpsc. Returns \`AsyncStdSampleStream\`.
- **\`RtlSdrDevice::stream_samples_smol(buffer_size)\`** (gated on \`feature = "smol"\`). Backed by \`blocking::unblock\` (with \`.detach()\` so the worker runs to natural completion) + \`async-channel\` mpsc. Returns \`SmolSampleStream\`.

Both new variants newtype the channel receiver behind a \`BoxedReceiver = Pin<Box<async_channel::Receiver<…>>>\` type alias because \`async_channel::Receiver\` is \`!Unpin\`; pinning into a Box lets us project safely without unsafe code or a \`pin-project\` macro dep. One heap alloc per stream construction.

## Naming symmetry

Renamed \`SampleStream\` → \`TokioSampleStream\` so all three runtime variants follow \`<Runtime>SampleStream\`. Breaking change to the freshly-shipped #632 API but the spin-out crate hasn't published yet — cost is zero. Multiple features can be enabled simultaneously (intentional — consumers shouldn't have to choose at compile-time), so distinct type names per runtime are mandatory.

## Cargo manifest

\`\`\`toml
async-channel = { version = "2", optional = true }
async-std = { version = "1", optional = true }
blocking = { version = "1", optional = true }

[features]
async-std = ["dep:async-std", "dep:async-channel", "dep:futures-core"]
smol = ["dep:blocking", "dep:async-channel", "dep:futures-core"]

[package.metadata.docs.rs]
all-features = true
\`\`\`

The \`docs.rs/all-features\` hint makes the published docs render with all three variants; per-feature local builds still succeed because cross-runtime mentions in module docs use plain code spans rather than intra-doc links.

## Test plan

Validated across the full feature matrix (default, tokio, async-std, smol, all-three):

- [x] \`cargo build --workspace\` clean (default features)
- [x] \`cargo build -p sdr-rtlsdr --features X\` for each X
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` clean (default)
- [x] \`cargo clippy -p sdr-rtlsdr --features X -- -D warnings\` clean for each X
- [x] \`cargo test -p sdr-rtlsdr --features X --lib\` 102 passed for each X
- [x] \`cargo check --workspace --locked\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --features X\` clean for each X
- [x] \`cargo test --doc -p sdr-rtlsdr --features X\` passed for each X

Compile-time \`Stream + Send\` trait assertions on the new types pin the contract. Real-streaming smoke tests against hardware will land via the next round (wire \`sdr-source-rtlsdr\` to the new tokio Stream so the user can smoke-test the chain end-to-end against NOAA passes).

## Out of scope

- App wire-up of the new tokio Stream (separate PR after this lands)
- Spin-out to \`librtlsdr-rs\` repo (after smoke testing confirms no regressions)
- libusb-cancel for proper in-flight drop (#633)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `async-std` and `smol` async runtimes alongside existing Tokio support.
  * New runtime-specific streaming methods enable flexible async integration across different runtime ecosystems.

* **Documentation**
  * Enhanced API documentation now displays all available runtime-specific streaming options and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->