### PR TITLE
feat: per-satellite expected-APID set + LOS schedule-mismatch warning (#645)

### DIFF
--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -117,6 +117,30 @@ pub const METEOR_M2_LRPT_DOWNLINK_HZ: u64 = 137_900_000;
 /// the previous default would have imposed.
 pub const METEOR_M2_LRPT_BANDWIDTH_HZ: u32 = 144_000;
 
+/// AVHRR APIDs we expect METEOR-M2 3 to transmit during a clean
+/// pass. As of May 2026 Roscosmos has M2-3 broadcasting its
+/// **summer mode** — three visual channels c1/c2/c3 (APIDs 64/65/66),
+/// no IR. The "Natural colour (123)" composite recipe in
+/// `sdr_ui::lrpt_viewer::COMPOSITE_CATALOG` covers this set; the
+/// IR-based composites (False-colour IR, Thermal IR) are
+/// unavailable on these passes by design — Roscosmos schedules them
+/// out for the warm half of the year.
+///
+/// At LOS the wiring layer compares this set against the actually-
+/// received APIDs and warns if any expected APID is missing AND we
+/// got at least one APID otherwise (silent passes don't trigger —
+/// they're indistinguishable from "satellite was off"). Per #645.
+pub const METEOR_M2_3_EXPECTED_LRPT_APIDS: &[u16] = &[64, 65, 66];
+
+/// AVHRR APIDs we expect METEOR-M2 4 to transmit during a clean
+/// pass. M2-4 broadcasts the **standard** three-channel set —
+/// c1/c2/c4 (APIDs 64/65/68) — visible + visible + thermal IR.
+/// All three composite recipes
+/// (`sdr_ui::lrpt_viewer::COMPOSITE_CATALOG`) have full coverage on
+/// these passes. Per #645 — M2-4 is currently the easier first-decode
+/// target than M2-3 for exactly this reason.
+pub const METEOR_M2_4_EXPECTED_LRPT_APIDS: &[u16] = &[64, 65, 68];
+
 /// Imaging protocol the receiver should use for a given catalog
 /// satellite. Drives the auto-record dispatch in
 /// `sidebar::satellites_recorder` so APT vs LRPT vs SSTV each get
@@ -222,6 +246,52 @@ pub struct KnownSatellite {
     /// shipped in Task 7 of epic #469; ISS SSTV shipped in epic
     /// #472 with `Some(Sstv)`.
     pub imaging_protocol: Option<ImagingProtocol>,
+    /// Per-pass expected AVHRR APIDs for LRPT satellites. `None` for
+    /// non-LRPT satellites (ISS / future Cubesats), `Some(set)` for
+    /// Meteor-M family entries — the value reflects the current
+    /// Roscosmos broadcast schedule (M2-3 summer mode = 64/65/66,
+    /// M2-4 standard mode = 64/65/68 as of May 2026).
+    ///
+    /// Used by the wiring layer at LOS: if the satellite delivered
+    /// some APIDs but not all of these, we emit a warning so
+    /// schedule changes (e.g. Roscosmos flipping M2-3 back to
+    /// winter mode) surface as a single log line instead of silent
+    /// "missing composite" failures. Per #645.
+    ///
+    /// NOT a requirement / NOT used as a filter — every received APID
+    /// produces a per-channel PNG regardless of whether it's in this
+    /// set. The set drives diagnostics only.
+    pub expected_lrpt_apids: Option<&'static [u16]>,
+}
+
+impl KnownSatellite {
+    /// Compute the APIDs in `expected_lrpt_apids` that are not present
+    /// in the `received` slice. Returns an empty `Vec` if:
+    /// - This satellite has no expected-APID set (`expected_lrpt_apids` is `None`),
+    /// - The satellite delivered no APIDs at all (silent pass — we don't
+    ///   want to false-alarm "missing APIDs" when the receiver got
+    ///   nothing), or
+    /// - All expected APIDs were received.
+    ///
+    /// Returns the missing APIDs in catalog order (the order they appear
+    /// in `expected_lrpt_apids`) otherwise. Pure function — used by the
+    /// wiring layer at LOS to drive a single diagnostic warning per
+    /// Roscosmos schedule mismatch, no allocations on the empty path.
+    /// Per #645.
+    #[must_use]
+    pub fn missing_lrpt_apids(&self, received: &[u16]) -> Vec<u16> {
+        let Some(expected) = self.expected_lrpt_apids else {
+            return Vec::new();
+        };
+        if received.is_empty() {
+            return Vec::new();
+        }
+        expected
+            .iter()
+            .copied()
+            .filter(|apid| !received.contains(apid))
+            .collect()
+    }
 }
 
 /// Built-in catalog. Order is the order the scheduler UI displays.
@@ -251,8 +321,10 @@ pub struct KnownSatellite {
 /// active M2-3 / M2-4 birds.
 pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
     // Meteor-M LRPT — epic #469. Both M2-3 and M2-4 transmit on
-    // 137.900 MHz with 72 ksym/s QPSK and APIDs 64/65/67. They're in
-    // different orbital planes so they don't conflict simultaneously.
+    // 137.900 MHz with 72 ksym/s QPSK and AVHRR APIDs in the
+    // 64..=68 range. They're in different orbital planes so they
+    // don't conflict simultaneously.
+    //
     // `imaging_protocol: Some(Lrpt)` enrolls these in the
     // auto-record flow per epic #469 task 7. The recorder
     // constructor's `supported_protocols` set now includes
@@ -260,6 +332,15 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
     // LRPT viewer + signals the DSP to attach the decoder, and
     // the LOS save walks every decoded APID into a per-pass
     // directory.
+    //
+    // **Per-satellite APID expectations differ.** Roscosmos schedules
+    // each Meteor-M bird's broadcast set independently:
+    // M2-3 is currently in summer mode (3 visual channels), M2-4 in
+    // standard mode (2 visual + 1 IR). See
+    // `METEOR_M2_3_EXPECTED_LRPT_APIDS` /
+    // `METEOR_M2_4_EXPECTED_LRPT_APIDS` for the live values; the
+    // wiring layer warns at LOS if expected APIDs are missing
+    // (vs. silently shipping incomplete composites). Per #645.
     //
     // METEOR-M 2 (40069) is intentionally absent — battery damage from
     // a 2022 micrometeorite collision means it can't power the LRPT
@@ -273,12 +354,17 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         // rationale; both M2-3 and M2-4 share the channel.
         bandwidth_hz: METEOR_M2_LRPT_BANDWIDTH_HZ,
         imaging_protocol: Some(ImagingProtocol::Lrpt),
+        // Summer mode: c1/c2/c3 (visual triplet). The Natural
+        // colour composite covers this set; the IR-based
+        // composites are unavailable until Roscosmos schedules
+        // M2-3 back to standard mode. Per #645.
+        expected_lrpt_apids: Some(METEOR_M2_3_EXPECTED_LRPT_APIDS),
     },
     KnownSatellite {
         // METEOR-M2 4 launched in 2024 and is actively transmitting
-        // LRPT — same downlink as M2-3 (137.900 MHz, 72 kbaud, APIDs
-        // 64/65/67), different orbital plane so the two never contend
-        // for the same pass.
+        // LRPT — same downlink as M2-3 (137.900 MHz, 72 kbaud,
+        // different orbital plane so the two never contend for the
+        // same pass.
         //
         // **NORAD id is 59051**, NOT 61024. The original #506
         // exclusion and some hobbyist references quote 61024, which
@@ -295,6 +381,11 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         demod_mode: sdr_types::DemodMode::Lrpt,
         bandwidth_hz: METEOR_M2_LRPT_BANDWIDTH_HZ,
         imaging_protocol: Some(ImagingProtocol::Lrpt),
+        // Standard mode: c1/c2/c4 (visible/visible/thermal IR). All
+        // three composite recipes have full coverage on these
+        // passes — currently the easier first-decode target than
+        // M2-3 for exactly that reason. Per #645.
+        expected_lrpt_apids: Some(METEOR_M2_4_EXPECTED_LRPT_APIDS),
     },
     // ISS SSTV — epic #472. Currently 437.550 MHz UHF (ARISS Series
     // 31+, April 2026 onward, see #638); the catalog tracks the live
@@ -318,6 +409,10 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: DEFAULT_SATELLITE_BANDWIDTH_HZ,
         imaging_protocol: Some(ImagingProtocol::Sstv),
+        // ISS SSTV is a single FM audio channel, not a multi-APID
+        // LRPT broadcast — the per-pass expected-APID set doesn't
+        // apply.
+        expected_lrpt_apids: None,
     },
 ];
 
