### PR TITLE
feat(sdr-rtlsdr,sdr-source-rtlsdr): RtlSdrReader split + gain-respect (#626)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3368,6 +3368,7 @@ dependencies = [
  "async-std",
  "blocking",
  "futures-core",
+ "futures-util",
  "rusb",
  "thiserror 2.0.18",
  "tokio",
@@ -4060,7 +4061,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2 0.6.3",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/sdr-rtlsdr/Cargo.toml
+++ b/crates/sdr-rtlsdr/Cargo.toml
@@ -45,6 +45,17 @@ async-std = ["dep:async-std", "dep:async-channel", "dep:futures-core"]
 # blocking work) and `async-channel`.
 smol = ["dep:blocking", "dep:async-channel", "dep:futures-core"]
 
+[dev-dependencies]
+# `tokio` with `macros + time + rt-multi-thread` for the
+# `live_streaming.rs` integration tests (which run real USB
+# bulk reads on a `multi_thread` runtime). The production
+# `tokio` feature itself only needs `sync + rt` — dev-deps
+# additions don't bleed into consumers.
+tokio = { version = "1", features = ["macros", "time", "rt-multi-thread", "sync", "rt"] }
+# `StreamExt::next` for the live tests; `0.3` matches what
+# `futures-core` resolves to in the regular dep tree.
+futures-util = "0.3"
+
 [lints]
 workspace = true
 

--- a/crates/sdr-rtlsdr/src/device/mod.rs
+++ b/crates/sdr-rtlsdr/src/device/mod.rs
@@ -25,6 +25,9 @@ pub use streaming::SampleIter;
 mod builder;
 pub use builder::RtlSdrDeviceBuilder;
 
+mod reader;
+pub use reader::{ReaderIter, RtlSdrReader};
+
 #[cfg(feature = "tokio")]
 mod streaming_tokio;
 #[cfg(feature = "tokio")]
@@ -131,6 +134,26 @@ impl RtlSdrDevice {
     #[must_use]
     pub fn list() -> Vec<DeviceInfo> {
         enumerate::list_devices()
+    }
+
+    /// Build a streaming-focused [`RtlSdrReader`] handle.
+    ///
+    /// The reader is the right surface for moving the streaming
+    /// path to another thread / async runtime while the parent
+    /// retains `&mut self` for control methods like
+    /// [`Self::set_center_freq`] and [`Self::set_tuner_gain`].
+    /// See [`RtlSdrReader`]'s docs for the full pattern,
+    /// concurrency-safety caveat, and examples.
+    ///
+    /// Cheap to call — clones the underlying `Arc<DeviceHandle>`,
+    /// no USB traffic. Build a fresh reader anywhere you'd want
+    /// to start a new streaming session; the reader's methods
+    /// consume `self` so each session is its own handle.
+    #[must_use]
+    pub fn reader(&self) -> RtlSdrReader {
+        RtlSdrReader {
+            handle: std::sync::Arc::clone(&self.handle),
+        }
     }
 
     /// Open an RTL-SDR device by index.

--- a/crates/sdr-rtlsdr/src/device/reader.rs
+++ b/crates/sdr-rtlsdr/src/device/reader.rs
@@ -1,0 +1,208 @@
+//! Streaming-focused handle that runs concurrently with control.
+//!
+//! See [`RtlSdrReader`] and [`RtlSdrDevice::reader`].
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::error::RtlSdrError;
+
+use super::RtlSdrDevice;
+
+/// Streaming-focused handle. Acquired via [`RtlSdrDevice::reader`].
+///
+/// `RtlSdrReader` exists to resolve the design tension between
+/// Rust's ownership model (control methods like
+/// [`RtlSdrDevice::set_center_freq`] take `&mut self`; concurrent
+/// streaming would require holding `self` for the duration) and
+/// the underlying USB protocol's reality (bulk reads use endpoint
+/// 0x81; control transfers use endpoint 0x00 — different
+/// endpoints, no conflict on real hardware).
+///
+/// The reader internally clones the device's
+/// `Arc<rusb::DeviceHandle>`, then exposes the streaming surface
+/// (sync iterator + per-runtime async streams) by consuming the
+/// reader. The parent retains the [`RtlSdrDevice`] for control:
+///
+/// ```no_run
+/// # use sdr_rtlsdr::{RtlSdrDevice, RtlSdrError};
+/// # fn example() -> Result<(), RtlSdrError> {
+/// let mut device = RtlSdrDevice::open(0)?;
+/// device.set_sample_rate(2_400_000)?;
+/// device.set_center_freq(100_000_000)?;
+/// device.reset_buffer()?;
+///
+/// // Hand a reader to a worker thread.
+/// let reader = device.reader();
+/// let thread = std::thread::spawn(move || {
+///     for chunk in reader.iter_samples(262_144) {
+///         match chunk {
+///             Ok(buf) => { /* push to ring / DSP */ let _ = buf; }
+///             Err(e) => { eprintln!("read error: {e}"); break; }
+///         }
+///     }
+/// });
+///
+/// // Parent thread retains control of the device while the reader
+/// // streams — separate USB endpoints, no rusb-level conflict.
+/// device.set_center_freq(101_000_000)?;
+/// device.set_tuner_gain(150)?;
+/// # let _ = thread;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Concurrency safety
+///
+/// The shared-handle pattern (one `Arc<DeviceHandle>` reffed by
+/// both the parent device and any number of readers) is what
+/// upstream `librtlsdr`'s reference implementations have used for
+/// years. Bulk reads on endpoint 0x81 don't interfere with
+/// control transfers on endpoint 0x00 at the libusb level on
+/// real hardware.
+///
+/// **However**, libusb's documentation does not formally
+/// guarantee that concurrent bulk and control transfers on a
+/// single device handle are safe. The shared-handle pattern is a
+/// practical convention rather than a documented promise. If you
+/// need strict by-the-book safety, sequence the operations from
+/// a single thread (e.g. fully drop the reader before retuning,
+/// then build a new reader). For the typical "stream while
+/// retuning the satellite at AOS" pattern this works reliably on
+/// the dongles in active use; verify against your specific
+/// hardware in production.
+///
+/// # Cheap clone via the device
+///
+/// A [`RtlSdrReader`] is just an `Arc` clone of the device's USB
+/// handle plus an init flag. Build one via [`RtlSdrDevice::reader`]
+/// any time you need a fresh streaming handle — the cost is one
+/// atomic increment.
+#[derive(Clone)]
+pub struct RtlSdrReader {
+    pub(crate) handle: Arc<rusb::DeviceHandle<rusb::GlobalContext>>,
+}
+
+impl RtlSdrReader {
+    /// Default per-read USB transfer timeout used by sync reads.
+    /// Matches [`RtlSdrDevice::read_sync`]'s timeout for symmetry.
+    /// Per-call control: the per-runtime stream variants use a
+    /// shorter polling timeout for cancellation responsiveness;
+    /// the synchronous iterator uses this longer timeout because
+    /// it has no async cancellation pathway.
+    const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+    /// Synchronous bulk read into a caller-owned buffer.
+    ///
+    /// Mirror of [`RtlSdrDevice::read_sync`] with the same
+    /// semantics, exposed on the Reader so streaming code that
+    /// already has a Reader doesn't need to round-trip through
+    /// the device.
+    ///
+    /// # Errors
+    ///
+    /// - [`RtlSdrError::DeviceLost`] if the dongle was
+    ///   disconnected.
+    /// - [`RtlSdrError::Usb`] for any other rusb transport
+    ///   error.
+    pub fn read_sync(&self, buf: &mut [u8]) -> Result<usize, RtlSdrError> {
+        match self
+            .handle
+            .read_bulk(RtlSdrDevice::BULK_ENDPOINT, buf, Self::DEFAULT_TIMEOUT)
+        {
+            Ok(n) => Ok(n),
+            Err(rusb::Error::NoDevice) => Err(RtlSdrError::DeviceLost),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Sync iterator over IQ-sample buffers, consuming the
+    /// reader.
+    ///
+    /// Each [`Iterator::next`] performs one [`Self::read_sync`]
+    /// into a freshly-allocated `Vec<u8>` and yields it. Same
+    /// fuse-on-error semantics as [`RtlSdrDevice::iter_samples`]:
+    /// returns `None` permanently after the first error or
+    /// zero-length read.
+    ///
+    /// Consumes the reader so the iterator owns the
+    /// `Arc<DeviceHandle>` clone — usable across thread
+    /// boundaries (`'static`-friendly, sendable).
+    ///
+    /// # Buffer size
+    ///
+    /// Same guidance as [`RtlSdrDevice::iter_samples`] — 256 KB
+    /// (`262_144`) is the librtlsdr-equivalent default. Passing
+    /// `0` selects the default.
+    #[must_use]
+    pub fn iter_samples(self, buffer_size: usize) -> ReaderIter {
+        let buffer_size = if buffer_size == 0 {
+            crate::constants::DEFAULT_BUF_LENGTH as usize
+        } else {
+            buffer_size
+        };
+        ReaderIter {
+            reader: Some(self),
+            buffer_size,
+        }
+    }
+}
+
+/// Owned, sendable iterator over IQ-sample buffers, returned by
+/// [`RtlSdrReader::iter_samples`].
+///
+/// Differs from [`crate::SampleIter`] in that it owns the reader
+/// (and thus the underlying `Arc<DeviceHandle>` clone) rather
+/// than borrowing the device — so it satisfies `'static` and can
+/// be sent to other threads / async runtimes. Same
+/// `FusedIterator` contract: `None` permanently after the first
+/// error or zero read.
+pub struct ReaderIter {
+    /// `None` once the iterator has fused.
+    reader: Option<RtlSdrReader>,
+    buffer_size: usize,
+}
+
+impl Iterator for ReaderIter {
+    type Item = Result<Vec<u8>, RtlSdrError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let reader = self.reader.as_ref()?;
+        let mut buf = vec![0u8; self.buffer_size];
+        match reader.read_sync(&mut buf) {
+            Ok(0) => {
+                self.reader = None;
+                None
+            }
+            Ok(n) => {
+                buf.truncate(n);
+                Some(Ok(buf))
+            }
+            Err(e) => {
+                self.reader = None;
+                Some(Err(e))
+            }
+        }
+    }
+}
+
+impl std::iter::FusedIterator for ReaderIter {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pin the trait + marker contract: ReaderIter is Iterator +
+    // FusedIterator + Send. The Send guarantee is the whole
+    // point of the Reader split — the iterator must move freely
+    // between threads / async runtimes.
+    const _: fn() = || {
+        fn assert_iter<T: Iterator>() {}
+        fn assert_fused<T: std::iter::FusedIterator>() {}
+        fn assert_send<T: Send>() {}
+        assert_iter::<ReaderIter>();
+        assert_fused::<ReaderIter>();
+        assert_send::<ReaderIter>();
+        assert_send::<RtlSdrReader>();
+    };
+}

--- a/crates/sdr-rtlsdr/src/device/streaming_async_std.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming_async_std.rs
@@ -4,29 +4,19 @@
 //! bulk-read path into a `Stream` consumable from an async-std
 //! executor without blocking it.
 //!
-//! # Implementation
-//!
-//! Mirrors the tokio variant (`super::streaming_tokio`) with
-//! two differences:
+//! Mirrors the tokio variant (`super::streaming_tokio`) with two
+//! differences:
 //!
 //! - **Blocking offload** uses [`async_std::task::spawn_blocking`]
 //!   instead of `tokio::task::spawn_blocking`.
 //! - **mpsc bridge** uses the runtime-agnostic [`async_channel`]
-//!   crate, whose `Receiver` already implements `Stream` natively
-//!   — no manual `poll_next` impl needed; we wrap the receiver in
-//!   a newtype to keep the public type name runtime-tagged.
+//!   crate. `Receiver` is `!Unpin`; we store it as `Pin<Box<…>>`
+//!   so we can pin-project safely without unsafe code or a
+//!   `pin-project` macro dep.
 //!
-//! Same back-pressure-by-default channel depth
-//! ([`STREAM_BACKPRESSURE_DEPTH`]) as the tokio variant — sample
-//! drops are usually fatal for SDR (gaps in the stream).
-//!
-//! # Drop semantics
-//!
-//! Same trade-off as the tokio path: between-reads drops exit
-//! within one buffer cadence (~65 ms typical at 2 Msps); a drop
-//! while a USB read is in flight waits up to one read timeout
-//! (~5 s on a stalled device). True in-flight cancellation needs
-//! libusb's async-submit + cancel API and is tracked as #633.
+//! Same back-pressure-by-default channel depth, same drop
+//! semantics (~65 ms between-reads, up to one read timeout for
+//! mid-read; #633 tracks proper libusb-cancel).
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -35,40 +25,26 @@ use futures_core::Stream;
 
 use crate::error::RtlSdrError;
 
-use super::RtlSdrDevice;
+use super::RtlSdrReader;
 
-/// Channel depth — see `super::streaming_tokio` for the
-/// derivation (4 × 256 KB ≈ 1 MB ≈ 250 ms at 2 Msps × 2 bytes/
-/// sample = 4 MB/s). Matched here so async-std consumers see
-/// the same back-pressure shape as tokio consumers.
 const STREAM_BACKPRESSURE_DEPTH: usize = 4;
 
-/// Type alias for the boxed-pinned async-channel receiver used
-/// inside [`AsyncStdSampleStream`]. Pulled out to keep the
-/// struct definition readable (and to satisfy clippy's
-/// `type_complexity` lint).
 type BoxedReceiver = Pin<Box<async_channel::Receiver<Result<Vec<u8>, RtlSdrError>>>>;
 
-impl RtlSdrDevice {
+impl RtlSdrReader {
     /// Stream IQ samples as an async-std-friendly `Stream`.
     ///
     /// Same shape as `Self::stream_samples_tokio` (only present
-    /// when the `tokio` feature is enabled) — consumes the
-    /// device, returns the device on the error path so the
-    /// caller can recover its configured state. This method
-    /// differs only in which runtime drives the blocking
-    /// offload.
+    /// when the `tokio` feature is enabled). Differs only in
+    /// which runtime drives the blocking offload.
     ///
     /// # Errors
     ///
     /// Currently never fails at the preflight stage —
     /// `async_std::task::spawn_blocking` works without an
-    /// active executor (queues the closure for the next
-    /// poll). The error type is kept as
+    /// active executor. Error type kept as
     /// `Box<(RtlSdrError, Self)>` for shape parity with the
-    /// other runtime variants in case a future error path
-    /// (e.g. allocator failure on the channel construction)
-    /// surfaces.
+    /// other runtime variants.
     ///
     /// ```no_run
     /// # #[cfg(feature = "async-std")]
@@ -77,11 +53,11 @@ impl RtlSdrDevice {
     /// use std::pin::Pin;
     /// use sdr_rtlsdr::RtlSdrDevice;
     ///
-    /// let dev = RtlSdrDevice::open(0)?;
+    /// let mut dev = RtlSdrDevice::open(0)?;
     /// dev.reset_buffer()?;
-    /// let stream = dev.stream_samples_async_std(262_144).map_err(|boxed| boxed.0)?;
+    /// let reader = dev.reader();
+    /// let stream = reader.stream_samples_async_std(262_144).map_err(|boxed| boxed.0)?;
     /// let mut stream: Pin<Box<dyn Stream<Item = _>>> = Box::pin(stream);
-    /// // futures_util::StreamExt::next() — left to the consumer's choice of helper crate.
     /// # Ok(())
     /// # }
     /// ```
@@ -91,14 +67,9 @@ impl RtlSdrDevice {
     ) -> Result<AsyncStdSampleStream, Box<(RtlSdrError, Self)>> {
         let (tx, rx) = async_channel::bounded(STREAM_BACKPRESSURE_DEPTH);
 
-        // Spawn the blocking iterator-driver onto async-std's
-        // blocking thread pool. Unlike tokio, async-std's
-        // `spawn_blocking` doesn't require an active runtime
-        // context — it manages its own pool — so no preflight
-        // check needed here.
         async_std::task::spawn_blocking(move || {
-            let dev = self;
-            let mut iter = dev.iter_samples(buffer_size);
+            let reader = self;
+            let mut iter = reader.iter_samples(buffer_size);
             loop {
                 if tx.is_closed() {
                     return;
@@ -123,17 +94,7 @@ impl RtlSdrDevice {
 }
 
 /// async-std's `Stream` over IQ-sample buffers, returned by
-/// [`RtlSdrDevice::stream_samples_async_std`].
-///
-/// Wraps a pinned, boxed [`async_channel::Receiver`] whose
-/// `Stream` impl drives `poll_next`. The receiver is `!Unpin`
-/// (carries a `PhantomPinned` to keep its internal event-listener
-/// in place), so storing it as `Pin<Box<…>>` lets us pin-project
-/// safely without unsafe code or a `pin-project` macro dep. The
-/// single heap allocation happens once at stream construction.
-///
-/// Newtype'd so consumers don't need to import `async_channel` to
-/// name the stream type.
+/// [`RtlSdrReader::stream_samples_async_std`].
 pub struct AsyncStdSampleStream {
     rx: BoxedReceiver,
 }
@@ -150,7 +111,6 @@ impl Stream for AsyncStdSampleStream {
 mod tests {
     use super::*;
 
-    // Same trait + marker contract as the tokio variant.
     const _: fn() = || {
         fn assert_stream<T: Stream>() {}
         fn assert_send<T: Send>() {}

--- a/crates/sdr-rtlsdr/src/device/streaming_smol.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming_smol.rs
@@ -5,33 +5,17 @@
 //! executor (smol, async-executor, async-global-executor) without
 //! blocking it.
 //!
-//! # Implementation
-//!
 //! Mirrors the async-std variant (`super::streaming_async_std`)
 //! with one difference: the blocking offload uses
-//! [`blocking::unblock`] from the `blocking` crate (which is what
-//! `smol::unblock` re-exports under the hood) rather than
-//! async-std's spawn_blocking. Same
-//! [`async_channel`] mpsc bridge, same back-pressure shape, same
-//! drop semantics (~65 ms typical, up to one read timeout on a
-//! stalled device — see #633 for the libusb-cancel follow-up).
+//! [`blocking::unblock`] (the foundation `smol::unblock` re-
+//! exports) rather than async-std's spawn_blocking. Same
+//! `async_channel` mpsc bridge, same back-pressure shape, same
+//! drop semantics (#633 tracks libusb-cancel).
 //!
-//! Pulling in `blocking` directly rather than the full `smol`
-//! crate keeps the dep tree minimal — `smol` re-exports
-//! `blocking::unblock` as `smol::unblock`, so the public surface
-//! is the same regardless.
-//!
-//! # Returning the Task
-//!
-//! [`blocking::unblock`] returns a [`blocking::Task`] which the
-//! runtime drives forward when polled. Unlike tokio's
-//! `spawn_blocking` (fire-and-forget) or async-std's
-//! `spawn_blocking` (also fire-and-forget — its `JoinHandle`
-//! detaches automatically), `blocking::Task` cancels its
-//! underlying work if dropped without `.detach()`. We call
-//! `.detach()` so the worker continues running until the
-//! channel closes naturally on consumer drop, matching the
-//! semantics of the other two runtime variants.
+//! [`blocking::unblock`] returns a [`blocking::Task`] which
+//! cancels its underlying work if dropped. We call `.detach()`
+//! so the worker runs to natural completion — matches the
+//! fire-and-forget shape of the tokio / async-std variants.
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -40,34 +24,25 @@ use futures_core::Stream;
 
 use crate::error::RtlSdrError;
 
-use super::RtlSdrDevice;
+use super::RtlSdrReader;
 
-/// Channel depth — same derivation as the other runtime
-/// variants; see `super::streaming_tokio`.
 const STREAM_BACKPRESSURE_DEPTH: usize = 4;
 
-/// Type alias for the boxed-pinned async-channel receiver used
-/// inside [`SmolSampleStream`] — keeps the struct readable and
-/// satisfies clippy's `type_complexity` lint.
 type BoxedReceiver = Pin<Box<async_channel::Receiver<Result<Vec<u8>, RtlSdrError>>>>;
 
-impl RtlSdrDevice {
+impl RtlSdrReader {
     /// Stream IQ samples as a smol-friendly `Stream`.
     ///
     /// Same shape as `Self::stream_samples_tokio` (only present
-    /// when the `tokio` feature is enabled) — consumes the
-    /// device, returns the device on the error path so the
-    /// caller can recover its configured state. This method
-    /// differs only in which runtime drives the blocking
-    /// offload.
+    /// when the `tokio` feature is enabled). Differs only in
+    /// which runtime drives the blocking offload.
     ///
     /// # Errors
     ///
     /// Currently never fails at the preflight stage —
     /// [`blocking::unblock`] runs on its own internal thread
-    /// pool independent of any active executor. The error type
-    /// is kept as `Box<(RtlSdrError, Self)>` for shape parity
-    /// with the other runtime variants.
+    /// pool independent of any active executor. Error type kept
+    /// as `Box<(RtlSdrError, Self)>` for shape parity.
     ///
     /// ```no_run
     /// # #[cfg(feature = "smol")]
@@ -76,11 +51,11 @@ impl RtlSdrDevice {
     /// use std::pin::Pin;
     /// use sdr_rtlsdr::RtlSdrDevice;
     ///
-    /// let dev = RtlSdrDevice::open(0)?;
+    /// let mut dev = RtlSdrDevice::open(0)?;
     /// dev.reset_buffer()?;
-    /// let stream = dev.stream_samples_smol(262_144).map_err(|boxed| boxed.0)?;
+    /// let reader = dev.reader();
+    /// let stream = reader.stream_samples_smol(262_144).map_err(|boxed| boxed.0)?;
     /// let mut stream: Pin<Box<dyn Stream<Item = _>>> = Box::pin(stream);
-    /// // futures_util::StreamExt::next() — left to the consumer's choice of helper crate.
     /// # Ok(())
     /// # }
     /// ```
@@ -90,14 +65,9 @@ impl RtlSdrDevice {
     ) -> Result<SmolSampleStream, Box<(RtlSdrError, Self)>> {
         let (tx, rx) = async_channel::bounded(STREAM_BACKPRESSURE_DEPTH);
 
-        // `blocking::unblock` returns a `Task` that cancels its
-        // underlying work on drop. Detach so the worker runs to
-        // natural completion (channel closure on consumer drop)
-        // — matches the fire-and-forget shape of the tokio /
-        // async-std variants.
         blocking::unblock(move || {
-            let dev = self;
-            let mut iter = dev.iter_samples(buffer_size);
+            let reader = self;
+            let mut iter = reader.iter_samples(buffer_size);
             loop {
                 if tx.is_closed() {
                     return;
@@ -123,13 +93,7 @@ impl RtlSdrDevice {
 }
 
 /// smol's `Stream` over IQ-sample buffers, returned by
-/// [`RtlSdrDevice::stream_samples_smol`].
-///
-/// Same shape as `super::AsyncStdSampleStream` — wraps a
-/// pinned, boxed [`async_channel::Receiver`] (the receiver is
-/// `!Unpin`; pinning into a `Box` lets us project safely without
-/// unsafe code or a `pin-project` macro dep). One heap alloc at
-/// stream construction.
+/// [`RtlSdrReader::stream_samples_smol`].
 pub struct SmolSampleStream {
     rx: BoxedReceiver,
 }

--- a/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
+++ b/crates/sdr-rtlsdr/src/device/streaming_tokio.rs
@@ -6,24 +6,23 @@
 //!
 //! # Implementation
 //!
-//! `tokio::task::spawn_blocking` runs the underlying
-//! [`super::SampleIter`] loop on tokio's blocking-task thread
-//! pool, pushing each yielded buffer through a
-//! `tokio::sync::mpsc` channel. The returned [`TokioSampleStream`]
-//! drains the receiver as a `Stream`.
+//! `tokio::task::spawn_blocking` runs a [`super::ReaderIter`]
+//! loop on tokio's blocking-task thread pool, pushing each
+//! yielded buffer through a `tokio::sync::mpsc` channel. The
+//! returned [`TokioSampleStream`] drains the receiver as a
+//! `Stream`.
 //!
-//! Bounded channel (depth = [`STREAM_BACKPRESSURE_DEPTH`])
-//! provides back-pressure: if the consumer falls behind the
-//! reader thread blocks on `blocking_send` rather than dropping
-//! samples. For SDR, sample drops are usually fatal (gaps in
-//! the stream) — the back-pressure default is correct. Tune
-//! the consumer (or scale up to a faster runtime) rather than
-//! widening the channel.
+//! Bounded channel ([`STREAM_BACKPRESSURE_DEPTH`] = 4) provides
+//! back-pressure: if the consumer falls behind the reader thread
+//! blocks on `blocking_send` rather than dropping samples. For
+//! SDR, sample drops are usually fatal (gaps in the stream) — the
+//! back-pressure default is correct. Tune the consumer (or scale
+//! up to a faster runtime) rather than widening the channel.
 //!
-//! When the consumer drops the `Stream`, the channel closes and
-//! the worker exits on the next `blocking_send` failure. On
-//! transport error the worker pushes the error and exits; the
-//! `Stream` yields the error, then `None`.
+//! When the consumer drops the `Stream`, the worker observes the
+//! closed channel between reads and exits cleanly. On transport
+//! error the worker pushes the error and exits; the `Stream`
+//! yields the error then `None`.
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -32,41 +31,32 @@ use futures_core::Stream;
 
 use crate::error::RtlSdrError;
 
-use super::RtlSdrDevice;
+use super::RtlSdrReader;
 
-/// Number of buffers the tokio mpsc channel holds before the
-/// reader thread blocks. Picked to give the consumer ~250 ms
-/// of slack at typical RTL-SDR rates (4 × 256 KB ≈ 1 MB ≈
-/// 0.25 s at 2 Msps × 2 bytes/sample = 4 MB/s — enough to
-/// absorb a slow tick on the consumer without dropping a
-/// transfer, not so much that latency-sensitive consumers
-/// observe a long queue).
+/// Channel depth — 4 × 256 KB ≈ 1 MB ≈ 250 ms at 2 Msps × 2
+/// bytes/sample = 4 MB/s. Enough to absorb a slow tick on the
+/// consumer without dropping a transfer; not so much that
+/// latency-sensitive consumers observe a long queue.
 const STREAM_BACKPRESSURE_DEPTH: usize = 4;
 
-impl RtlSdrDevice {
+impl RtlSdrReader {
     /// Stream IQ samples as a tokio-friendly async `Stream`.
     ///
-    /// Consumes the device. The returned [`TokioSampleStream`] owns
-    /// the [`RtlSdrDevice`] inside a blocking task — there's no
-    /// way to drive both the stream and other control methods
-    /// concurrently against the same handle without giving up
-    /// the `Send`-but-not-`Sync` guarantees we documented on
-    /// the device. Configure the device (frequency, bandwidth,
-    /// gain, etc.) before calling this.
+    /// Consumes the reader. The returned [`TokioSampleStream`]
+    /// owns the reader inside a blocking task; build a fresh
+    /// reader via [`super::RtlSdrDevice::reader`] if you need
+    /// another stream session.
     ///
-    /// # Errors / termination
+    /// # Errors
     ///
-    /// Each yielded item is `Result<Vec<u8>, RtlSdrError>`. The
-    /// stream ends (`Poll::Ready(None)`) when:
-    /// - The reader observed a transport error and yielded it
-    ///   on the previous `poll_next` call. Standard
-    ///   error-then-fuse contract.
-    /// - The underlying `read_sync` returned zero bytes (rare,
-    ///   degenerate-device case).
-    /// - The consumer drops the stream — the worker observes
-    ///   the closed channel and exits cleanly.
-    ///
-    /// # Example
+    /// On preflight failure (no tokio runtime active) the
+    /// returned `Err` carries both the diagnostic
+    /// [`RtlSdrError`] and the unconsumed [`RtlSdrReader`] back
+    /// to the caller. The reader is cheap to recreate but the
+    /// pattern matches the std-library "error preserves the
+    /// resource" idiom (see `Vec::push_within_capacity`,
+    /// `mpsc::Sender::send`'s `SendError<T>`); boxed because
+    /// the inline tuple trips clippy's `result_large_err` lint.
     ///
     /// ```no_run
     /// # #[cfg(feature = "tokio")]
@@ -75,13 +65,10 @@ impl RtlSdrDevice {
     /// use std::pin::Pin;
     /// use sdr_rtlsdr::RtlSdrDevice;
     ///
-    /// let dev = RtlSdrDevice::open(0)?;
+    /// let mut dev = RtlSdrDevice::open(0)?;
     /// dev.reset_buffer()?;
-    /// // `stream_samples_tokio` returns the device back on
-    /// // preflight failure (e.g. no tokio runtime active);
-    /// // `.map_err(|boxed| boxed.0)` discards the device and
-    /// // surfaces the underlying `RtlSdrError` so `?` works.
-    /// let stream = dev.stream_samples_tokio(262_144).map_err(|boxed| boxed.0)?;
+    /// let reader = dev.reader();
+    /// let stream = reader.stream_samples_tokio(262_144).map_err(|boxed| boxed.0)?;
     /// let mut stream: Pin<Box<dyn Stream<Item = _>>> = Box::pin(stream);
     /// // futures_util::StreamExt::next() — left to the consumer's choice of helper crate.
     /// # Ok(())
@@ -90,79 +77,31 @@ impl RtlSdrDevice {
     ///
     /// `buffer_size` follows the same guidance as
     /// [`Self::iter_samples`] — 256 KB / 64 KB are typical good
-    /// values; smaller for lower latency, larger to amortise
-    /// USB overhead.
+    /// values. Passing `0` selects the default.
     ///
     /// # Runtime requirement
     ///
     /// Must be called from inside a tokio runtime context (the
-    /// implementation calls [`tokio::task::spawn_blocking`]
-    /// internally). Returns
-    /// [`RtlSdrError::InvalidParameter`] when called outside a
-    /// runtime — checked via
+    /// implementation calls [`tokio::task::spawn_blocking`]).
+    /// Returns [`RtlSdrError::InvalidParameter`] when called
+    /// outside a runtime — checked via
     /// [`tokio::runtime::Handle::try_current`] before any task
     /// spawn so the failure mode is a clean error instead of
     /// the runtime's own panic.
     ///
     /// # Drop semantics
     ///
-    /// When the consumer drops the [`TokioSampleStream`], the worker
-    /// observes the closed channel **between** USB reads and
-    /// exits cleanly — typical drop latency is one read cadence
-    /// (~65 ms at 2 Msps with the default 256 KB buffer). On a
-    /// stalled device the worst case is one read timeout (5 s
-    /// per [`RtlSdrDevice::read_sync`]). For sub-millisecond
-    /// cancellation of an in-flight bulk transfer we'd need
-    /// libusb's async-submit + cancel API rather than the
-    /// blocking read; that's tracked as #633 rather than done
-    /// here. Per #632 CR round 1.
-    ///
-    /// # Errors
-    ///
-    /// On preflight failure (no tokio runtime active) the
-    /// returned `Err` carries both the diagnostic
-    /// [`RtlSdrError`] and the unconsumed [`RtlSdrDevice`]
-    /// back to the caller — the configured frequency, gain,
-    /// tuner state, etc. survive so the caller can enter a
-    /// runtime and retry without re-opening:
-    ///
-    /// ```no_run
-    /// # #[cfg(feature = "tokio")]
-    /// # async fn example() -> Result<(), sdr_rtlsdr::RtlSdrError> {
-    /// # use sdr_rtlsdr::RtlSdrDevice;
-    /// let dev = RtlSdrDevice::open(0)?;
-    /// // dev.set_center_freq(...) etc. ...
-    /// let stream = match dev.stream_samples_tokio(0) {
-    ///     Ok(stream) => stream,
-    ///     Err(boxed) => {
-    ///         let (err, _device) = *boxed;
-    ///         return Err(err);
-    ///     }
-    /// };
-    /// # let _ = stream;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// Pattern matches the std-library "error preserves the
-    /// resource" idiom (see `Vec::push_within_capacity`,
-    /// `mpsc::Sender::send`'s `SendError<T>`). The `Err` is
-    /// boxed because [`RtlSdrDevice`] is a sizeable struct and
-    /// returning it inline would inflate every `Result` on the
-    /// happy path (clippy's `result_large_err` lint).
+    /// Between-reads drops exit within one buffer cadence
+    /// (~65 ms typical at 2 Msps); a drop while a USB read is
+    /// in flight waits up to one read timeout (~5 s on a
+    /// stalled device). True in-flight cancellation needs
+    /// libusb's async-submit + cancel API and is tracked as
+    /// #633.
     pub fn stream_samples_tokio(
         self,
         buffer_size: usize,
     ) -> Result<TokioSampleStream, Box<(RtlSdrError, Self)>> {
-        // Preflight runtime check BEFORE consuming `self`'s
-        // resources into the worker. `tokio::task::spawn_blocking`
-        // doesn't document its outside-runtime behaviour but
-        // panics in practice; library code shouldn't panic.
-        // Returning the device on the error path means a caller
-        // who forgot to enter a runtime can retry without losing
-        // their configured frequency / gain / tuner state. Per
-        // #632 CR round 2 (round 1 added the check; round 2 fixed
-        // the device-loss-on-error bug).
+        // Preflight runtime check BEFORE consuming the reader.
         if tokio::runtime::Handle::try_current().is_err() {
             return Err(Box::new((
                 RtlSdrError::InvalidParameter(
@@ -174,26 +113,17 @@ impl RtlSdrDevice {
 
         let (tx, rx) = tokio::sync::mpsc::channel(STREAM_BACKPRESSURE_DEPTH);
 
-        // The blocking task owns the device for the duration
-        // of the stream — no `Arc<Mutex<…>>`, no shared
-        // mutable access. When the consumer drops the
-        // `TokioSampleStream` the channel closes; we observe that
-        // via `tx.is_closed()` between reads (so a healthy
-        // streaming device exits within one buffer cadence)
-        // and via `tx.blocking_send` returning `Err` after the
-        // read (so a still-completing read isn't wasted). On
-        // exit, tokio's runtime drops the task's stack
-        // including the device, which runs `Drop` and releases
-        // the USB interface cleanly.
+        // The blocking task owns the reader (and via it the
+        // Arc<DeviceHandle> clone) for the duration of the
+        // stream. Pre-read drop check via `tx.is_closed()`
+        // catches consumer drops in the brief window between
+        // reads; mid-read drops still wait for the in-flight
+        // bulk transfer to return (see method-level "Drop
+        // semantics" docs).
         tokio::task::spawn_blocking(move || {
-            let dev = self;
-            let mut iter = dev.iter_samples(buffer_size);
+            let reader = self;
+            let mut iter = reader.iter_samples(buffer_size);
             loop {
-                // Pre-read drop check: catches the common case
-                // of a consumer dropping the stream during the
-                // brief window between reads. For an in-flight
-                // read we still wait for it to return (see
-                // method-level "Drop semantics" docs).
                 if tx.is_closed() {
                     return;
                 }
@@ -204,10 +134,6 @@ impl RtlSdrDevice {
                             return;
                         }
                         if is_err {
-                            // Iterator fuses on error; yielding
-                            // once matches the documented
-                            // "yields the error, then `None`"
-                            // contract.
                             return;
                         }
                     }
@@ -220,12 +146,12 @@ impl RtlSdrDevice {
     }
 }
 
-/// Async `Stream` wrapping the tokio mpsc receiver fed by
-/// [`RtlSdrDevice::stream_samples_tokio`]'s blocking worker.
+/// Async `Stream` over IQ-sample buffers, returned by
+/// [`RtlSdrReader::stream_samples_tokio`].
 ///
-/// Owns the receiver end of the channel; the worker task on
-/// the other end terminates when this stream is dropped (next
-/// blocking-send fails). No additional cleanup is required
+/// Owns the receiver end of the tokio mpsc channel; the worker
+/// task on the other end terminates when this stream is dropped
+/// (next blocking-send fails). No additional cleanup required
 /// from the consumer.
 pub struct TokioSampleStream {
     rx: tokio::sync::mpsc::Receiver<Result<Vec<u8>, RtlSdrError>>,
@@ -243,13 +169,7 @@ impl Stream for TokioSampleStream {
 mod tests {
     use super::*;
 
-    // Pin the trait-impl + marker contract documented on
-    // `TokioSampleStream`: it implements `Stream` (so consumers can
-    // use `StreamExt`) and is `Send` (so it can cross `await`
-    // boundaries on multi-threaded executors). If a future
-    // refactor changes the receiver type or adds non-`Send`
-    // state, the assertion fires at compile time before
-    // breaking downstream consumers.
+    // Pin the Stream + Send contract.
     const _: fn() = || {
         fn assert_stream<T: Stream>() {}
         fn assert_send<T: Send>() {}

--- a/crates/sdr-rtlsdr/src/lib.rs
+++ b/crates/sdr-rtlsdr/src/lib.rs
@@ -128,7 +128,8 @@ pub(crate) mod tuner;
 pub(crate) mod usb;
 
 pub use device::{
-    RtlSdrDevice, get_device_count, get_device_name, get_device_usb_strings, get_index_by_serial,
+    DeviceInfo, ReaderIter, RtlSdrDevice, RtlSdrDeviceBuilder, RtlSdrReader, SampleIter,
+    get_device_count, get_device_name, get_device_usb_strings, get_index_by_serial, list_devices,
 };
 pub use error::RtlSdrError;
 /// Tuner family identifier for the IC inside the dongle.

--- a/crates/sdr-rtlsdr/tests/live_streaming.rs
+++ b/crates/sdr-rtlsdr/tests/live_streaming.rs
@@ -1,0 +1,203 @@
+//! Live hardware tests for the streaming surface.
+//!
+//! These tests open a real RTL-SDR dongle and exercise the
+//! `RtlSdrReader` + per-runtime stream pattern end-to-end. They
+//! require:
+//!
+//! - A dongle physically plugged in (any RTL-SDR variant)
+//! - The current user can claim the USB interface (no other
+//!   client holding the device)
+//!
+//! All tests are `#[ignore]` so `cargo test` skips them by
+//! default. Run explicitly with the dongle plugged in:
+//!
+//! ```text
+//! cargo test --features tokio -p sdr-rtlsdr --test live_streaming -- --ignored
+//! ```
+//!
+//! The tests cover the design-pivot validations from #626 round
+//! 4: that the Reader pattern lets the parent retune mid-stream,
+//! that the tokio Stream yields real samples, and that drop
+//! semantics work as documented.
+
+#![cfg(feature = "tokio")]
+
+use std::time::Duration;
+
+use sdr_rtlsdr::RtlSdrDevice;
+
+/// Helper: open device 0 and configure for FM broadcast tuning.
+/// Skips the test by returning `None` if no device is plugged
+/// in — keeps `--ignored` runs informative without a hard panic
+/// when the dongle is unplugged mid-suite.
+fn open_or_skip(test_name: &str) -> Option<RtlSdrDevice> {
+    if sdr_rtlsdr::get_device_count() == 0 {
+        eprintln!("[{test_name}] no RTL-SDR plugged in; skipping");
+        return None;
+    }
+    match RtlSdrDevice::open(0) {
+        Ok(mut dev) => {
+            // Stable, valid-everywhere config: FM broadcast in
+            // most regions, 2.048 Msps. The tests don't care
+            // about signal content — they just need bytes to
+            // flow.
+            dev.set_sample_rate(2_048_000).ok()?;
+            dev.set_center_freq(100_000_000).ok()?;
+            dev.reset_buffer().ok()?;
+            Some(dev)
+        }
+        Err(e) => {
+            eprintln!("[{test_name}] open failed: {e}; skipping");
+            None
+        }
+    }
+}
+
+/// Smoke: tokio stream yields real bytes.
+///
+/// Opens the device, builds a reader, gets a tokio stream, polls
+/// it for 3 buffers, asserts each contains data. End-to-end
+/// validation that the spawn_blocking + mpsc + Stream impl
+/// composition works against real hardware.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs real RTL-SDR hardware — run with --ignored"]
+async fn tokio_stream_yields_bytes() {
+    use futures_util::StreamExt;
+
+    let Some(dev) = open_or_skip("tokio_stream_yields_bytes") else {
+        return;
+    };
+
+    let reader = dev.reader();
+    let stream = reader
+        .stream_samples_tokio(0)
+        .map_err(|boxed| boxed.0)
+        .expect("stream_samples_tokio inside multi_thread runtime");
+
+    let mut stream = Box::pin(stream);
+    for i in 0..3 {
+        let item = tokio::time::timeout(Duration::from_secs(5), stream.next())
+            .await
+            .unwrap_or_else(|_| panic!("buffer {i} timed out"))
+            .unwrap_or_else(|| panic!("stream ended unexpectedly at buffer {i}"))
+            .unwrap_or_else(|e| panic!("read error at buffer {i}: {e}"));
+        assert!(
+            !item.is_empty(),
+            "buffer {i} was empty (expected ≥1 byte from a configured device)"
+        );
+    }
+}
+
+/// The whole point of the `RtlSdrReader` split: the parent
+/// retains `&mut device` for control while the reader streams.
+/// This test pins that contract end-to-end against hardware.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs real RTL-SDR hardware — run with --ignored"]
+async fn parent_can_retune_during_stream() {
+    use futures_util::StreamExt;
+
+    let Some(mut dev) = open_or_skip("parent_can_retune_during_stream") else {
+        return;
+    };
+
+    let reader = dev.reader();
+    let stream = reader
+        .stream_samples_tokio(0)
+        .map_err(|boxed| boxed.0)
+        .expect("stream_samples_tokio inside multi_thread runtime");
+
+    let mut stream = Box::pin(stream);
+
+    // Drain one buffer at the initial freq.
+    let _ = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("first buffer timed out")
+        .expect("stream ended early")
+        .expect("first read failed");
+
+    // Retune the parent while the stream is live. This is the
+    // shared-handle pattern documented on `RtlSdrDevice::reader`
+    // — different USB endpoints, no rusb-level conflict.
+    dev.set_center_freq(99_000_000)
+        .expect("retune during streaming should succeed");
+    dev.set_tuner_gain(150)
+        .expect("gain change during streaming should succeed");
+
+    // Drain another buffer at the new freq — proves the stream
+    // is still alive after the parent's control activity.
+    let buf = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("post-retune buffer timed out")
+        .expect("stream ended after retune")
+        .expect("post-retune read failed");
+    assert!(!buf.is_empty(), "post-retune buffer was empty");
+}
+
+/// Drop semantics: dropping the stream stops the worker
+/// promptly and returns control of the device handle.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs real RTL-SDR hardware — run with --ignored"]
+async fn dropping_stream_stops_worker() {
+    use futures_util::StreamExt;
+
+    let Some(dev) = open_or_skip("dropping_stream_stops_worker") else {
+        return;
+    };
+
+    let reader = dev.reader();
+    let stream = reader
+        .stream_samples_tokio(0)
+        .map_err(|boxed| boxed.0)
+        .expect("stream_samples_tokio inside multi_thread runtime");
+
+    let mut stream = Box::pin(stream);
+
+    // Drain one buffer.
+    let _ = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("buffer timed out")
+        .expect("stream ended early")
+        .expect("read failed");
+
+    // Drop the stream. The worker's `tx.is_closed()` check
+    // (between reads) plus `blocking_send` failure (after each
+    // read) cooperate to exit the worker within one buffer
+    // cadence on the happy path.
+    drop(stream);
+
+    // Give the worker a moment to observe the drop. If the
+    // underlying USB reads were stalled the worst case would
+    // be ~5 s; happy path is much faster. We just need to
+    // confirm that the test process doesn't deadlock.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+}
+
+/// Sync iterator, also via the reader. Validates the
+/// `ReaderIter` `Send` story (move it to a std::thread, drive
+/// it, send results back).
+#[test]
+#[ignore = "needs real RTL-SDR hardware — run with --ignored"]
+fn reader_iter_in_std_thread() {
+    let Some(dev) = open_or_skip("reader_iter_in_std_thread") else {
+        return;
+    };
+
+    let reader = dev.reader();
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    let handle = std::thread::spawn(move || {
+        for chunk in reader.iter_samples(0).take(3) {
+            tx.send(chunk).expect("channel rx should still be alive");
+        }
+    });
+
+    for i in 0..3 {
+        let buf = rx
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap_or_else(|_| panic!("buffer {i} not received"))
+            .unwrap_or_else(|e| panic!("buffer {i} errored: {e}"));
+        assert!(!buf.is_empty(), "buffer {i} was empty");
+    }
+
+    handle.join().expect("worker thread panicked");
+}

--- a/crates/sdr-source-rtlsdr/src/lib.rs
+++ b/crates/sdr-source-rtlsdr/src/lib.rs
@@ -137,6 +137,226 @@ pub struct RtlSdrSource {
     running: Arc<AtomicBool>,
     ring: Option<Arc<UsbRingBuffer>>,
     reader_thread: Option<std::thread::JoinHandle<()>>,
+    /// Most-recent tuner-gain value the controller / UI dispatched
+    /// at us, in tenths of dB. `None` means nothing has been
+    /// dispatched yet — `start()` falls back to the
+    /// out-of-the-box default (`FIRST_TIME_TUNER_GAIN_TENTHS_DB`)
+    /// in that case so a fresh user with no persisted gain still
+    /// gets signal on first Play. Once the UI dispatches its
+    /// persisted value (typically right after the source becomes
+    /// available), this transitions to `Some(...)` and `start()`
+    /// honours that value forever after — fixes the regression
+    /// where source-restart paths (e.g. satellite auto-record
+    /// after a stop+start cycle) silently overrode the user's
+    /// 0 dB choice with the 29.7 dB default and saturated the
+    /// front-end on LNA-equipped chains.
+    last_tuner_gain_tenths_db: Option<i32>,
+}
+
+/// USB reader-thread main loop.
+///
+/// Drives [`sdr_rtlsdr::RtlSdrReader::iter_samples`] forever
+/// (until `cancel` flips false or the iterator yields an error),
+/// pushing each owned `Vec<u8>` into the lock-free SPSC ring for
+/// the DSP thread to consume. Pulled out of the closure inside
+/// `RtlSdrSource::start` so the start path stays under clippy's
+/// too-many-lines threshold.
+fn run_reader_thread(
+    reader: sdr_rtlsdr::RtlSdrReader,
+    ring_writer: &Arc<UsbRingBuffer>,
+    cancel: &Arc<AtomicBool>,
+) {
+    tracing::info!("USB reader thread started (ring slots={RING_SLOTS})");
+
+    // First-buffer stats: sanity check that real USB data is
+    // flowing (not all zeros, not all 127) and what its rough
+    // amplitude looks like. Periodic heartbeat: confirms the
+    // stream stays alive at the expected throughput.
+    let mut buffers_seen = 0u32;
+    let mut bytes_total: u64 = 0;
+    let mut last_stats_log = std::time::Instant::now();
+
+    // Drive `reader.iter_samples(RAW_BUF_SIZE)` — yields owned
+    // `Vec<u8>` per USB bulk transfer. One allocation per yield
+    // (~15/sec at 2 Msps × 256 KB), negligible at modern
+    // allocator speeds. A zero-alloc
+    // `iter_samples_into(&mut Vec<u8>)` variant is a future
+    // optimisation if the per-yield allocation ever shows up in
+    // profiles.
+    for chunk in reader.iter_samples(RAW_BUF_SIZE) {
+        if !cancel.load(Ordering::Acquire) {
+            break;
+        }
+
+        let buf = match chunk {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!("USB reader error: {e}");
+                ring_writer.error.store(true, Ordering::Release);
+                break;
+            }
+        };
+        if buf.is_empty() {
+            continue;
+        }
+
+        buffers_seen = buffers_seen.saturating_add(1);
+        bytes_total = bytes_total.saturating_add(buf.len() as u64);
+
+        if buffers_seen == 1 {
+            log_buffer_stats(&buf, "first USB buffer received");
+        }
+        if last_stats_log.elapsed() >= Duration::from_secs(5) {
+            let mb = bytes_total as f64 / 1_048_576.0;
+            tracing::debug!(
+                buffers_seen,
+                mb_total = format!("{mb:.2}"),
+                "USB reader thread heartbeat"
+            );
+            // Amplitude stats every 5 sec (info level so they're
+            // visible without bumping log verbosity). Lets us
+            // see how the IQ-byte distribution changes after
+            // bias-T toggles, gain changes, frequency retunes,
+            // and during a satellite pass — captures the
+            // saturation / quiet-noise / real-signal shapes
+            // that the previous "log only the first buffer"
+            // approach missed.
+            log_buffer_stats(&buf, "periodic USB buffer stats");
+            last_stats_log = std::time::Instant::now();
+        }
+
+        // Find an empty slot; yield briefly if the ring is full
+        // (DSP can't keep up). The pre-iter-call cancel check
+        // above bounds worst-case shutdown latency to one
+        // in-flight USB read (~65 ms typical, up to one read
+        // timeout on stalled hardware).
+        let idx = ring_writer.write_idx.load(Ordering::Relaxed) % ring_writer.slot_count;
+        let slot = &ring_writer.slots[idx];
+
+        while slot.state.load(Ordering::Acquire) != 0 {
+            if !cancel.load(Ordering::Acquire) {
+                tracing::debug!("USB reader thread stopping (ring-full wait)");
+                return;
+            }
+            std::thread::yield_now();
+        }
+
+        let Ok(mut data) = slot.data.lock() else {
+            tracing::error!("ring slot mutex poisoned");
+            ring_writer.error.store(true, Ordering::Release);
+            break;
+        };
+
+        let n = buf.len();
+        data[..n].copy_from_slice(&buf);
+        drop(data);
+        slot.len.store(n, Ordering::Relaxed);
+        slot.state.store(1, Ordering::Release);
+        ring_writer.write_idx.fetch_add(1, Ordering::Relaxed);
+    }
+    tracing::debug!("USB reader thread stopped");
+}
+
+/// Histogram-style amplitude stats for one USB buffer.
+///
+/// The reader-thread `log_buffer_stats` calls below are the
+/// diagnostic backbone for LNA / saturation / signal-level
+/// debugging — three info-level lines per source-start (first
+/// buffer + every 5 sec) is the right cadence to spot
+/// regressions without spamming the log. Examples of what these
+/// stats catch:
+///
+/// - `mean` significantly off from 127.5 → tuner DC offset (rare)
+/// - `frac_at_0` or `frac_at_255` > 1% → ADC clipping / front-
+///   end saturation (gain too high)
+/// - `std_dev` < 1 → near-zero signal at the antenna (LNA dead,
+///   antenna disconnected, SAW filter blocking the band)
+/// - `std_dev` 3-10 → healthy noise floor with proper LNA gain
+/// - `std_dev` > 30 → strong in-band signal OR full clipping
+///
+/// Stats are computed in a single pass and returned so the
+/// caller can format the log line with a context-specific
+/// event name. Per the #626 RtlSdrReader-split smoke test,
+/// where the periodic `log_buffer_stats` lines were the
+/// definitive proof that bias-T + LNA + 0 dB tuner gain was
+/// producing healthy noise (std_dev 4.65, no rail clipping)
+/// rather than the saturation we'd suspected from waterfall
+/// appearance alone.
+struct BufferStats {
+    len: usize,
+    min: u8,
+    max: u8,
+    mean: f64,
+    std_dev: f64,
+    frac_at_0: f64,
+    frac_at_255: f64,
+}
+
+fn compute_buffer_stats(buf: &[u8]) -> Option<BufferStats> {
+    let len = buf.len();
+    if len == 0 {
+        return None;
+    }
+    let mut min = 255u8;
+    let mut max = 0u8;
+    let mut sum: u64 = 0;
+    let mut zeros: u64 = 0;
+    let mut peaks: u64 = 0;
+    for &b in buf {
+        if b < min {
+            min = b;
+        }
+        if b > max {
+            max = b;
+        }
+        sum += b as u64;
+        if b == 0 {
+            zeros += 1;
+        }
+        if b == 255 {
+            peaks += 1;
+        }
+    }
+    let mean = sum as f64 / len as f64;
+    let var: f64 = buf
+        .iter()
+        .map(|&b| {
+            let d = b as f64 - mean;
+            d * d
+        })
+        .sum::<f64>()
+        / len as f64;
+    Some(BufferStats {
+        len,
+        min,
+        max,
+        mean,
+        std_dev: var.sqrt(),
+        frac_at_0: zeros as f64 / len as f64,
+        frac_at_255: peaks as f64 / len as f64,
+    })
+}
+
+/// Log the buffer-stats summary at info level with a caller-
+/// supplied event message. Used both for the one-time first-
+/// buffer log AND the periodic post-toggle heartbeat so we can
+/// see how the IQ amplitude shifts after gain / bias-T /
+/// frequency changes. Per the bias-T-saturation diagnosis
+/// during the #626 RtlSdrReader-split smoke test.
+fn log_buffer_stats(buf: &[u8], event: &'static str) {
+    let Some(stats) = compute_buffer_stats(buf) else {
+        return;
+    };
+    tracing::info!(
+        len = stats.len,
+        min = stats.min,
+        max = stats.max,
+        mean = format!("{:.2}", stats.mean),
+        std_dev = format!("{:.2}", stats.std_dev),
+        frac_at_0 = format!("{:.4}", stats.frac_at_0),
+        frac_at_255 = format!("{:.4}", stats.frac_at_255),
+        event,
+    );
 }
 
 impl RtlSdrSource {
@@ -150,6 +370,7 @@ impl RtlSdrSource {
             running: Arc::new(AtomicBool::new(false)),
             ring: None,
             reader_thread: None,
+            last_tuner_gain_tenths_db: None,
         }
     }
 
@@ -175,18 +396,61 @@ impl Source for RtlSdrSource {
     }
 
     fn start(&mut self) -> Result<(), SourceError> {
-        // R820T supports 29.7 dB exactly (gain-table index 17).
-        // See the supported-gains list in
-        // `crates/sdr-rtlsdr/src/tuner/r82xx/mod.rs` if porting
-        // to a different tuner family (E4000 / FC0012 / FC0013
-        // / FC2580 have different step tables; the post-open
-        // default-gain call below would need to be tuner-
-        // adaptive then. Per issue #407 + PR #418 smoke test
-        // feedback ("AGC off by default").
-        const DEFAULT_TUNER_GAIN_TENTHS_DB: i32 = 297;
+        // First-time-user fallback gain. R820T supports 29.7 dB
+        // exactly (gain-table index 17) — picked as a mid-range
+        // value that produces audible signal on broadcast FM
+        // without amplifier saturation for the bare-dongle (no
+        // LNA) case. Used only when the controller / UI hasn't
+        // dispatched a gain yet (`last_tuner_gain_tenths_db ==
+        // None`) — once the user's persisted setting flows in,
+        // `start()` honours that instead so the LNA-equipped
+        // setup the user explicitly configured (e.g. 0 dB tuner
+        // + SAW LNA = ~28 dB total) survives source restarts.
+        // Per issue #407 + PR #418 smoke test feedback
+        // ("AGC off by default") + the LNA-saturation bug found
+        // during the #626 RtlSdrReader-split smoke test.
+        const FIRST_TIME_TUNER_GAIN_TENTHS_DB: i32 = 297;
+        let initial_gain_tenths_db = self
+            .last_tuner_gain_tenths_db
+            .unwrap_or(FIRST_TIME_TUNER_GAIN_TENTHS_DB);
+
+        // Per-start diagnostic: this single log line lets us reconstruct
+        // the source's intent on every fresh open from a session log.
+        // Most LNA-related issues we've debugged (saturation, silence,
+        // wrong-band noise) come down to a mismatch between what the
+        // user thinks the gain / mode is and what the source actually
+        // applied. Per #626 RtlSdrReader-split smoke test debugging.
+        tracing::info!(
+            device_index = self.device_index,
+            sample_rate = self.sample_rate,
+            frequency_hz = self.frequency,
+            initial_gain_tenths_db,
+            initial_gain_db = initial_gain_tenths_db as f64 / 10.0,
+            last_dispatched_gain = ?self.last_tuner_gain_tenths_db,
+            ring_slots = RING_SLOTS,
+            buffer_bytes = RAW_BUF_SIZE,
+            "RtlSdrSource::start: opening device with config"
+        );
 
         let mut device = RtlSdrDevice::open(self.device_index)
             .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
+
+        // Capture device identity + tuner gain ladder right after
+        // open. Logging the gain table tells us which tuner family
+        // was probed (R820T vs E4000 vs FC0012/13/2580 vs FC2580
+        // each have different step counts), and the USB strings
+        // confirm which physical dongle the workflow opened —
+        // important when more than one is plugged in or after a
+        // hot-plug. Per #626 RtlSdrReader-split smoke test
+        // debugging.
+        tracing::info!(
+            tuner_type = ?device.tuner_type(),
+            manufacturer = device.manufacturer(),
+            product = device.product(),
+            serial = device.serial(),
+            gain_table_tenths_db = ?device.tuner_gains(),
+            "RtlSdrSource::start: device opened"
+        );
 
         device
             .set_sample_rate(self.sample_rate as u32)
@@ -234,7 +498,7 @@ impl Source for RtlSdrSource {
         device
             .set_tuner_gain_mode(true)
             .map_err(|e| SourceError::OpenFailed(e.to_string()))?;
-        if let Err(e) = device.set_tuner_gain(DEFAULT_TUNER_GAIN_TENTHS_DB) {
+        if let Err(e) = device.set_tuner_gain(initial_gain_tenths_db) {
             // Non-fatal: the gain-mode write above already put
             // the tuner in a valid manual state. If the
             // mid-range default fails (unexpected tuner
@@ -251,53 +515,22 @@ impl Source for RtlSdrSource {
         self.running.store(true, Ordering::Release);
 
         // Create the ring buffer and spawn the USB reader thread.
+        // The reader uses sdr-rtlsdr's `RtlSdrReader` —
+        // a streaming-focused handle acquired cheaply from the
+        // device, holding its own `Arc<DeviceHandle>` clone — so
+        // the parent thread retains `self.device = Some(device)`
+        // for control methods (`set_center_freq`, etc.) that the
+        // satellite auto-record + UI tune both call mid-stream
+        // without restarting the source. Per #626 round 4
+        // (RtlSdrReader split).
         let ring = Arc::new(UsbRingBuffer::new(RING_SLOTS, RAW_BUF_SIZE));
         let ring_writer = Arc::clone(&ring);
         let cancel = Arc::clone(&self.running);
-        let handle = device.usb_handle();
+        let reader = device.reader();
 
         let thread = std::thread::Builder::new()
             .name("usb-reader".into())
-            .spawn(move || {
-                tracing::info!("USB reader thread started (ring slots={RING_SLOTS})");
-                let timeout = Duration::from_secs(1);
-
-                while cancel.load(Ordering::Acquire) {
-                    let idx =
-                        ring_writer.write_idx.load(Ordering::Relaxed) % ring_writer.slot_count;
-                    let slot = &ring_writer.slots[idx];
-
-                    // Wait for slot to be empty.
-                    if slot.state.load(Ordering::Acquire) != 0 {
-                        // Ring full — DSP can't keep up. Yield briefly.
-                        std::thread::yield_now();
-                        continue;
-                    }
-
-                    // Lock the slot's buffer for writing. Never contended because
-                    // the state flag ensures reader and writer don't overlap.
-                    let Ok(mut data) = slot.data.lock() else {
-                        tracing::error!("ring slot mutex poisoned");
-                        ring_writer.error.store(true, Ordering::Release);
-                        break;
-                    };
-
-                    match handle.read_bulk(RtlSdrDevice::BULK_ENDPOINT, &mut data, timeout) {
-                        Ok(n) if n > 0 => {
-                            slot.len.store(n, Ordering::Relaxed);
-                            slot.state.store(1, Ordering::Release); // mark full
-                            ring_writer.write_idx.fetch_add(1, Ordering::Relaxed);
-                        }
-                        Ok(_) | Err(rusb::Error::Timeout) => {}
-                        Err(e) => {
-                            tracing::warn!("USB reader error: {e}");
-                            ring_writer.error.store(true, Ordering::Release);
-                            break;
-                        }
-                    }
-                }
-                tracing::debug!("USB reader thread stopped");
-            })
+            .spawn(move || run_reader_thread(reader, &ring_writer, &cancel))
             .map_err(|e| SourceError::OpenFailed(format!("failed to spawn USB reader: {e}")))?;
 
         self.ring = Some(ring);
@@ -393,6 +626,35 @@ impl Source for RtlSdrSource {
     }
 
     fn set_gain(&mut self, gain_tenths: i32) -> Result<(), SourceError> {
+        // Remember the dispatched value EVEN IF the device isn't
+        // currently open, so a later `start()` call (e.g. user
+        // clicked Play after dispatching gain at app launch, or
+        // satellite auto-record restarted the source) reapplies
+        // the user's choice rather than the first-time default.
+        // Per the regression fix in the #626 RtlSdrReader-split
+        // smoke test where a 0 dB user setting was silently
+        // overridden by 29.7 dB on every start, saturating the
+        // front-end on LNA-equipped chains.
+        // Diagnostic info-level log: gain dispatches are
+        // user-paced (UI slider drag, persisted-settings replay
+        // on source open, satellite auto-record paths) so
+        // logging each one at info doesn't add meaningful noise
+        // and is invaluable when debugging
+        // saturation / silent-recording issues. The
+        // `device_open` field disambiguates "dispatched and
+        // applied to hardware" from "dispatched but stored in
+        // `last_tuner_gain_tenths_db` for the next open" —
+        // critical for the LNA-saturation-debug workflow that
+        // motivated this log. Per #626 RtlSdrReader-split smoke
+        // test debugging.
+        let device_open = self.device.is_some();
+        tracing::info!(
+            gain_tenths_db = gain_tenths,
+            gain_db = gain_tenths as f64 / 10.0,
+            device_open,
+            "RtlSdrSource::set_gain dispatch"
+        );
+        self.last_tuner_gain_tenths_db = Some(gain_tenths);
         if let Some(device) = &mut self.device {
             device
                 .set_tuner_gain(gain_tenths)
@@ -402,6 +664,16 @@ impl Source for RtlSdrSource {
     }
 
     fn set_gain_mode(&mut self, manual: bool) -> Result<(), SourceError> {
+        // Diagnostic info-level log — user-paced (fires only on
+        // a UI AGC-toggle flip or persisted-settings replay),
+        // so logging each one at info doesn't add meaningful
+        // noise. Pairs with `set_gain dispatch`: when AGC is
+        // on the manual gain is silently ignored by librtlsdr,
+        // which is a known class of bug — having both events
+        // on the same log timeline makes that diagnosis
+        // straightforward. Per #626 smoke test.
+        let device_open = self.device.is_some();
+        tracing::info!(manual, device_open, "RtlSdrSource::set_gain_mode dispatch");
         if let Some(device) = &mut self.device {
             device
                 .set_tuner_gain_mode(manual)
@@ -436,6 +708,17 @@ impl Source for RtlSdrSource {
         // every other source type (file, network) ignores the
         // command — only the live RTL-SDR USB path actually
         // toggles hardware.
+        // Diagnostic info-level log — user-paced (UI bias-T
+        // checkbox flip), so one info line per toggle is fine.
+        // Critical for LNA-debug workflows where the
+        // observable state of the dongle (waterfall noise floor,
+        // periodic-buffer-stats std_dev) only makes sense in the
+        // context of the bias-T timeline. Per #626 smoke test
+        // where bias-T off → std_dev 0.48, bias-T on → std_dev
+        // 4.65 was THE smoking-gun confirmation that the LNA was
+        // wired correctly.
+        let device_open = self.device.is_some();
+        tracing::info!(enabled, device_open, "RtlSdrSource::set_bias_tee dispatch");
         if let Some(device) = &mut self.device {
             device
                 .set_bias_tee(enabled)


### PR DESCRIPTION
## Summary

The design pivot from the round-3 smoke test, plus a gain-override regression fix and the diagnostic tracing that helped us validate everything against real hardware. Single PR by user request — the pieces compose cleanly and validating them in isolation would have meant breaking the app's mid-stream-retune use case for one of the rounds.

## What's in here

### 1. \`RtlSdrReader\` — streaming-focused handle (#626 round 4)

Round 3a/3b's stream methods consumed \`self\` on \`RtlSdrDevice\`, which conflicted with our app's mid-stream retune pattern (satellite auto-record + UI tune dispatches). The fix: a separate \`RtlSdrReader\` handle acquired cheaply via \`device.reader()\` that owns an \`Arc<DeviceHandle>\` clone. Streaming consumes the reader; the parent retains the device for control. Bulk reads on USB endpoint 0x81 don't conflict with control transfers on endpoint 0x00 — same shared-handle pattern librtlsdr uses. Documented honestly: libusb's docs don't formally guarantee concurrent bulk + control safety; this is a practical convention.

\`stream_samples_tokio\` / \`_async_std\` / \`_smol\` migrated from device to reader. Same shape, same Result<_, Box<(Err, Self)>> preserve-on-error pattern. Plus \`reader.iter_samples()\` returning a sendable \`ReaderIter\` (always available, no features).

### 2. Gain-override regression fix

\`RtlSdrSource::start()\` was hardcoding \`set_tuner_gain(297)\` (29.7 dB) on every device open. Combined with an LNA-equipped chain it pushed total gain to ~58 dB and saturated the R820T2 front-end on every source restart, silently overriding the user's persisted 0 dB setting. The smoke test's first-buffer stats showed std_dev=36.56 with 1.4% of bytes at each ADC rail — exactly what saturation looks like.

Fix: source remembers the most-recent dispatched gain in \`last_tuner_gain_tenths_db\`. \`start()\` honours it when set, falling back to the 29.7 dB first-time default only when no value has been dispatched.

### 3. App wire-up via \`reader.iter_samples()\`

\`sdr-source-rtlsdr\`'s reader thread now uses \`reader.iter_samples(RAW_BUF_SIZE)\` instead of the manual \`handle.read_bulk\` loop. Threading model unchanged. One alloc per ~65 ms, negligible.

### 4. Diagnostic tracing

Six info-level log sites covering: source-start config, every gain / gain-mode / bias-T dispatch, the first USB buffer's amplitude histogram, and periodic 5-second buffer-stats. Each call site documents why it's there. The periodic stats catch:

- \`mean\` ≠ 127.5 → tuner DC offset
- \`frac_at_0\` / \`frac_at_255\` > 1% → ADC clipping
- \`std_dev\` < 1 → near-zero signal (LNA dead, antenna off)
- \`std_dev\` 3-10 → healthy noise floor with LNA gain
- \`std_dev\` > 30 → strong signal OR full clipping

The periodic-stats line was THE smoking-gun proving bias-T + SAW LNA + 0 dB tuner produces healthy noise (std_dev 4.65, zero rail clipping) rather than the saturation we'd suspected from waterfall appearance alone.

## Live hardware tests

\`crates/sdr-rtlsdr/tests/live_streaming.rs\` — four \`#[ignore]\` tests against a real dongle. All four pass in 3.78s end-to-end:

- \`tokio_stream_yields_bytes\`
- \`parent_can_retune_during_stream\` ← the design hypothesis
- \`dropping_stream_stops_worker\`
- \`reader_iter_in_std_thread\`

\`\`\`bash
cargo test --features tokio -p sdr-rtlsdr --test live_streaming -- --ignored
\`\`\`

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo build -p sdr-rtlsdr --features X\` for each feature combo (tokio, async-std, smol, all-three)
- [x] \`cargo clippy --all-targets --workspace -- -D warnings\` clean
- [x] \`cargo test -p sdr-rtlsdr --features X --lib\` 102 passed for each feature combo
- [x] \`cargo test --workspace --lib\` 418 passed
- [x] \`cargo check --workspace --locked\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps -p sdr-rtlsdr --features X\` clean for each feature combo
- [x] **Live: 4/4 hardware integration tests pass against real dongle**
- [x] **Smoke: app launches, source start logs config + tuner identity, gain dispatches honour user value, periodic stats show healthy noise floor with LNA on, bias-T toggle drives std_dev as expected (0.48 off → 4.65 on)**

## Out of scope

- Wiring \`stream_samples_tokio\` into the app's source layer (the iterator path is the right fit for the current sync pipeline; switching to the async stream would be a bigger pipeline-level discussion).
- libusb-cancel for proper in-flight drop semantics — tracked as #633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `RtlSdrReader` for dedicated streaming sessions, enabling concurrent device control while streaming is active.
  * Added synchronous sample iteration support for streaming workflows.

* **Improvements**
  * Streaming methods now operate on reader objects, providing better separation between streaming and device control operations.
  * Enhanced tuner gain state tracking to preserve user settings across device open/close cycles.

* **Tests**
  * Added live integration tests validating real hardware streaming behavior, concurrent control, and proper worker cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->