### PR TITLE
feat(display): waterfall master toggle + auto-pause-on-minimize (#646, #647)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -282,6 +282,12 @@ struct DspState {
     invert_iq: bool,
     window_fn: FftWindow,
     fft_rate: f64,
+    /// Master FFT compute gate. Mirrors `IqFrontend::fft_enabled` and
+    /// is reapplied to any newly-built frontend so a frontend rebuild
+    /// (e.g. on source switch / decimation change) doesn't silently
+    /// resume the waterfall when the user had it toggled off. Driven
+    /// by `UiToDsp::SetFftEnabled` (#646 / #647).
+    fft_enabled: bool,
     /// Current channel bandwidth (persisted so VFO rebuilds use it, not mode default).
     bandwidth: f64,
 
@@ -648,6 +654,11 @@ impl DspState {
             invert_iq: false,
             window_fn: FftWindow::Nuttall,
             fft_rate: DEFAULT_FFT_RATE,
+            // Default-on so existing setup paths that don't explicitly
+            // toggle the gate keep historical behavior. UI is the only
+            // caller that turns this off (Display sidebar toggle for
+            // #646; window-minimize handler for #647).
+            fft_enabled: true,
             bandwidth: initial_bandwidth,
             vfo: None,
             vfo_buf: Vec::new(),
@@ -1669,6 +1680,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 Ok(mut new_frontend) => {
                     new_frontend.set_invert_iq(state.invert_iq);
                     new_frontend.set_fft_rate(state.fft_rate);
+                    new_frontend.set_fft_enabled(state.fft_enabled);
                     state.frontend = new_frontend;
                     state.fft_buf = vec![0.0; size];
                 }
@@ -1757,6 +1769,7 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
                 Ok(mut new_frontend) => {
                     new_frontend.set_invert_iq(state.invert_iq);
                     new_frontend.set_fft_rate(state.fft_rate);
+                    new_frontend.set_fft_enabled(state.fft_enabled);
                     state.fft_buf = vec![0.0; new_frontend.fft_size()];
                     state.frontend = new_frontend;
                 }
@@ -1819,6 +1832,12 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             tracing::debug!(fps, "set FFT rate");
             state.fft_rate = fps;
             state.frontend.set_fft_rate(fps);
+        }
+
+        UiToDsp::SetFftEnabled(enabled) => {
+            tracing::debug!(enabled, "set FFT enabled");
+            state.fft_enabled = enabled;
+            state.frontend.set_fft_enabled(enabled);
         }
 
         UiToDsp::SetHighPass(enabled) => {
@@ -3671,6 +3690,7 @@ fn rebuild_frontend(state: &mut DspState) -> Result<(), String> {
 
     new_frontend.set_invert_iq(state.invert_iq);
     new_frontend.set_fft_rate(state.fft_rate);
+    new_frontend.set_fft_enabled(state.fft_enabled);
     state.frontend = new_frontend;
     Ok(())
 }

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -311,6 +311,20 @@ pub enum UiToDsp {
     SetWfmStereo(bool),
     /// Set the FFT display frame rate (FPS).
     SetFftRate(f64),
+    /// Master FFT compute gate. When `false`, the IQ frontend skips
+    /// the entire FFT accumulation + compute loop — saving the
+    /// per-sample copy into the FFT accumulator, the windowing
+    /// pass, and the FFT itself. Audio / demod / decimation /
+    /// recording paths continue to run normally; only the spectrum-
+    /// display path is suspended.
+    ///
+    /// Used by the UI to pause the waterfall when the user toggles
+    /// it off via the Display sidebar (#646) or the window is
+    /// minimized (#647). Independent of `SetFftRate` — the rate is
+    /// preserved across enable / disable cycles so re-enabling
+    /// resumes at the previously-configured frame rate without a
+    /// settings round-trip.
+    SetFftEnabled(bool),
     /// Enable or disable the audio high-pass filter (voice modes).
     SetHighPass(bool),
     /// Enable or disable the audio notch filter.

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -853,6 +853,14 @@ mod tests {
         let fft_rate = UiToDsp::SetFftRate(30.0);
         assert!(matches!(fft_rate, UiToDsp::SetFftRate(r) if (r - 30.0).abs() < f64::EPSILON));
 
+        // FFT compute gate (#646 / #647) — both polarities so a
+        // future refactor that flips the payload type or renames
+        // the variant trips this regression net.
+        let fft_on = UiToDsp::SetFftEnabled(true);
+        assert!(matches!(fft_on, UiToDsp::SetFftEnabled(true)));
+        let fft_off = UiToDsp::SetFftEnabled(false);
+        assert!(matches!(fft_off, UiToDsp::SetFftEnabled(false)));
+
         let hp = UiToDsp::SetHighPass(true);
         assert!(matches!(hp, UiToDsp::SetHighPass(true)));
 

--- a/crates/sdr-pipeline/src/iq_frontend.rs
+++ b/crates/sdr-pipeline/src/iq_frontend.rs
@@ -90,6 +90,16 @@ pub struct IqFrontend {
     fft_skip_counter: usize,
     /// Whether we're currently accumulating for the next FFT.
     fft_accumulating: bool,
+    /// Master FFT compute gate. When `false`, `process()` skips the
+    /// entire FFT accumulation + compute loop and returns
+    /// `fft_ready = false` unconditionally — saving the per-sample
+    /// copy into `fft_accum`, the windowing pass, and the FFT
+    /// itself. Used by the UI to suspend the waterfall display when
+    /// the user toggles it off (issue #646) or the window is
+    /// minimized (#647). Independent of `fft_rate` — rate stays
+    /// untouched so re-enabling immediately resumes at the
+    /// previously-configured frame rate without a setting round-trip.
+    fft_enabled: bool,
 
     // Scratch buffers
     decim_buf: Vec<Complex>,
@@ -175,6 +185,12 @@ impl IqFrontend {
             fft_skip_samples,
             fft_skip_counter: 0,
             fft_accumulating: true,
+            // Default-on so existing call sites that don't explicitly
+            // toggle the gate keep the historical behavior. The UI is
+            // responsible for sending `SetFftEnabled(false)` when the
+            // user toggles the waterfall off (#646) or the window is
+            // minimized (#647).
+            fft_enabled: true,
             decim_buf: Vec::new(),
             dc_scratch: Vec::new(),
             fft_work: vec![Complex::default(); fft_size],
@@ -219,6 +235,34 @@ impl IqFrontend {
     /// Get the current target FFT rate.
     pub fn fft_rate(&self) -> f64 {
         self.fft_rate
+    }
+
+    /// Toggle the master FFT compute gate. When `false`, `process()`
+    /// skips the entire FFT accumulation + compute loop and returns
+    /// `fft_ready = false` unconditionally — the per-sample copy
+    /// into `fft_accum`, the windowing pass, and the FFT itself are
+    /// all elided. Audio / demod / decimation continue to run
+    /// normally — only the spectrum-display path is suspended.
+    ///
+    /// Used by the UI to suspend the waterfall when the user toggles
+    /// it off (#646) or the window is minimized (#647). Also resets
+    /// the FFT accumulator so re-enabling starts fresh — a stale
+    /// half-frame at the moment of disable would otherwise prepend
+    /// the first FFT after re-enable, producing a brief
+    /// discontinuity in the waterfall.
+    pub fn set_fft_enabled(&mut self, enabled: bool) {
+        if self.fft_enabled == enabled {
+            return;
+        }
+        self.fft_enabled = enabled;
+        self.fft_accum_count = 0;
+        self.fft_skip_counter = 0;
+        self.fft_accumulating = true;
+    }
+
+    /// Whether the FFT compute gate is currently enabled.
+    pub fn fft_enabled(&self) -> bool {
+        self.fft_enabled
     }
 
     /// Enable or disable IQ inversion correction.
@@ -315,8 +359,14 @@ impl IqFrontend {
         // Step 1: FFT accumulation from raw input (pre-decimation).
         // Shows the full tuner bandwidth in the waterfall/FFT display,
         // matching how SDR++ renders its spectrum.
+        //
+        // Gated by `fft_enabled` (#646 / #647): when the user toggles
+        // the waterfall off, or the window is minimized, the entire
+        // accumulator + compute loop is skipped — saving the per-
+        // sample memcpy, the windowing pass, and the FFT itself.
+        // Audio / demod / decimation below continue to run normally.
         let mut fft_ready = false;
-        {
+        if self.fft_enabled {
             let mut pos = 0;
             let raw_len = input.len();
             while pos < raw_len {
@@ -754,6 +804,146 @@ mod tests {
         assert_eq!(
             fft_count, 10,
             "expected 10 FFTs at 10 FPS with non-aligned chunks, got {fft_count}"
+        );
+    }
+
+    #[test]
+    fn test_fft_enabled_default_is_true() {
+        // Existing call sites that don't explicitly toggle the gate
+        // must keep historical behavior. A `new()` IqFrontend should
+        // produce FFTs immediately. Per #646.
+        let fe = IqFrontend::new(
+            TEST_SAMPLE_RATE,
+            1,
+            TEST_FFT_SIZE,
+            FftWindow::Nuttall,
+            false,
+        )
+        .unwrap();
+        assert!(fe.fft_enabled(), "fft_enabled defaults to true");
+    }
+
+    #[test]
+    fn test_fft_disabled_suppresses_fft_ready() {
+        // With `fft_enabled = false`, `process()` must skip the
+        // accumulator + compute loop entirely — no `fft_ready = true`
+        // ever surfaces, even after enough samples for many FFTs to
+        // have completed at the current rate. Audio path still runs
+        // (output buffer is filled by Step 2). Per #646.
+        let mut fe = IqFrontend::new(
+            TEST_SAMPLE_RATE,
+            1,
+            TEST_FFT_SIZE,
+            FftWindow::Nuttall,
+            false,
+        )
+        .unwrap();
+        fe.set_fft_rate(10.0);
+        fe.set_fft_enabled(false);
+        assert!(!fe.fft_enabled());
+
+        let chunk = vec![Complex::new(1.0, 0.0); TEST_FFT_SIZE];
+        let mut output = vec![Complex::default(); TEST_FFT_SIZE];
+        let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+        let mut fft_count = 0;
+        let mut total_processed = 0;
+
+        for _ in 0..47 {
+            let (processed, fft_ready) = fe.process(&chunk, &mut output, &mut fft_out).unwrap();
+            total_processed += processed;
+            if fft_ready {
+                fft_count += 1;
+            }
+        }
+
+        assert_eq!(fft_count, 0, "no FFTs should fire while gate is disabled");
+        assert!(
+            total_processed > 0,
+            "audio / decimation path must still run while FFT is disabled \
+             (got 0 processed samples — the gate is leaking past Step 1)",
+        );
+    }
+
+    #[test]
+    fn test_fft_re_enable_resumes_at_configured_rate() {
+        // Toggling the gate off then back on must restore the
+        // previously-configured FFT rate without a settings round-
+        // trip. Counter resets on toggle so re-enable starts a fresh
+        // window — preventing a half-accumulated frame from the pre-
+        // disable period from being emitted as the first post-enable
+        // FFT. Per #646.
+        let mut fe = IqFrontend::new(
+            TEST_SAMPLE_RATE,
+            1,
+            TEST_FFT_SIZE,
+            FftWindow::Nuttall,
+            false,
+        )
+        .unwrap();
+        fe.set_fft_rate(10.0);
+
+        let chunk = vec![Complex::new(1.0, 0.0); TEST_FFT_SIZE];
+        let mut output = vec![Complex::default(); TEST_FFT_SIZE];
+        let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+
+        // Half a second disabled (no FFTs).
+        fe.set_fft_enabled(false);
+        for _ in 0..23 {
+            let (_, fft_ready) = fe.process(&chunk, &mut output, &mut fft_out).unwrap();
+            assert!(!fft_ready, "FFT should not fire while disabled");
+        }
+
+        // Re-enable + half a second of input.
+        fe.set_fft_enabled(true);
+        let mut post_enable_count = 0;
+        for _ in 0..47 {
+            let (_, fft_ready) = fe.process(&chunk, &mut output, &mut fft_out).unwrap();
+            if fft_ready {
+                post_enable_count += 1;
+            }
+        }
+        // ~10 FPS target on 1 second of input ≈ 10 FFTs after re-enable.
+        assert_eq!(
+            post_enable_count, 10,
+            "re-enable should resume at the previously-configured 10 FPS rate, got {post_enable_count}"
+        );
+    }
+
+    #[test]
+    fn test_fft_set_enabled_idempotent() {
+        // Setting the gate to its current state is a no-op — must
+        // not reset the accumulator or skip counter mid-pass. A
+        // chatty UI that re-applies the persisted toggle on every
+        // frame would otherwise stall the FFT cadence indefinitely.
+        let mut fe = IqFrontend::new(
+            TEST_SAMPLE_RATE,
+            1,
+            TEST_FFT_SIZE,
+            FftWindow::Nuttall,
+            false,
+        )
+        .unwrap();
+        fe.set_fft_rate(10.0);
+
+        let chunk = vec![Complex::new(1.0, 0.0); TEST_FFT_SIZE];
+        let mut output = vec![Complex::default(); TEST_FFT_SIZE];
+        let mut fft_out = vec![0.0_f32; TEST_FFT_SIZE];
+        let mut fft_count = 0;
+
+        for _ in 0..47 {
+            // Repeatedly setting to the existing `true` state must not
+            // disturb the accumulator. Without the early-return guard
+            // in `set_fft_enabled` this would zero `fft_skip_counter`
+            // every call and we'd never see an FFT.
+            fe.set_fft_enabled(true);
+            let (_, fft_ready) = fe.process(&chunk, &mut output, &mut fft_out).unwrap();
+            if fft_ready {
+                fft_count += 1;
+            }
+        }
+        assert_eq!(
+            fft_count, 10,
+            "idempotent set_fft_enabled(true) must not reset cadence; got {fft_count}"
         );
     }
 }

--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -4,6 +4,36 @@
 use libadwaita as adw;
 use libadwaita::prelude::*;
 
+/// Config key for the user's "Show waterfall" toggle. Mirrors the
+/// `ui_sidebar_*` naming pattern in `activity_bar.rs` so future
+/// per-pane prefs land in the same namespace. Per #646.
+pub const KEY_WATERFALL_ENABLED: &str = "ui_display_waterfall_enabled";
+
+/// Default value for the waterfall master toggle. Default-on so a
+/// fresh install matches the historical "you see the waterfall as
+/// soon as you tune in" expectation; users opt out for CPU savings
+/// on audio-only listening sessions.
+pub const DEFAULT_WATERFALL_ENABLED: bool = true;
+
+/// Read the persisted waterfall-enabled toggle. Returns
+/// [`DEFAULT_WATERFALL_ENABLED`] when the key is missing or not a
+/// bool (covers "fresh install" and "user hand-edited the config
+/// to garbage" both).
+pub fn read_waterfall_enabled(config: &std::sync::Arc<sdr_config::ConfigManager>) -> bool {
+    config.read(|v| {
+        v.get(KEY_WATERFALL_ENABLED)
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(DEFAULT_WATERFALL_ENABLED)
+    })
+}
+
+/// Persist the waterfall-enabled toggle.
+pub fn save_waterfall_enabled(config: &std::sync::Arc<sdr_config::ConfigManager>, enabled: bool) {
+    config.write(|v| {
+        v[KEY_WATERFALL_ENABLED] = serde_json::json!(enabled);
+    });
+}
+
 /// Default frame rate in FPS.
 const DEFAULT_FPS: f64 = 20.0;
 /// Minimum frame rate in FPS.
@@ -68,6 +98,12 @@ pub struct DisplayPanel {
     pub max_db_row: adw::SpinRow,
     /// Toggle for spectrum fill area under the trace.
     pub fill_mode_row: adw::SwitchRow,
+    /// Toggle for the waterfall display + the underlying FFT compute.
+    /// Off suspends the FFT loop entirely (no per-sample copy, no
+    /// windowing, no FFT) for CPU savings during audio-only listening
+    /// sessions where the spectrum isn't being looked at. Audio /
+    /// recording paths are unaffected. Per #646.
+    pub waterfall_enabled_row: adw::SwitchRow,
     /// Spectrum averaging mode selector.
     pub averaging_row: adw::ComboRow,
     /// Theme selector (System / Dark / Light).
@@ -182,6 +218,18 @@ pub fn build_display_panel() -> DisplayPanel {
         .active(true)
         .build();
 
+    // --- Waterfall master toggle ---
+    // Off suspends the FFT compute + waterfall draw entirely.
+    // Audio + recording paths are independent and continue to run.
+    // Default-on so first-launch behavior matches the historical
+    // "you see the waterfall as soon as you tune in" expectation.
+    // Per #646.
+    let waterfall_enabled_row = adw::SwitchRow::builder()
+        .title("Show waterfall")
+        .subtitle("Disable to save CPU when listening only — audio + recording unaffected")
+        .active(true)
+        .build();
+
     // --- Averaging Mode ---
     let averaging_model = gtk4::StringList::new(&["None", "Peak Hold", "Average", "Min Hold"]);
     let averaging_row = adw::ComboRow::builder()
@@ -213,6 +261,7 @@ pub fn build_display_panel() -> DisplayPanel {
         .title("Waterfall")
         .description("Color mapping for the scrolling history")
         .build();
+    waterfall_group.add(&waterfall_enabled_row);
     waterfall_group.add(&color_map_row);
 
     let levels_group = adw::PreferencesGroup::builder()
@@ -264,6 +313,7 @@ pub fn build_display_panel() -> DisplayPanel {
         min_db_row,
         max_db_row,
         fill_mode_row,
+        waterfall_enabled_row,
         averaging_row,
         theme_row,
         scanner_axis_row,

--- a/crates/sdr-ui/src/sidebar/display_panel.rs
+++ b/crates/sdr-ui/src/sidebar/display_panel.rs
@@ -227,7 +227,9 @@ pub fn build_display_panel() -> DisplayPanel {
     let waterfall_enabled_row = adw::SwitchRow::builder()
         .title("Show waterfall")
         .subtitle("Disable to save CPU when listening only — audio + recording unaffected")
-        .active(true)
+        // Reference the named default so a future flip applies in
+        // one place. Per CR round 1.
+        .active(DEFAULT_WATERFALL_ENABLED)
         .build();
 
     // --- Averaging Mode ---

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -313,6 +313,43 @@ impl SpectrumHandle {
         self.fft_area.queue_draw();
     }
 
+    /// Wipe the waterfall surface, clear the spectrum trace data,
+    /// and reset the signal-history ring + averaging buffer. Used
+    /// when the waterfall master toggle goes off (#646) so the
+    /// user doesn't see a frozen pre-disable snapshot while the
+    /// FFT compute is suspended.
+    ///
+    /// Three states are reset:
+    /// - **Waterfall pixel buffer** (`WaterfallRenderer::clear`):
+    ///   surface returns to its as-built blank state.
+    /// - **FFT trace** (`FftPlotState::current_data` cleared): the
+    ///   spectrum line draws empty until new data arrives.
+    /// - **Signal history** (`SignalHistoryRenderer::clear`): the
+    ///   top signal-strength chart resets to its empty as-built
+    ///   state.
+    /// - **Averaging buffer**: cleared so re-enable starts a fresh
+    ///   running average instead of continuing from stale samples.
+    ///
+    /// Each `DrawingArea` is queued for a redraw so the user sees
+    /// the cleared state immediately, including when the receiver
+    /// isn't currently playing (no incoming data to trigger a
+    /// natural redraw).
+    pub fn clear_displays(&self) {
+        if let Some(s) = self.waterfall_state.borrow_mut().as_mut() {
+            s.renderer.clear();
+        }
+        if let Some(s) = self.fft_state.borrow_mut().as_mut() {
+            s.current_data.clear();
+        }
+        if let Some(s) = self.signal_history_state.borrow_mut().as_mut() {
+            s.renderer.clear();
+        }
+        self.avg_buffer.borrow_mut().clear();
+        self.fft_area.queue_draw();
+        self.waterfall_area.queue_draw();
+        self.signal_history_area.queue_draw();
+    }
+
     /// Set the spectrum averaging mode, resetting the averaging buffer.
     pub fn set_averaging_mode(&self, mode: AveragingMode) {
         self.averaging_mode.set(mode);

--- a/crates/sdr-ui/src/spectrum/signal_history.rs
+++ b/crates/sdr-ui/src/spectrum/signal_history.rs
@@ -52,6 +52,16 @@ impl SignalHistoryRenderer {
         }
     }
 
+    /// Drop all accumulated samples and reset the write head.
+    /// Used when the waterfall master toggle goes off so the user
+    /// doesn't see a stale signal trace from before the gate
+    /// closed. Per #646.
+    pub fn clear(&mut self) {
+        self.samples.fill(f32::NEG_INFINITY);
+        self.write_pos = 0;
+        self.count = 0;
+    }
+
     /// Render the signal history line plot using Cairo.
     ///
     /// # Arguments
@@ -160,8 +170,32 @@ impl SignalHistoryRenderer {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     /// Compile-time validation that signal history constants are consistent.
     const _: () = {
         assert!(super::HISTORY_SIZE > 0);
     };
+
+    #[test]
+    fn clear_resets_to_as_built_state() {
+        // Per #646: when the user toggles the waterfall off, the
+        // signal-history chart must reset rather than freezing on
+        // pre-disable samples. `clear()` returns the renderer to
+        // its `new()` state — empty count, write head at 0, samples
+        // back to NEG_INFINITY.
+        let mut r = SignalHistoryRenderer::new();
+        for db in [-30.0_f32, -25.0, -20.0, -15.0] {
+            r.push(db);
+        }
+        assert_eq!(r.count, 4, "push should bump count");
+        assert_eq!(r.write_pos, 4, "push should advance write head");
+        assert_ne!(r.samples[0], f32::NEG_INFINITY, "samples populated");
+
+        r.clear();
+
+        assert_eq!(r.count, 0);
+        assert_eq!(r.write_pos, 0);
+        assert!(r.samples.iter().all(|s| *s == f32::NEG_INFINITY));
+    }
 }

--- a/crates/sdr-ui/src/spectrum/signal_history.rs
+++ b/crates/sdr-ui/src/spectrum/signal_history.rs
@@ -190,12 +190,26 @@ mod tests {
         }
         assert_eq!(r.count, 4, "push should bump count");
         assert_eq!(r.write_pos, 4, "push should advance write head");
-        assert_ne!(r.samples[0], f32::NEG_INFINITY, "samples populated");
+        // `is_finite()` is sentinel-aware: NEG_INFINITY is not finite,
+        // any pushed dB sample is. Avoids the `clippy::float_cmp` lint
+        // that direct equality against NEG_INFINITY would trigger.
+        assert!(r.samples[0].is_finite(), "samples populated");
 
         r.clear();
 
         assert_eq!(r.count, 0);
         assert_eq!(r.write_pos, 0);
-        assert!(r.samples.iter().all(|s| *s == f32::NEG_INFINITY));
+        // Every slot must be the NEG_INFINITY sentinel post-clear.
+        // `is_infinite() && is_sign_negative()` is the lint-clean
+        // way to assert "this is exactly NEG_INFINITY" without a
+        // direct float-compare. Stricter than `!is_finite()` because
+        // it rejects positive infinity and NaN — both would indicate
+        // a bug in `clear()`.
+        assert!(
+            r.samples
+                .iter()
+                .all(|s| s.is_infinite() && s.is_sign_negative()),
+            "every slot must be NEG_INFINITY post-clear",
+        );
     }
 }

--- a/crates/sdr-ui/src/spectrum/waterfall.rs
+++ b/crates/sdr-ui/src/spectrum/waterfall.rs
@@ -427,6 +427,17 @@ impl WaterfallRenderer {
         self.colormap_bgra = rgba_to_bgra(&map);
     }
 
+    /// Wipe the entire waterfall surface back to its as-built blank
+    /// state. Used when the waterfall master toggle goes off
+    /// (#646) so the user doesn't see a frozen snapshot of pre-
+    /// disable data while the FFT compute is suspended. Re-enabling
+    /// the toggle starts painting from the top — same behavior as
+    /// a fresh launch with no data yet.
+    pub fn clear(&mut self) {
+        self.pixel_buf.fill(0);
+        self.top_row = 0;
+    }
+
     pub fn set_db_range(&mut self, min_db: f32, max_db: f32) {
         if min_db.is_finite() && max_db.is_finite() && max_db > min_db {
             self.min_db = min_db;
@@ -593,6 +604,37 @@ fn rgba_to_bgra(rgba: &[[u8; 4]]) -> Vec<[u8; 4]> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clear_zeros_pixel_buf_and_resets_top_row() {
+        // Per #646: toggling the waterfall off must wipe the
+        // surface so the user doesn't see a frozen pre-disable
+        // snapshot. Fresh `new()` state is all-zeros + top_row=0;
+        // `clear()` must restore that exact state regardless of
+        // how many lines were pushed first.
+        let mut r = WaterfallRenderer::new(64);
+        for _ in 0..10 {
+            r.push_line(&vec![-30.0_f32; 64]);
+        }
+        assert!(
+            r.pixel_buf.iter().any(|b| *b != 0),
+            "push_line must have written non-zero pixels for the test premise to hold"
+        );
+        // top_row may have advanced (it walks backwards as new
+        // rows arrive — the ring-buffer wrap shipped in PR #458).
+        // Whichever value it landed on, `clear()` should reset it.
+
+        r.clear();
+
+        assert!(
+            r.pixel_buf.iter().all(|b| *b == 0),
+            "clear must zero every byte of pixel_buf"
+        );
+        assert_eq!(
+            r.top_row, 0,
+            "clear must reset top_row so the next push_line starts at the top"
+        );
+    }
 
     #[test]
     fn downsample_preserves_peak() {

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -314,6 +314,20 @@ pub struct AppState {
     pub sstv_recording_pass: RefCell<Option<(u32, chrono::DateTime<chrono::Utc>)>>,
     /// ACARS toggle (mirrors persisted `acars_enabled`).
     pub acars_enabled: Cell<bool>,
+    /// User-facing waterfall master toggle. Mirrors the persisted
+    /// `ui_display_waterfall_enabled` config key. Combined with
+    /// `waterfall_window_minimized` to drive the DSP-side
+    /// `SetFftEnabled` gate — see `resolve_waterfall_gate`. Per #646.
+    pub waterfall_user_enabled: Cell<bool>,
+    /// Transient window-minimize state. Updated by the GdkToplevel
+    /// state-notify handler when the compositor reports the
+    /// application window is minimized; reverted when restored.
+    /// Combines with `waterfall_user_enabled` to suspend FFT
+    /// compute even when the user has the toggle on. Default false
+    /// — best-effort: not all compositors fire `MINIMIZED` state
+    /// changes, in which case auto-pause is a no-op and the user
+    /// toggle remains the only gate. Per #647.
+    pub waterfall_window_minimized: Cell<bool>,
     /// Bounded ring of recent decoded messages. Cap is set
     /// from `acars_recent_keep_count` config (default 500).
     pub acars_recent: RefCell<VecDeque<AcarsMessage>>,
@@ -479,6 +493,9 @@ impl AppState {
             sstv_pending_export: RefCell::new(Vec::new()),
             sstv_recording_pass: RefCell::new(None),
             acars_enabled: Cell::new(false),
+            // Default-on; loaded from config in `connect_display_panel`.
+            waterfall_user_enabled: Cell::new(true),
+            waterfall_window_minimized: Cell::new(false),
             acars_recent: RefCell::new(VecDeque::with_capacity(
                 crate::acars_config::default_recent_keep() as usize,
             )),
@@ -502,6 +519,21 @@ impl AppState {
         if let Err(e) = self.ui_tx.send(msg) {
             tracing::warn!("failed to send DSP command: {e}");
         }
+    }
+
+    /// Compute the waterfall gate (`user_enabled && !window_minimized`),
+    /// dispatch a `SetFftEnabled(bool)` to the DSP, and return the
+    /// resolved boolean so the caller can drive any UI-side cleanup
+    /// (e.g. clearing the waterfall surface when the gate goes
+    /// false; per #646 the visible waterfall + spectrum trace + signal-
+    /// history chart must reset rather than freezing on stale data).
+    /// Called from the user-toggle handler (#646), the window-minimize
+    /// handler (#647), and once at startup so the engine starts in
+    /// the resolved state. Cheap to call — Cell reads are unsynchronized.
+    pub fn resolve_and_send_waterfall_gate(&self) -> bool {
+        let enabled = self.waterfall_user_enabled.get() && !self.waterfall_window_minimized.get();
+        self.send_dsp(UiToDsp::SetFftEnabled(enabled));
+        enabled
     }
 
     /// `true` if the app is actively writing pass artifacts to disk

--- a/crates/sdr-ui/src/state.rs
+++ b/crates/sdr-ui/src/state.rs
@@ -319,7 +319,7 @@ pub struct AppState {
     /// `waterfall_window_minimized` to drive the DSP-side
     /// `SetFftEnabled` gate — see `resolve_waterfall_gate`. Per #646.
     pub waterfall_user_enabled: Cell<bool>,
-    /// Transient window-minimize state. Updated by the GdkToplevel
+    /// Transient window-minimize state. Updated by the `GdkToplevel`
     /// state-notify handler when the compositor reports the
     /// application window is minimized; reverted when restored.
     /// Combines with `waterfall_user_enabled` to suspend FFT

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -716,6 +716,61 @@ pub fn build_window(
 
     window.add_breakpoint(breakpoint);
 
+    // Auto-pause waterfall when the window is minimized (#647).
+    // Surface-level state listening: GTK4 exposes `is_active` /
+    // `is_maximized` as window properties but minimization lives on
+    // the underlying `GdkToplevel` surface. The surface isn't
+    // realized until the window is mapped, so we wait for
+    // `connect_realize` and then attach a state-notify on the
+    // toplevel.
+    //
+    // **Best-effort.** `GdkToplevelState::MINIMIZED` is reported by
+    // most major compositors (Mutter / KWin / sway / Hyprland) but
+    // some tiling WMs don't emit it; on those, this handler simply
+    // never fires and the user's Display-panel toggle remains the
+    // only gate. Audio + recording paths are unaffected regardless
+    // — the gate only runs through the FFT compute loop.
+    {
+        let state_min = Rc::clone(&state);
+        let spectrum_min = Rc::clone(&spectrum_handle);
+        window.connect_realize(move |w| {
+            let Some(surface) = w.surface() else {
+                tracing::debug!("waterfall auto-pause: window has no surface yet — skipping");
+                return;
+            };
+            let Some(toplevel) = surface.dynamic_cast_ref::<gtk4::gdk::Toplevel>() else {
+                tracing::debug!(
+                    "waterfall auto-pause: surface is not a Toplevel — minimize \
+                     detection unsupported on this platform"
+                );
+                return;
+            };
+            let state_inner = Rc::clone(&state_min);
+            let spectrum_inner = Rc::clone(&spectrum_min);
+            toplevel.connect_state_notify(move |t| {
+                let minimized = t.state().contains(gtk4::gdk::ToplevelState::MINIMIZED);
+                let prev = state_inner.waterfall_window_minimized.get();
+                if prev == minimized {
+                    return;
+                }
+                state_inner.waterfall_window_minimized.set(minimized);
+                let resolved = state_inner.resolve_and_send_waterfall_gate();
+                // Clear when going off (about to be hidden anyway,
+                // but the unminimize-then-toggle-off path needs the
+                // surface blanked so the first paint after restore
+                // doesn't show stale data while the FFT is paused).
+                // Per #647.
+                if !resolved {
+                    spectrum_inner.clear_displays();
+                }
+                tracing::info!(
+                    minimized,
+                    "window minimize state changed — waterfall gate resolved (#647)"
+                );
+            });
+        });
+    }
+
     // Wire `app.apt-open` (Ctrl+Shift+A) — opens the live APT
     // viewer window. Done here rather than in `app.rs::activate`
     // because the action's line-routing handler reads
@@ -4019,7 +4074,7 @@ fn connect_sidebar_panels(
     connect_rtl_tcp_discovery(panels, state, config, favorites_header, &favorites);
     connect_server_panel(panels, toast_overlay, server_running);
     connect_radio_panel(panels, state, scanner_force_disable);
-    connect_display_panel(panels, state, spectrum_handle);
+    connect_display_panel(panels, state, spectrum_handle, config);
     connect_audio_panel(panels, state);
     connect_volume_persistence(panels, state, config, volume_button);
     connect_distance_estimator_persistence(panels, config);
@@ -9295,6 +9350,7 @@ fn connect_display_panel(
     panels: &SidebarPanels,
     state: &Rc<AppState>,
     spectrum_handle: &Rc<spectrum::SpectrumHandle>,
+    config: &std::sync::Arc<sdr_config::ConfigManager>,
 ) {
     // FFT size
     let state_fft = Rc::clone(state);
@@ -9383,6 +9439,54 @@ fn connect_display_panel(
         .connect_active_notify(move |row| {
             spectrum_fill.set_fill_enabled(row.is_active());
             tracing::debug!(fill = row.is_active(), "fill mode changed");
+        });
+
+    // Waterfall master toggle (#646). Two inputs combine into the
+    // DSP gate: this user-facing toggle and the auto-pause-on-
+    // minimize handler in `wire_window_minimize_pause`. Both feed
+    // `state.resolve_and_send_waterfall_gate()` which dispatches a
+    // single `SetFftEnabled(bool)` to the engine.
+    //
+    // Seed-then-wire: `set_active` fires `connect_active_notify` on
+    // some GTK4 builds, so we apply the persisted state first, send
+    // the resolved gate to the DSP, and only then connect the
+    // handler. The handler's first call after wiring is a real user
+    // toggle, not the seed.
+    let initial_waterfall_enabled = sidebar::display_panel::read_waterfall_enabled(config);
+    state.waterfall_user_enabled.set(initial_waterfall_enabled);
+    panels
+        .display
+        .waterfall_enabled_row
+        .set_active(initial_waterfall_enabled);
+    let initial_resolved = state.resolve_and_send_waterfall_gate();
+    if !initial_resolved {
+        // Persisted-off launch: ensure the displays start blank
+        // instead of inheriting whatever the last frame painted
+        // before the previous shutdown — matters when
+        // `waterfall_state` was just initialized with non-zero
+        // pixels (race-window unlikely, but the cost is one
+        // memset).
+        spectrum_handle.clear_displays();
+    }
+    let state_wf = Rc::clone(state);
+    let config_wf = std::sync::Arc::clone(config);
+    let spectrum_wf = Rc::clone(spectrum_handle);
+    panels
+        .display
+        .waterfall_enabled_row
+        .connect_active_notify(move |row| {
+            let active = row.is_active();
+            state_wf.waterfall_user_enabled.set(active);
+            sidebar::display_panel::save_waterfall_enabled(&config_wf, active);
+            let resolved = state_wf.resolve_and_send_waterfall_gate();
+            // Clear the visible state on disable so the user doesn't
+            // see a frozen pre-disable snapshot. Skipped on enable —
+            // the next FFT frame will paint the start of fresh data
+            // naturally without an explicit clear. Per #646.
+            if !resolved {
+                spectrum_wf.clear_displays();
+            }
+            tracing::info!(active, "waterfall master toggle changed (#646)");
         });
 
     // Averaging mode selector.

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -747,25 +747,52 @@ pub fn build_window(
             };
             let state_inner = Rc::clone(&state_min);
             let spectrum_inner = Rc::clone(&spectrum_min);
+
+            // Shared logic for both the initial seed and every
+            // subsequent state change. `connect_state_notify` only
+            // fires when the property changes — not at handler
+            // attachment — so a window that's already minimized at
+            // realize-time would otherwise leave the FFT gate open
+            // until the next state transition. Per CR round 1 on
+            // PR #653.
+            let apply_minimized =
+                |minimized: bool, state: &Rc<AppState>, spectrum: &spectrum::SpectrumHandle| {
+                    let prev = state.waterfall_window_minimized.replace(minimized);
+                    if prev == minimized {
+                        return;
+                    }
+                    let resolved = state.resolve_and_send_waterfall_gate();
+                    // Clear when the gate is going off so the first
+                    // paint after restore doesn't show stale data while
+                    // the FFT compute is suspended. Per #647.
+                    if !resolved {
+                        spectrum.clear_displays();
+                    }
+                    tracing::info!(
+                        minimized,
+                        "window minimize state changed — waterfall gate resolved (#647)"
+                    );
+                };
+
+            // Initial seed: read whatever state the toplevel was in
+            // at realize time. Most launches start non-minimized
+            // (apply_minimized's `prev == minimized` early-return
+            // makes this a no-op there); the unusual case is a
+            // session-restored minimize from the WM, where this
+            // line catches it before any state-notify would.
+            apply_minimized(
+                toplevel
+                    .state()
+                    .contains(gtk4::gdk::ToplevelState::MINIMIZED),
+                &state_inner,
+                &spectrum_inner,
+            );
+
             toplevel.connect_state_notify(move |t| {
-                let minimized = t.state().contains(gtk4::gdk::ToplevelState::MINIMIZED);
-                let prev = state_inner.waterfall_window_minimized.get();
-                if prev == minimized {
-                    return;
-                }
-                state_inner.waterfall_window_minimized.set(minimized);
-                let resolved = state_inner.resolve_and_send_waterfall_gate();
-                // Clear when going off (about to be hidden anyway,
-                // but the unminimize-then-toggle-off path needs the
-                // surface blanked so the first paint after restore
-                // doesn't show stale data while the FFT is paused).
-                // Per #647.
-                if !resolved {
-                    spectrum_inner.clear_displays();
-                }
-                tracing::info!(
-                    minimized,
-                    "window minimize state changed — waterfall gate resolved (#647)"
+                apply_minimized(
+                    t.state().contains(gtk4::gdk::ToplevelState::MINIMIZED),
+                    &state_inner,
+                    &spectrum_inner,
                 );
             });
         });


### PR DESCRIPTION
## Summary

Two coupled features that share a single DSP-side gate, plus a real-world-tested correctness fix for the visible-state-on-disable case:

### 1. Display sidebar "Show waterfall" toggle (#646)

A new `AdwSwitchRow` in the Display panel's Waterfall group, titled **"Show waterfall"** with subtitle "Disable to save CPU when listening only — audio + recording unaffected". When off, the IQ frontend's FFT compute loop is suspended entirely — the per-sample copy into `fft_accum`, the windowing pass, and the FFT itself are all skipped. Audio + recording paths are independent and continue to run normally.

State persists in a new `ui_display_waterfall_enabled` config key. Default-on so a fresh install matches the historical "you see the waterfall as soon as you tune in" expectation.

### 2. Auto-pause on window minimize (#647)

Best-effort `GdkToplevel::state-notify` handler that suspends the same gate when the compositor reports `MINIMIZED`. Auto-restored on unminimize. Handler attaches via `connect_realize` since the surface isn't available before the window is mapped.

On compositors that don't fire `MINIMIZED` state changes (some tiling WMs), this is a no-op and the user toggle remains the only gate.

### 3. Display state cleared on disable

Surfaced from real-world testing during the smoke run: toggling the waterfall off mid-play left the surface frozen on the last pre-disable frame, with the signal-history chart at the top still showing pre-disable dB values — visually misleading. The toggle now calls `SpectrumHandle::clear_displays()` which resets:

- **Waterfall pixel buffer** (`WaterfallRenderer::clear`) — surface returns to its as-built blank state
- **FFT trace data** (`FftPlotState::current_data`) — the spectrum line draws empty
- **Signal-history ring** (`SignalHistoryRenderer::clear`) — top chart resets to its empty state
- **Averaging buffer** — re-enable starts a fresh running average instead of continuing from stale samples

Each `DrawingArea` is queued for a redraw so the cleared state is visible immediately, including when the receiver isn't currently playing (no incoming data to trigger a natural redraw).

## Architecture

```
[User toggle] -> AppState.waterfall_user_enabled -+
                                                  |
[Window minimize] -> AppState.waterfall_window_   +-> resolve_and_send_waterfall_gate()
                     minimized                   /          |
                                                /           v
                                               /     UiToDsp::SetFftEnabled(bool)
                                              /            |
                                             /             v
                                            /     IqFrontend::fft_enabled
                                           /          (skips FFT loop)
                                          /
                  (returns resolved bool) -> on disable: SpectrumHandle::clear_displays()
```

The DSP-side gate (`IqFrontend::fft_enabled`) is independent of `fft_rate` so re-enabling resumes at the previously-configured frame rate without a settings round-trip.

`set_fft_enabled` is also mirrored alongside `set_fft_rate` at the three frontend-rebuild sites (`SetFftSize`, `SetWindowFunction`, sample-rate change) so a rebuild doesn't silently resume the waterfall after the user had it toggled off.

## Tests

**6 new unit tests:**

`sdr-pipeline::iq_frontend`:
- `test_fft_enabled_default_is_true` — historical behavior preserved for call sites that don't toggle the gate
- `test_fft_disabled_suppresses_fft_ready` — gate skips the entire FFT loop; audio path still runs (verifies `processed > 0`)
- `test_fft_re_enable_resumes_at_configured_rate` — toggling off then back on restores the previously-configured 10 FPS rate
- `test_fft_set_enabled_idempotent` — repeatedly setting to the existing state is a no-op (no accumulator reset on no-op; otherwise a chatty UI would stall the cadence)

`spectrum::waterfall`:
- `clear_zeros_pixel_buf_and_resets_top_row` — pin the as-built-state-restoration contract

`spectrum::signal_history`:
- `clear_resets_to_as_built_state` — same for the top signal-strength chart

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --features whisper-cuda --workspace -- -D warnings` clean
- [x] `cargo build --features whisper-cuda` green
- [x] `cargo test --workspace --features whisper-cuda` — 1921 passed / 0 failed / 14 ignored (6 more than 1915 baseline, matches the new tests)
- [x] `make install CARGO_FLAGS="--release --features whisper-cuda"` completes; binary at `~/.cargo/bin/sdr-rs`
- [x] Live UI smoke: toggle persists across restart
- [x] Live UI smoke: mid-play disable clears the visible state immediately (waterfall blanks, signal-history graph resets, FFT trace empties)
- [x] Live UI smoke: re-enabling immediately resumes painting at the configured FPS without a config round-trip
- [x] Live UI smoke: scanner audio + Whisper transcription unaffected with toggle off (validated end-to-end on local PD/fire scanner)
- [x] Live UI smoke: toggle off while paused / not playing also clears the visible state (the edge case from the original bug report)

## Files changed

| File | What |
|---|---|
| `crates/sdr-pipeline/src/iq_frontend.rs` | `fft_enabled` flag + `set_fft_enabled` setter, gate at top of `process()`, 4 unit tests |
| `crates/sdr-core/src/messages.rs` | New `UiToDsp::SetFftEnabled(bool)` variant |
| `crates/sdr-core/src/controller.rs` | `state.fft_enabled` field, message handler, reapply at 3 frontend-rebuild sites |
| `crates/sdr-ui/src/state.rs` | `waterfall_user_enabled` + `waterfall_window_minimized` Cells + `resolve_and_send_waterfall_gate` method |
| `crates/sdr-ui/src/sidebar/display_panel.rs` | `KEY_WATERFALL_ENABLED` + `read_waterfall_enabled` / `save_waterfall_enabled`, new `waterfall_enabled_row` |
| `crates/sdr-ui/src/window.rs` | Toggle wiring, minimize handler via `connect_realize` → `gdk::Toplevel::connect_state_notify`, clear-on-disable |
| `crates/sdr-ui/src/spectrum/mod.rs` | `SpectrumHandle::clear_displays()` |
| `crates/sdr-ui/src/spectrum/waterfall.rs` | `WaterfallRenderer::clear` + unit test |
| `crates/sdr-ui/src/spectrum/signal_history.rs` | `SignalHistoryRenderer::clear` + unit test |

Closes #646, closes #647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User-configurable master toggle to disable the waterfall/FFT display (saves CPU; audio/demodulation continue).
  * Waterfall auto-pauses when the application window is minimized.
  * Preference for waterfall enabled/disabled is persisted across sessions.
  * Clear displays: resets FFT plot, waterfall and signal-history immediately.

* **Behavior**
  * Disabling the waterfall suppresses FFT output without altering configured FFT rate; re-enabling resumes at the prior cadence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->