@@ -428,6 +523,116 @@ mod tests {
                 .any(|s| s.norad_id == USA_403_WRONG_METEOR_NORAD_ID),
             "NORAD 61024 is USA 403, NOT METEOR-M2 4 — must not be in KNOWN_SATELLITES",
         );
+    }
+
+    #[test]
+    fn meteor_m2_3_carries_summer_mode_expected_apids() {
+        // M2-3 currently broadcasts c1/c2/c3 (visual triplet). Pin
+        // the expected-APID set so a Roscosmos schedule change back
+        // to standard mode (c1/c2/c4) shows up as a CR-able diff
+        // here, not a silent failure of the missing-APIDs warning
+        // at LOS. Per #645.
+        let m2_3 = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.norad_id == METEOR_M2_3_NORAD_ID)
+            .expect("METEOR-M2 3 should be in KNOWN_SATELLITES");
+        assert_eq!(
+            m2_3.expected_lrpt_apids,
+            Some(METEOR_M2_3_EXPECTED_LRPT_APIDS),
+        );
+        assert_eq!(METEOR_M2_3_EXPECTED_LRPT_APIDS, &[64, 65, 66]);
+    }
+
+    #[test]
+    fn meteor_m2_4_carries_standard_mode_expected_apids() {
+        // M2-4 broadcasts c1/c2/c4 (visual + visual + thermal IR) —
+        // the standard set every composite recipe in
+        // `sdr_ui::lrpt_viewer::COMPOSITE_CATALOG` covers. Per #645.
+        let m2_4 = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.norad_id == METEOR_M2_4_NORAD_ID)
+            .expect("METEOR-M2 4 should be in KNOWN_SATELLITES");
+        assert_eq!(
+            m2_4.expected_lrpt_apids,
+            Some(METEOR_M2_4_EXPECTED_LRPT_APIDS),
+        );
+        assert_eq!(METEOR_M2_4_EXPECTED_LRPT_APIDS, &[64, 65, 68]);
+    }
+
+    #[test]
+    fn iss_has_no_expected_lrpt_apids() {
+        // ISS is SSTV (single FM audio channel), not LRPT. The
+        // per-pass expected-APID set doesn't apply.
+        let iss = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.norad_id == ISS_NORAD_ID)
+            .expect("ISS should be in KNOWN_SATELLITES");
+        assert_eq!(iss.expected_lrpt_apids, None);
+    }
+
+    #[test]
+    fn missing_lrpt_apids_returns_empty_when_no_expected_set() {
+        // Satellites with `expected_lrpt_apids: None` (ISS,
+        // future non-LRPT entries) never emit the warning even if
+        // an unrelated `received` slice is passed.
+        let iss = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.norad_id == ISS_NORAD_ID)
+            .expect("ISS should be in KNOWN_SATELLITES");
+        assert!(iss.missing_lrpt_apids(&[1, 2, 3]).is_empty());
+        assert!(iss.missing_lrpt_apids(&[]).is_empty());
+    }
+
+    #[test]
+    fn missing_lrpt_apids_returns_empty_on_silent_pass() {
+        // Silent pass (received is empty) must NOT warn — that's
+        // a different failure mode (no signal / weak signal /
+        // satellite off) handled by `pass_decoded_nothing` in the
+        // wiring layer. Returning empty here keeps the warning
+        // scoped to "got SOME imagery but expected MORE."
+        let m2_3 = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.norad_id == METEOR_M2_3_NORAD_ID)
+            .expect("METEOR-M2 3 should be in KNOWN_SATELLITES");
+        assert!(m2_3.missing_lrpt_apids(&[]).is_empty());
+    }
+
+    #[test]
+    fn missing_lrpt_apids_reports_summer_mode_partial_pass() {
+        // M2-3 expects 64/65/66; if we got 64+65 only, the warning
+        // should call out 66 missing.
+        let m2_3 = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.norad_id == METEOR_M2_3_NORAD_ID)
+            .expect("METEOR-M2 3 should be in KNOWN_SATELLITES");
+        assert_eq!(m2_3.missing_lrpt_apids(&[64, 65]), vec![66]);
+    }
+
+    #[test]
+    fn missing_lrpt_apids_reports_standard_mode_partial_pass() {
+        // M2-4 expects 64/65/68; if we got 64+68 only, the warning
+        // should call out 65 missing. Order follows the catalog
+        // expected-APIDs order so future readers see the slot
+        // gap directly.
+        let m2_4 = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.norad_id == METEOR_M2_4_NORAD_ID)
+            .expect("METEOR-M2 4 should be in KNOWN_SATELLITES");
+        assert_eq!(m2_4.missing_lrpt_apids(&[64, 68]), vec![65]);
+    }
+
+    #[test]
+    fn missing_lrpt_apids_returns_empty_when_full_set_received() {
+        // Happy path: every expected APID delivered. No warning.
+        let m2_3 = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.norad_id == METEOR_M2_3_NORAD_ID)
+            .expect("METEOR-M2 3 should be in KNOWN_SATELLITES");
+        assert!(m2_3.missing_lrpt_apids(&[64, 65, 66]).is_empty());
+        // Extra received APIDs (e.g., M2-3 unexpectedly transmitting
+        // an IR channel) are fine — the function returns the
+        // complement of expected over received, ignoring extras.
+        assert!(m2_3.missing_lrpt_apids(&[64, 65, 66, 70]).is_empty());
     }
 
     #[test]

