### PR TITLE
ISS catalog: 437.550 MHz UHF for ARISS Series 32 (#638)

### DIFF
--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -244,9 +244,10 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
     // METEOR-M2 4 (NORAD 61024) deliberately omitted — launched 2024,
     // failed shortly after, no usable TLE on Celestrak (404 from the
     // GP API). Per #506.
-    // ISS SSTV — epic #472. 145.800 MHz is the primary downlink for
-    // SSTV transmission events during ARISS events; ISS rides wide-FM
-    // so the standard NFM demod path captures it cleanly.
+    // ISS SSTV — epic #472. Currently 437.550 MHz UHF (ARISS Series
+    // 31+, April 2026 onward, see #638); the catalog tracks the live
+    // operational frequency via `ISS_SSTV_DOWNLINK_HZ`. ISS rides
+    // wide-FM so the standard NFM demod path captures it cleanly.
     // `imaging_protocol: Some(Sstv)` enrolls ISS in the auto-record
     // flow: at AOS the recorder opens the SSTV viewer and signals the
     // DSP to attach the `SstvDecoder`; at LOS the per-pass directory

--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -44,14 +44,11 @@ pub use tle_cache::{TleCache, TleCacheError, celestrak_gp_url};
 /// everywhere consistently.
 pub const DEFAULT_SATELLITE_BANDWIDTH_HZ: u32 = 38_000;
 
-/// VHF imaging-band lower bound (Hz). Every catalog satellite's
-/// downlink must land in [`IMAGING_BAND_MIN_HZ`,
-/// [`IMAGING_BAND_MAX_HZ`]] — checked at compile time-ish via the
-/// unit test below. Captures the standard 137 MHz weather-sat band
-/// plus the 145.8 MHz ISS SSTV / amateur-satellite slot.
-pub const IMAGING_BAND_MIN_HZ: u64 = 137_000_000;
-/// VHF imaging-band upper bound (Hz). See [`IMAGING_BAND_MIN_HZ`].
-pub const IMAGING_BAND_MAX_HZ: u64 = 148_000_000;
+// Per-protocol allowed-band lookup lives on `ImagingProtocol::allowed_bands_hz`
+// below — APT/LRPT pin to 137-138 MHz; SSTV accepts both VHF 2m (145.8 legacy)
+// and UHF 70cm (437.550 current). The previous single-band IMAGING_BAND_MIN_HZ /
+// MAX_HZ constants couldn't represent SSTV's two-band reality once ARISS migrated
+// to UHF (Series 31+ events on 437.550 MHz, see #638).
 
 /// Imaging protocol the receiver should use for a given catalog
 /// satellite. Drives the auto-record dispatch in
@@ -73,11 +70,39 @@ pub enum ImagingProtocol {
     /// on 137 MHz). Decoded by `sdr_dsp::lrpt::LrptDemod` +
     /// `sdr_lrpt::LrptPipeline`. Shipped in epic #469.
     Lrpt,
-    /// Slow-Scan Television (FM audio with PLL pixel decode on
-    /// 145.800 MHz). Used during ARISS SSTV events from the ISS.
-    /// Decoded by the `slowrx` crate via `sdr_radio::sstv_image`.
-    /// Shipped in epic #472.
+    /// Slow-Scan Television (FM audio with PLL pixel decode). Used
+    /// during ARISS SSTV events from the ISS. Originally on the 2m
+    /// amateur slot at 145.800 MHz; ARISS migrated to UHF 70cm at
+    /// 437.550 MHz starting with Series 31 (April 2026). The
+    /// catalog tracks the current operational frequency. Decoded by
+    /// the `slowrx` crate via `sdr_radio::sstv_image`. Shipped in
+    /// epic #472.
     Sstv,
+}
+
+impl ImagingProtocol {
+    /// Frequency bands (Hz) permitted for this protocol's downlink.
+    ///
+    /// Returns one or more `(low, high)` inclusive ranges. Used by
+    /// the catalog assertion to reject typoed or wrong-band
+    /// frequencies (e.g. forgot to convert MHz → Hz, pasted a
+    /// different satellite's value, used a band the protocol can't
+    /// be transmitted on).
+    ///
+    /// - **APT** (NOAA): 137-138 MHz weather-sat slot only.
+    /// - **LRPT** (Meteor-M): 137-138 MHz, same band as APT.
+    /// - **SSTV** (ARISS): both the legacy 2m amateur slot
+    ///   (144-148 MHz, historically 145.800) and the current UHF 70cm
+    ///   amateur slot (430-440 MHz, currently 437.550). Both are
+    ///   valid; the active frequency is determined by the ARISS
+    ///   event series.
+    #[must_use]
+    pub const fn allowed_bands_hz(&self) -> &'static [(u64, u64)] {
+        match self {
+            Self::Apt | Self::Lrpt => &[(137_000_000, 138_000_000)],
+            Self::Sstv => &[(144_000_000, 148_000_000), (430_000_000, 440_000_000)],
+        }
+    }
 }
 
 /// A satellite the user-facing scheduler ships with by default. The list