--- a/crates/sdr-ui/src/doppler_tracker.rs
+++ b/crates/sdr-ui/src/doppler_tracker.rs
@@ -305,6 +305,8 @@ mod tests {
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: TEST_APT_BANDWIDTH_HZ,
         imaging_protocol: Some(sdr_sat::ImagingProtocol::Apt),
+        // Doppler tracker tests don't read this field.
+        expected_lrpt_apids: None,
     };
     static FIXTURE_B: KnownSatellite = KnownSatellite {
         name: "TEST_SAT_B",
@@ -313,6 +315,7 @@ mod tests {
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: TEST_APT_BANDWIDTH_HZ,
         imaging_protocol: Some(sdr_sat::ImagingProtocol::Apt),
+        expected_lrpt_apids: None,
     };
     static FIXTURE_C: KnownSatellite = KnownSatellite {
         name: "TEST_SAT_C",
@@ -321,6 +324,7 @@ mod tests {
         demod_mode: sdr_types::DemodMode::Nfm,
         bandwidth_hz: TEST_APT_BANDWIDTH_HZ,
         imaging_protocol: Some(sdr_sat::ImagingProtocol::Apt),
+        expected_lrpt_apids: None,
     };
 
     fn noaa_15() -> &'static KnownSatellite {

--- a/crates/sdr-ui/src/lrpt_viewer.rs
+++ b/crates/sdr-ui/src/lrpt_viewer.rs
@@ -106,14 +106,31 @@ pub struct CompositeRecipe {
 ///    passes where the visible channels are dark but thermal
 ///    still discriminates land/sea/cloud.
 ///
-/// APID values are the AVHRR slots Meteor-M N2-2 transmits on:
-/// 64 = ch1, 65 = ch2, 66 = ch3, 68 = ch4 (ch4 thermal is the
-/// commonly-active IR slot when operating in the standard
-/// "three visible plus one IR" mode). If a future Meteor variant
-/// ships a different APID assignment we'll add new recipes
-/// alongside these rather than mutate the existing values —
-/// composites that worked once must keep working as the catalog
-/// grows.
+/// APID values are the AVHRR slots: 64 = ch1, 65 = ch2, 66 = ch3,
+/// 68 = ch4 (thermal IR).
+///
+/// **Per-satellite, per-season availability.** Roscosmos schedules
+/// each Meteor-M bird's broadcast set independently and rotates
+/// IR availability with the season. As of May 2026:
+///
+/// - **METEOR-M2 4** transmits the standard set 64/65/68
+///   (visible/visible/IR) — all three composites have full coverage.
+/// - **METEOR-M2 3** is in summer mode broadcasting 64/65/66 (three
+///   visible channels, no IR) — only Natural colour (123) covers
+///   this set; the IR-based composites are silently unavailable
+///   (`save_composite` returns `CompositeUnavailable` and the
+///   recipe is skipped at LOS).
+///
+/// `sdr_sat::KnownSatellite::expected_lrpt_apids` carries each
+/// satellite's current expected set, and the auto-record LOS path
+/// emits a warning if the live transmission diverges from it (e.g.,
+/// Roscosmos flips M2-3 back to standard mode and we start receiving
+/// APID 68 again). Per #645.
+///
+/// If a future Meteor variant ships a different APID assignment
+/// we'll add new recipes alongside these rather than mutate the
+/// existing values — composites that worked once must keep working
+/// as the catalog grows.
 pub const COMPOSITE_CATALOG: &[CompositeRecipe] = &[
     CompositeRecipe {
         name: "Natural colour (123)",

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11764,6 +11764,35 @@ fn connect_satellites_panel(
                 // many passes produce no LRPT). Per silent-pass
                 // diagnosis 2026-05-08.
                 let pass_decoded_nothing = snapshots.is_empty();
+                // Diagnostic: warn if the satellite delivered some
+                // APIDs but not the full per-satellite expected set.
+                // Catches schedule changes (e.g. Roscosmos flipping
+                // M2-3 between summer-mode c1/c2/c3 and standard
+                // c1/c2/c4) as a single log line instead of the user
+                // wondering why some composite recipes silently
+                // produced nothing. Silent passes are skipped — they're
+                // a different failure mode handled by
+                // `pass_decoded_nothing` above. Per #645.
+                if !pass_decoded_nothing
+                    && let Some((norad_id, _aos)) = exported_lrpt_pass
+                    && let Some(sat) = sdr_sat::KNOWN_SATELLITES
+                        .iter()
+                        .find(|s| s.norad_id == norad_id)
+                {
+                    let received_apids: Vec<u16> =
+                        snapshots.iter().map(|(apid, _)| *apid).collect();
+                    let missing = sat.missing_lrpt_apids(&received_apids);
+                    if !missing.is_empty() {
+                        tracing::warn!(
+                            "auto-record LOS: {} delivered APIDs {:?} but expected {:?}; \
+                             missing {:?} — Roscosmos schedule may have changed (see #645)",
+                            sat.name,
+                            received_apids,
+                            sat.expected_lrpt_apids.unwrap_or(&[]),
+                            missing,
+                        );
+                    }
+                }
                 glib::spawn_future_local(async move {
                     let dir_for_msg = dir.clone();
                     // Tuple return: (toast message, saved-at-least-one).


### PR DESCRIPTION
## Summary

Closes #645. The issue was filed off the Reddit M2-3 vs M2-4 investigation framed as "our pipeline likely has SatDump's preset bug." **Audit shows we don't** — `crates/sdr-lrpt/src/image/composite.rs::ImageAssembler` keys per-APID buffers on raw APID, and our recipe-driven composite save path (`crates/sdr-lrpt/src/image/png_export.rs::save_composite`) silently skips composites whose APIDs weren't received this pass. M2-3 in summer mode (c1/c2/c3 = APIDs 64/65/66) already produces correct per-APID PNGs and a working "Natural colour (123)" composite via the existing pipeline; the IR-based composites (False-colour IR, Thermal IR) are silently absent because APID 68 isn't transmitted in summer mode.

What was actually missing: a **diagnostic surface for the schedule mismatch.** A Roscosmos flip from summer-mode (c1/c2/c3) to standard-mode (c1/c2/c4) — or vice versa — currently surfaces as "user notices some composite recipes are silently empty." This PR makes it a single warning line at LOS naming the satellite, the received APIDs, the expected set, and the missing APIDs.

## What changed

### 1. `KnownSatellite::expected_lrpt_apids: Option<&'static [u16]>` field
Per-satellite expected APID set. `None` for non-LRPT satellites (ISS, future Cubesats); `Some(set)` for Meteor-M family entries. Carries the current Roscosmos schedule:
- `METEOR-M2 3 = [64, 65, 66]` (summer mode, 3 visual)
- `METEOR-M2 4 = [64, 65, 68]` (standard mode, visual + IR)

Both values surfaced as `pub const`s (`METEOR_M2_3_EXPECTED_LRPT_APIDS`, `METEOR_M2_4_EXPECTED_LRPT_APIDS`) so a future Roscosmos schedule change is a one-line catalog edit, not a data-spelunking exercise.

### 2. `KnownSatellite::missing_lrpt_apids(&[u16]) -> Vec<u16>` helper
Pure function. Returns `Vec::new()` when:
- The satellite has no expected-APID set (`None`)
- The pass produced no APIDs (silent — different failure mode handled by `pass_decoded_nothing`)
- The full expected set was received

Returns missing APIDs in catalog order otherwise. Centralised in `sdr-sat` so it's unit-testable without GTK.

### 3. Wiring in `crates/sdr-ui/src/window.rs::SaveLrptPass`
After the per-pass APIDs are collected and `pass_decoded_nothing` is computed, look up the catalog entry by NORAD id and emit a `tracing::warn!` if `missing_lrpt_apids` returns non-empty. Warning format:
```
auto-record LOS: METEOR-M2 3 delivered APIDs [64, 65] but expected [64, 65, 66]; missing [66] — Roscosmos schedule may have changed (see #645)
```

### 4. Stale comment cleanup
Catalog comment was claiming "APIDs 64/65/67" — incorrect against the canonical AVHRR slot mapping (64=ch1, 65=ch2, 66=ch3, 68=ch4). Replaced with "AVHRR APIDs in the 64..=68 range" + cross-reference to the per-satellite expected-APID constants. `COMPOSITE_CATALOG` doc in `lrpt_viewer.rs` updated to spell out the per-satellite, per-season availability situation explicitly.

## Tests

8 new unit tests in `sdr-sat` covering:
- Summer-mode expected APIDs pinned for M2-3
- Standard-mode expected APIDs pinned for M2-4
- ISS has `None`
- Helper returns empty on `None`
- Helper returns empty on silent pass
- Helper reports summer-mode partial pass (got 64+65, missing 66)
- Helper reports standard-mode partial pass (got 64+68, missing 65)
- Helper returns empty on full set received (with extra-APID variant)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --features whisper-cuda --workspace -- -D warnings` clean
- [x] `cargo build --features whisper-cuda` green
- [x] `cargo test --workspace --features whisper-cuda` — 1915 passed / 0 failed / 14 ignored (8 more than 1907 baseline; matches the new unit tests)
- [x] `make install CARGO_FLAGS="--release --features whisper-cuda"` completes; binary at `~/.cargo/bin/sdr-rs`
- [x] Live UI smoke: app restarts, Satellites panel renders catalog (METEOR-M2 3 / METEOR-M2 4 / ISS) without crash from the new field; LRPT viewer keycombo (`Ctrl+Shift+L`) opens manual viewer
- [x] No regressions in auto-record path: the new code is purely a `tracing::warn!` after the existing save flow, runs only when the satellite delivered some APIDs but not the full expected set

## Why not a bigger change

The original issue framed this as a SatDump-level bug. It isn't — our pipeline already handles partial-channel transmissions correctly (per-APID PNGs always saved; composites fall through `CompositeUnavailable` when missing APIDs). What was missing was the diagnostic, not the decoder behavior. This PR adds the diagnostic and updates the docs to explicitly call out the per-satellite, per-season schedule reality so a future maintainer doesn't get tricked by the same false-positive read of the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented per-pass APID tracking for Meteor-M2 satellites in different seasonal modes
  * Added warning notifications when expected satellite data is not fully received during recordings

* **Documentation**
  * Enhanced documentation with detailed APID availability information by satellite and season

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/rtl-sdr/pull/651)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->