@@ -93,7 +118,8 @@ pub struct KnownSatellite {
     pub norad_id: u32,
     /// Downlink centre frequency, Hz. Targets the satellite's primary
     /// imaging signal — APT (137.x MHz) for NOAA, LRPT (137.x MHz) for
-    /// Meteor-M, SSTV (145.8 MHz) for ISS during transmission events.
+    /// Meteor-M, SSTV (currently 437.550 MHz UHF) for ISS during ARISS
+    /// transmission events.
     /// Consumed by the Satellites panel's pass-row display and (in
     /// the upcoming #482b work) by the "tune to this satellite" play
     /// button.
@@ -202,7 +228,13 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
     KnownSatellite {
         name: "ISS (ZARYA)",
         norad_id: 25_544,
-        downlink_hz: 145_800_000,
+        // 437.550 MHz is the current ARISS SSTV operational frequency.
+        // ARISS migrated SSTV from the legacy 2m slot (145.800 MHz)
+        // to UHF 70cm starting with Series 31 (April 2026), and Series
+        // 32 (May 8-12, 2026) is also on 437.550. See #638.
+        // Note: voice contacts and packet APRS still use 145.800/145.825;
+        // this catalog entry is specifically for SSTV auto-record.
+        downlink_hz: 437_550_000,
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
         imaging_protocol: Some(ImagingProtocol::Sstv),
@@ -251,23 +283,69 @@ mod tests {
     }
 
     #[test]
-    fn known_satellites_have_imaging_band_downlinks() {
-        // All catalog entries today are weather / imaging / SSTV
-        // satellites that downlink in the 137-148 MHz VHF window.
-        // Pin the range so a future entry with a wildly-wrong freq
-        // (e.g. forgot to convert MHz → Hz, or pasted a different
-        // satellite's value) trips this test rather than reaching
-        // the user as a misconfigured tune button.
+    fn known_satellites_have_protocol_compatible_downlinks() {
+        // Catalog entries with an `imaging_protocol` must downlink
+        // in one of that protocol's allowed bands. Catches typos
+        // (forgot MHz → Hz), pasted-from-another-satellite values,
+        // or accidentally putting an APT satellite on a UHF amateur
+        // frequency. Entries with `imaging_protocol: None` are
+        // skipped — the band rule only applies once a protocol is
+        // committed to.
         for s in KNOWN_SATELLITES {
+            let Some(proto) = s.imaging_protocol else {
+                continue;
+            };
+            let in_band = proto
+                .allowed_bands_hz()
+                .iter()
+                .any(|&(lo, hi)| (lo..=hi).contains(&s.downlink_hz));
             assert!(
-                (IMAGING_BAND_MIN_HZ..=IMAGING_BAND_MAX_HZ).contains(&s.downlink_hz),
-                "{} downlink {} Hz is outside the {}-{} Hz VHF imaging band",
+                in_band,
+                "{} ({:?}) downlink {} Hz is outside any band allowed for that protocol: {:?}",
                 s.name,
+                proto,
                 s.downlink_hz,
-                IMAGING_BAND_MIN_HZ,
-                IMAGING_BAND_MAX_HZ,
+                proto.allowed_bands_hz(),
             );
         }
+    }
+
+    #[test]
+    fn imaging_protocol_allowed_bands_are_well_formed() {
+        // Pin the per-protocol allowed-band semantics so a future
+        // edit of the lookup table can't silently break the band
+        // assertion above. Each band must have low <= high, and
+        // the union must be non-empty for every variant.
+        for proto in [
+            ImagingProtocol::Apt,
+            ImagingProtocol::Lrpt,
+            ImagingProtocol::Sstv,
+        ] {
+            let bands = proto.allowed_bands_hz();
+            assert!(!bands.is_empty(), "{proto:?} has empty allowed-band list",);
+            for &(lo, hi) in bands {
+                assert!(lo <= hi, "{proto:?} has malformed band ({lo} > {hi})",);
+            }
+        }
+    }
+
+    #[test]
+    fn iss_catalog_targets_current_ariss_uhf_frequency() {
+        // Pin the ISS catalog entry to the active ARISS SSTV
+        // frequency. ARISS migrated from VHF 145.800 to UHF 437.550
+        // starting Series 31 (April 2026); Series 32 (May 8-12,
+        // 2026) is also on 437.550. If a future series moves the
+        // frequency again, this test FAILS until the catalog is
+        // bumped — which is the desired behavior, since stale
+        // catalog entries record dead air during the event.
+        let iss = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.name.contains("ISS"))
+            .expect("ISS in catalog");
+        assert_eq!(
+            iss.downlink_hz, 437_550_000,
+            "ISS catalog entry should be 437.550 MHz (ARISS Series 31+ UHF)",
+        );
     }
 
     #[test]

--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -48,7 +48,35 @@ pub const DEFAULT_SATELLITE_BANDWIDTH_HZ: u32 = 38_000;
 // below — APT/LRPT pin to 137-138 MHz; SSTV accepts both VHF 2m (145.8 legacy)
 // and UHF 70cm (437.550 current). The previous single-band IMAGING_BAND_MIN_HZ /
 // MAX_HZ constants couldn't represent SSTV's two-band reality once ARISS migrated
-// to UHF (Series 31+ events on 437.550 MHz, see #638).
+// to UHF (Series 31+ events on 437.550 MHz, see #638). The constants below are
+// the single source of truth — `allowed_bands_hz()`, the catalog's ISS entry,
+// and the test that pins the operational frequency all reference them rather
+// than re-pasting the literals.
+
+/// 137 MHz weather-satellite VHF slot (Hz, inclusive). NOAA APT and
+/// Meteor-M LRPT both downlink in this band.
+pub const WEATHER_SAT_137MHZ_BAND_HZ: (u64, u64) = (137_000_000, 138_000_000);
+
+/// 2 m amateur band (Hz, inclusive) used historically for ARISS SSTV
+/// at 145.800 MHz before the UHF migration (Series 31+, April 2026).
+/// Kept in the SSTV allowed-bands list so the catalog can flip back
+/// without code changes if a future ARISS series returns to 2 m.
+pub const SSTV_VHF_2M_BAND_HZ: (u64, u64) = (144_000_000, 148_000_000);
+
+/// 70 cm amateur band (Hz, inclusive). Current ARISS SSTV operating
+/// band — Series 31 (April 2026) and Series 32 (May 2026) are both on
+/// 437.550 MHz within this range.
+pub const SSTV_UHF_70CM_BAND_HZ: (u64, u64) = (430_000_000, 440_000_000);
+
+/// Current ARISS SSTV operational downlink (Hz). 437.550 MHz UHF
+/// 70 cm. Pinned by `iss_catalog_targets_current_ariss_uhf_frequency`
+/// — if a future ARISS series moves the frequency, the test FAILS
+/// until this constant + the catalog entry are bumped together.
+pub const ISS_SSTV_DOWNLINK_HZ: u64 = 437_550_000;
+
+/// NORAD catalog id for the ISS / ZARYA. Used both by the catalog
+/// entry and by tests that look the entry up.
+pub const ISS_NORAD_ID: u32 = 25_544;
 
 /// Imaging protocol the receiver should use for a given catalog
 /// satellite. Drives the auto-record dispatch in
@@ -99,8 +127,8 @@ impl ImagingProtocol {
     #[must_use]
     pub const fn allowed_bands_hz(&self) -> &'static [(u64, u64)] {
         match self {
-            Self::Apt | Self::Lrpt => &[(137_000_000, 138_000_000)],
-            Self::Sstv => &[(144_000_000, 148_000_000), (430_000_000, 440_000_000)],
+            Self::Apt | Self::Lrpt => &[WEATHER_SAT_137MHZ_BAND_HZ],
+            Self::Sstv => &[SSTV_VHF_2M_BAND_HZ, SSTV_UHF_70CM_BAND_HZ],
         }
     }
 }
@@ -227,14 +255,13 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
     // audible unlike LRPT's silent QPSK). Shipped in epic #472.
     KnownSatellite {
         name: "ISS (ZARYA)",
-        norad_id: 25_544,
-        // 437.550 MHz is the current ARISS SSTV operational frequency.
+        norad_id: ISS_NORAD_ID,
         // ARISS migrated SSTV from the legacy 2m slot (145.800 MHz)
         // to UHF 70cm starting with Series 31 (April 2026), and Series
         // 32 (May 8-12, 2026) is also on 437.550. See #638.
         // Note: voice contacts and packet APRS still use 145.800/145.825;
         // this catalog entry is specifically for SSTV auto-record.
-        downlink_hz: 437_550_000,
+        downlink_hz: ISS_SSTV_DOWNLINK_HZ,
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
         imaging_protocol: Some(ImagingProtocol::Sstv),
@@ -322,9 +349,9 @@ mod tests {
             ImagingProtocol::Sstv,
         ] {
             let bands = proto.allowed_bands_hz();
-            assert!(!bands.is_empty(), "{proto:?} has empty allowed-band list",);
+            assert!(!bands.is_empty(), "{proto:?} has empty allowed-band list");
             for &(lo, hi) in bands {
-                assert!(lo <= hi, "{proto:?} has malformed band ({lo} > {hi})",);
+                assert!(lo <= hi, "{proto:?} has malformed band ({lo} > {hi})");
             }
         }
     }
@@ -338,12 +365,16 @@ mod tests {
         // frequency again, this test FAILS until the catalog is
         // bumped — which is the desired behavior, since stale
         // catalog entries record dead air during the event.
+        // Lookup is by NORAD id (25544) rather than name-substring
+        // so a future catalog rename of the ISS display name (e.g.
+        // dropping "ZARYA") doesn't silently make this assertion
+        // skip the entry.
         let iss = KNOWN_SATELLITES
             .iter()
-            .find(|s| s.name.contains("ISS"))
-            .expect("ISS in catalog");
+            .find(|s| s.norad_id == ISS_NORAD_ID)
+            .expect("ISS catalog entry (NORAD 25544)");
         assert_eq!(
-            iss.downlink_hz, 437_550_000,
+            iss.downlink_hz, ISS_SSTV_DOWNLINK_HZ,
             "ISS catalog entry should be 437.550 MHz (ARISS Series 31+ UHF)",
         );
     }
@@ -393,8 +424,8 @@ mod tests {
         // end-to-end, so the catalog entry flips from None to Some(Sstv).
         let iss = KNOWN_SATELLITES
             .iter()
-            .find(|s| s.name.contains("ISS"))
-            .expect("ISS in catalog");
+            .find(|s| s.norad_id == ISS_NORAD_ID)
+            .expect("ISS catalog entry (NORAD 25544)");
         assert_eq!(
             iss.imaging_protocol,
             Some(ImagingProtocol::Sstv),

--- a/docs/guides/sstv-reception.md
+++ b/docs/guides/sstv-reception.md
@@ -77,8 +77,8 @@ relying on any one.
 
 ## Antenna
 
-ARISS SSTV is currently on **437.550 MHz** narrow FM — that's the
-70 cm amateur band, **not** the 137 MHz weather-satellite band APT
+ARISS SSTV (as of May 2026) is on **437.550 MHz** narrow FM — that's
+the 70 cm amateur band, **not** the 137 MHz weather-satellite band APT
 and LRPT use, and **not** the legacy 2 m slot at 145.800 MHz that
 older guides reference (see the migration note above). You need an
 antenna that works at 70 cm; a horizontal V-dipole tuned for 137 MHz
@@ -138,9 +138,9 @@ low passes.
 
 ## FM broadcast notch filter
 
-**Unnecessary** for current ARISS SSTV at 437.550 MHz UHF.
-Broadcast FM (88-108 MHz) is far enough below 437 MHz that
-intermodulation products don't land in-channel.
+**Unnecessary** for current ARISS SSTV at 437.550 MHz UHF (as of
+May 2026). Broadcast FM (88-108 MHz) is far enough below 437 MHz
+that intermodulation products don't land in-channel.
 
 A common pager / commercial-radio band sits around 460 MHz, which
 is closer in frequency. Most stations don't see interference from
@@ -217,7 +217,8 @@ passthrough and audio recording is suppressed).
 - Tunes to 437.550 MHz
 - Switches the demod to NFM (you'll hear the SSTV warble through
   your speakers)
-- Sets the channel bandwidth to 12.5 kHz
+- Sets the channel bandwidth to 38 kHz (covers Doppler swing at UHF
+  with headroom)
 - Zeros the VFO offset
 - Opens a non-modal **ISS SSTV** viewer window alongside the main
   radio window

--- a/docs/guides/sstv-reception.md
+++ b/docs/guides/sstv-reception.md
@@ -16,6 +16,14 @@ International Space Station) commemoration events, which (as of May
 You can't just arm the auto-record toggle on a quiet weekday and
 expect imagery — you need to time it to an active event.
 
+> **Frequency migration note (as of May 2026):** ARISS moved SSTV
+> from the legacy 2 m amateur slot at 145.800 MHz to UHF 70 cm at
+> **437.550 MHz** starting with Series 31 (April 2026). The catalog
+> entry tunes there automatically. Older write-ups and YouTube
+> videos still mention 145.800 — that's no longer current. Voice
+> contacts and APRS still use the 2 m slot, but SSTV events are
+> UHF until further notice.
+
 ---
 
 ## What you'll see
@@ -25,10 +33,12 @@ a rotation of ~12 photographs over a 2-5 day window. Each pass over
 your location typically captures 1-3 of them, depending on the pass
 duration and where the cycle was when the satellite came into view.
 
-Modes used (as of May 2026): **PD120** (most common), **PD180**
-(high quality), and **PD240** (highest quality). All three produce
-640 × 496 colour images. The viewer's window-title subtitle shows
-which mode the current image is being decoded as.
+Modes vary per event. Recent series have used **PD120** /
+**PD180** / **PD240** (640×496 colour) for longer slots, and
+**Robot 36** (320×240 colour) for tighter event schedules — the
+May 2026 Series 32 ("Cooperation in Space") is Robot 36. The
+viewer's window-title subtitle shows which mode the current image
+is being decoded as.
 
 > **TODO:** hero screenshot — a real ISS SSTV image we received
 > during an ARISS event, ideally showing the mode subtitle in the
@@ -45,13 +55,16 @@ gets you a paper certificate, which is a fun keepsake.
 The single most important step is timing — there's no point arming
 auto-record if there's no active event. Check both:
 
-- **[ariss-sstv.blogspot.com](https://ariss-sstv.blogspot.com)** —
-  the official ARISS SSTV blog. Posts go up several weeks before
-  each event with the start / end UTC times and the mode that will
-  be used. Subscribe via RSS if you want a heads-up.
+- **[ariss.org/upcoming-sstv-events.html](https://www.ariss.org/upcoming-sstv-events.html)** —
+  ARISS's primary event calendar. Lists upcoming series with start /
+  end UTC times, frequency, and mode. Updated 1-4 weeks before each
+  event.
+- **[@ARISS_Intl on X](https://x.com/ARISS_Intl)** — short-notice
+  announcements and last-minute schedule changes (e.g. event
+  windows extended or postponed).
 - **[amsat.org news](https://www.amsat.org/category/announcements/)** —
   cross-posts ARISS event announcements and sometimes adds
-  technical notes (e.g. "PD120 this time, not PD180").
+  technical notes.
 
 Past events (as of May 2026) have run from a few hours to five
 full days. Event windows are announced as continuous, but in
@@ -64,29 +77,42 @@ relying on any one.
 
 ## Antenna
 
-ISS SSTV is on **145.800 MHz** narrow FM — that's the 2 metre
-amateur band, **not** the 137 MHz weather-satellite band APT and
-LRPT use. You need an antenna that works at 145 MHz; the
-horizontal V-dipole tuned for 137 MHz APT will receive 145 MHz
-imperfectly but usefully on high-elevation passes.
+ARISS SSTV is currently on **437.550 MHz** narrow FM — that's the
+70 cm amateur band, **not** the 137 MHz weather-satellite band APT
+and LRPT use, and **not** the legacy 2 m slot at 145.800 MHz that
+older guides reference (see the migration note above). You need an
+antenna that works at 70 cm; a horizontal V-dipole tuned for 137 MHz
+APT is too far off-resonance to be useful at 437 MHz, and a
+SAW-filter-front-end designed for the 137 MHz weather band will
+heavily attenuate the UHF signal.
 
-### Best: 2 m / 70 cm vertical or J-pole
+### Best: 70 cm vertical or 2 m / 70 cm dual-band
 
 The ISS's onboard antennas are roughly omnidirectional and
 **vertically polarised**, unlike weather satellites' RHCP. A
-straight vertical antenna (a 2 m amateur whip, a J-pole, a
-quarter-wave ground plane) is the right match. Most of these
-antennas double as 70 cm receivers, which is convenient for ISS
-voice comms on 437 MHz too.
+70 cm vertical (quarter-wave for 70 cm is ~17 cm, easy to build),
+a 2 m / 70 cm dual-band whip, or a J-pole tuned for 70 cm is the
+right match. Many ham handhelds ship with a stock dual-band
+"rubber ducky" that works adequately for high-elevation passes —
+take the antenna off the radio and connect it to the dongle.
 
-### Acceptable: APT V-dipole rotated 90°
+### Acceptable: 2 m vertical or random wire
 
-If you already have a 137 MHz V-dipole built for APT, tilt one of
-the arms vertical (or stand it on end) and you'll get a usable
-145 MHz pattern. You're operating it 8 MHz off-resonance and at the
-wrong polarisation, so expect the SNR to be a few dB worse than a
-purpose-built 2 m antenna — but workable on passes above ~30°
-elevation.
+A 2 m vertical (designed for 145 MHz) operated at 437 MHz is
+~3× higher than its design frequency — the antenna will exhibit
+multiple lobes and uneven gain, so reception works on some passes
+and not others. A simple wire at the right physical length
+(quarter-wave ~17 cm, half-wave ~34 cm) outperforms a mismatched
+commercial antenna for this specific frequency.
+
+### Bypass the 137 MHz SAW + LNA chain
+
+If your station has a SAW filter + LNA tuned for the 137 MHz
+weather-sat band, **disconnect both for ARISS reception**. SAW
+filters are passive bandpass; a 137 MHz SAW will attenuate the
+437 MHz signal by 30+ dB. Plug the 70 cm antenna directly into the
+RTL-SDR. Bias-T should be **off** — the LNA isn't useful at 70 cm
+and would just draw current.
 
 ### Improvised: SDR's stock whip
 
@@ -112,20 +138,25 @@ low passes.
 
 ## FM broadcast notch filter
 
-**Probably unnecessary** for ISS SSTV. Broadcast FM (88-108 MHz)
-intermodulation lands on 137 MHz APT and LRPT but mostly skips
-145.800 MHz, which sits in the 2 m amateur band where the IMD
-products from 88-108 MHz land outside the channel.
+**Unnecessary** for current ARISS SSTV at 437.550 MHz UHF.
+Broadcast FM (88-108 MHz) is far enough below 437 MHz that
+intermodulation products don't land in-channel.
 
-If you already have a notch installed for APT, leave it in — it
-won't hurt and it does cut some noise on the 145 MHz side. If you
-don't have one, no need to buy one for SSTV alone.
+A common pager / commercial-radio band sits around 460 MHz, which
+is closer in frequency. Most stations don't see interference from
+it but if your 70 cm passes are noisier than expected, scan with a
+spectrum tool to confirm a clean band before suspecting the
+decoder.
+
+If you ever revert to monitoring legacy 145.800 MHz transmissions
+(rare, but ARISS has flipped frequencies before), an FM-broadcast
+notch helps marginally on the 2 m band.
 
 ---
 
 ## Active mission
 
-The ISS catalog entry is already in the app (NORAD 25544, 145.800
+The ISS catalog entry is already in the app (NORAD 25544, 437.550
 MHz NFM), wired with the SSTV imaging protocol. No setup needed
 beyond the standard ground-station entry.
 
@@ -183,7 +214,7 @@ passthrough and audio recording is suppressed).
 
 5 seconds before AOS, the recorder takes over your radio:
 
-- Tunes to 145.800 MHz
+- Tunes to 437.550 MHz
 - Switches the demod to NFM (you'll hear the SSTV warble through
   your speakers)
 - Sets the channel bandwidth to 12.5 kHz
@@ -245,9 +276,10 @@ viewer outside the auto-record path:
 
 - `Ctrl+Shift+V` opens the SSTV viewer window even when no pass is
   in progress. The decoder is wired to NFM audio, so as long as
-  you're tuned to 145.800 MHz NFM with a clean signal, the
-  decoder will produce frames. This is useful if the auto-record
-  schedule missed a pass and you want to watch the next one
+  you're tuned to a live ARISS SSTV signal (437.550 MHz NFM during
+  a current event window) with a clean carrier, the decoder will
+  produce frames. This is useful if the auto-record schedule
+  missed a pass and you want to watch the next one
   manually.
 - Switching the demod mode away from NFM stops decode entirely.
 - Closing the viewer window doesn't stop the decoder — the shared
@@ -270,18 +302,21 @@ The recorder armed and the radio tuned, but no SSTV image
 completed during the pass. Most common causes, in order:
 
 1. **No active ARISS event.** Check
-   [ariss-sstv.blogspot.com](https://ariss-sstv.blogspot.com).
+   [ariss.org/upcoming-sstv-events.html](https://www.ariss.org/upcoming-sstv-events.html).
 2. **Pass too low.** SSTV's PD-family decoders are line-rate-
    locked rather than per-line resyncable; a horizon-grazing pass
    may carry signal but never sustain enough SNR for VIS detection.
 3. **Antenna polarisation mismatch.** A horizontal antenna (e.g.
    the 137 MHz V-dipole used flat for APT) nulls vertically-
-   polarised 145 MHz signals. Lay the antenna vertical.
+   polarised UHF signals. Lay the antenna vertical, or use a 70 cm
+   vertical purpose-built for the band.
 4. **Wrong frequency due to Doppler.** The recorder doesn't apply
-   Doppler correction for SSTV (as of May 2026); the ±3 kHz shift
-   on 145.800 MHz is normally inside the 12.5 kHz channel
-   bandwidth, but if you've narrowed the bandwidth it may not be.
-   Reset bandwidth to 12.5 kHz.
+   Doppler correction for SSTV (as of May 2026); on UHF 437.550 MHz
+   the shift is roughly **±10 kHz** (3× larger than on the legacy
+   2 m frequency). At the catalog's 38 kHz bandwidth that fits, but
+   if you've narrowed the channel bandwidth, the Doppler can walk
+   the signal out of the passband near AOS / LOS. Restore bandwidth
+   to 38 kHz.
 
 If the directory is created but empty, you'll see a toast
 "Pass complete, but no SSTV images decoded — nothing saved to {dir}".


### PR DESCRIPTION
## Summary

- Bump ISS catalog entry: 145.800 MHz (legacy 2 m) → **437.550 MHz** (UHF 70 cm, current ARISS frequency).
- Refactor the catalog band-check from a single global VHF window into per-protocol allowed bands on `ImagingProtocol::allowed_bands_hz()` — needed because SSTV now operates on either 2 m (144–148 MHz) or 70 cm (430–440 MHz), and the previous single-window check couldn't represent that.
- Update `docs/guides/sstv-reception.md` end-to-end for UHF operation (antenna guidance, frequency callouts, Doppler note, troubleshooting).

## Why now

ARISS Series 32 — \"Cooperation in Space\" — runs **Friday May 8 → Tuesday May 12, 2026** continuously on **437.550 MHz Robot 36**. Until this PR the catalog was pinned at 145.800, so the auto-record state machine would have spent the whole 4-day window tuning to dead air on the legacy 2 m frequency while the actual transmissions ran 300 MHz higher in the 70 cm band.

Per [ariss.org/upcoming-sstv-events.html](https://www.ariss.org/upcoming-sstv-events.html), Series 31 (April 2026) was already on 437.550. The migration is real and the next event lands in 36 hours.

## Changes

**`crates/sdr-sat/src/lib.rs`**

- Removed `IMAGING_BAND_MIN_HZ` / `IMAGING_BAND_MAX_HZ` constants — they couldn't represent SSTV's two-band reality. Replaced with `ImagingProtocol::allowed_bands_hz()` returning a list of `(low, high)` ranges per protocol:
  - `Apt` / `Lrpt` → `[(137 MHz, 138 MHz)]`
  - `Sstv` → `[(144 MHz, 148 MHz), (430 MHz, 440 MHz)]`
- ISS catalog `downlink_hz`: 145_800_000 → 437_550_000. Demod / bandwidth / protocol unchanged.
- Tightened the catalog assertion: it now walks the entry's protocol bands instead of a single global window. **Strictly stronger** — an APT satellite on a 2 m amateur freq would now fail (used to pass).
- Updated doc comments mentioning 145.8 to reflect the migration.

**Tests** (sdr-sat goes from 69 → 72 passing)

- `known_satellites_have_imaging_band_downlinks` renamed → `known_satellites_have_protocol_compatible_downlinks`, rewritten to use per-protocol bands, skips `imaging_protocol: None` entries.
- New: `imaging_protocol_allowed_bands_are_well_formed` — defensive invariants on the lookup table (non-empty, low ≤ high).
- New: `iss_catalog_targets_current_ariss_uhf_frequency` — pins ISS entry to exactly 437_550_000 so a future ARISS frequency move fails this test until the catalog is bumped.

**`docs/guides/sstv-reception.md`** end-to-end pass:

- Migration callout at the top — UHF 437.550 is current, 145.800 is legacy
- Modes section reflects Series 32's Robot 36
- \"Knowing when to listen\" — primary source updated to ariss.org/upcoming-sstv-events.html (older blogspot is stale-ish), @ARISS_Intl on X for short-notice changes
- **Antenna section rewritten** — 70 cm vertical or dual-band primary, with explicit guidance to bypass 137 MHz SAW + LNA chains since SAW is a passive bandpass that gives 30–50 dB out-of-band rejection at UHF
- FM-broadcast notch section — unnecessary at UHF
- Auto-record walkthrough \"Tunes to\" line: 145.800 → 437.550
- Doppler troubleshooting note: UHF Doppler is ±10 kHz (3× VHF), still inside the 38 kHz catalog bandwidth
- Remaining 145.800 mentions are intentional historical context

## No Doppler-tracker changes needed

`Track::doppler_shift_hz(f) = -f * range_rate / c` — linear in carrier frequency. UHF Doppler at 437.550 MHz is exactly 3× VHF Doppler at 145.800 MHz for the same range-rate, which the existing `doppler_shift_sign_matches_range_rate` test already covers (parameterised by frequency). Nothing to re-implement.

## Verified

Local gates:
- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --workspace -- -D warnings` ✓
- `cargo test --workspace --locked` ✓ (sdr-sat: 72/72)
- `cargo build --workspace` ✓
- `cargo deny check` ✓

Smoke build: `make install CARGO_FLAGS=\"--release --features whisper-cuda\"` succeeded; user verified the install boots and tunes correctly. Friday's live ARISS pass will be the end-to-end validation.

## Test plan

- [x] All cargo gates pass locally
- [x] Smoke build with whisper-cuda
- [x] App boots, ISS pass row shows new frequency, NOAA / Meteor still work
- [ ] CR review
- [ ] **Friday May 8 ≥ 10:30 UTC**: live ARISS Series 32 reception on 437.550 MHz with a 70 cm antenna — the real validation

## Related

- Closes #638
- #639 — followup: per-satellite frequency override + SatNOGS DB auto-discovery (queued, no deadline)
- #640 — followup: let user choose which protocols / satellites to auto-record (queued, no deadline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-protocol frequency validation and explicit band support: APT/LRPT 137–138 MHz; SSTV VHF 144–148 MHz and UHF 430–440 MHz.

* **Bug Fixes**
  * ISS SSTV downlink frequency updated from 145.800 MHz to 437.550 MHz.

* **Documentation**
  * ISS SSTV reception guide revised for 437.550 MHz: 70 cm antenna guidance, NFM/38 kHz tuning, Doppler/bandwidth troubleshooting, and updated event sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->