### PR TITLE
feat(sdr-core): SSTV per-pass diagnostic counters + duty-cycle docs (#648)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -232,6 +232,74 @@ use crate::acars_output::AcarsOutputs;
 /// Mutable state owned by the DSP thread.
 ///
 /// This is a god-struct that holds every piece of DSP-thread state by
+/// Per-SSTV-pass diagnostic counters. Reset between passes by
+/// [`reset_imaging_decoders`] (which logs a summary first). Lets
+/// a post-pass log analysis answer:
+/// - "Did the satellite transmit at all?" (VIS count > 0)
+/// - "How many complete images did we get?" (image_complete_count)
+/// - "Did any decode get cut short?" (lines_decoded > 0 with
+///   image_complete_count == 0 means partial — the duty-cycle
+///   OFF window or the satellite going below horizon truncated a
+///   mid-decode image).
+///
+/// All fields are pure observational counters — incremented from
+/// the SSTV event loop in `sstv_decode_tap`. No processing impact.
+/// Per #648.
+#[derive(Debug, Default)]
+struct SstvPassStats {
+    /// VIS headers detected since the last reset. Each detection
+    /// indicates the start of a new image (Robot 36 / PD120 /
+    /// Scottie / etc.).
+    vis_count: u32,
+    /// Complete images decoded. A "complete" image is one where
+    /// the decoder emitted `SstvEvent::ImageComplete` — partial
+    /// images that ran out of audio mid-frame don't count here
+    /// (use `lines_decoded` to see if any imagery was captured).
+    image_complete_count: u32,
+    /// Total scan lines decoded across all images this pass
+    /// (complete + partial). A pass with `vis_count > 0`,
+    /// `image_complete_count == 0`, and `lines_decoded > 0` got
+    /// imagery but lost it before the final scan-line — a hint
+    /// that the pass elevation dropped or the duty-cycle OFF
+    /// window started before image completion.
+    lines_decoded: u64,
+}
+
+impl SstvPassStats {
+    /// Whether any SSTV event fired this pass. Drives the
+    /// "log summary or skip" decision in [`reset_imaging_decoders`]
+    /// — a no-op reset (e.g. between two non-SSTV passes) shouldn't
+    /// emit a "0 / 0 / 0" log line and clutter the trace.
+    fn saw_any_event(&self) -> bool {
+        self.vis_count > 0 || self.image_complete_count > 0 || self.lines_decoded > 0
+    }
+
+    /// Mutate counters for one [`slowrx::SstvEvent`]. Extracted from
+    /// the inline match arms in `sstv_decode_tap` so the counter
+    /// logic is testable without spinning up a real `SstvDecoder`
+    /// (which would need synthetic SSTV-mode tone generation, a
+    /// significant scaffolding investment that's deferred per #648).
+    /// Per #648.
+    fn record_event(&mut self, event: &slowrx::SstvEvent) {
+        match event {
+            slowrx::SstvEvent::VisDetected { .. } => {
+                self.vis_count += 1;
+            }
+            slowrx::SstvEvent::LineDecoded { .. } => {
+                self.lines_decoded += 1;
+            }
+            slowrx::SstvEvent::ImageComplete { .. } => {
+                self.image_complete_count += 1;
+            }
+            // `SstvEvent` is `#[non_exhaustive]` — silently ignore
+            // future variants so a slowrx update doesn't require a
+            // source change here. Same forward-compat stance as the
+            // event-dispatch loop in `sstv_decode_tap`.
+            _ => {}
+        }
+    }
+}
+
 /// design — the DSP thread owns everything exclusively. The
 /// `struct_excessive_bools` lint triggers at 4 bools (`running`,
 /// `dc_blocking`, `invert_iq`, `squelch_was_open`); splitting them
@@ -554,6 +622,14 @@ struct DspState {
     /// Reused across DSP blocks, resized in place each call so we
     /// don't alloc inside the hot loop. Mirrors `apt_mono_buf`.
     sstv_mono_buf: Vec<f32>,
+    /// Per-SSTV-pass statistics. Reset between passes by
+    /// `reset_imaging_decoders`, which also logs a summary line so
+    /// a `grep "SSTV pass summary"` of the log shows whether each
+    /// pass produced imagery, partial frames, or just VIS detections
+    /// without complete images. Important for duty-cycled events
+    /// like ARISS Series 32 where a pass might yield 1-3 complete
+    /// images out of 3-4 detected VIS bursts. Per #648.
+    sstv_pass_stats: SstvPassStats,
     /// Most recent audio sample rate that `SstvDecoder::new` rejected,
     /// or `None` if every prior init succeeded / hasn't been tried.
     /// Guards against the audio-block hot loop retrying on a rate the
@@ -712,6 +788,7 @@ impl DspState {
             sstv_decoder: None,
             sstv_mono_buf: Vec::new(),
             sstv_init_failed_at_rate: None,
+            sstv_pass_stats: SstvPassStats::default(),
             sstv_image: None,
             acars_bank: None,
             acars_pre_lock: None,
@@ -917,6 +994,11 @@ fn sstv_decode_tap(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, audio_c
     // dispatch. `SstvEvent` is `#[non_exhaustive]`, so a wildcard arm
     // handles future mode additions without a compile break.
     for event in decoder.process(&state.sstv_mono_buf) {
+        // Update per-pass diagnostic counters before dispatch — the
+        // counters tell us at LOS how many VIS were detected, how
+        // many images completed, and how many lines decoded across
+        // all (complete + partial) images. Per #648.
+        state.sstv_pass_stats.record_event(&event);
         match event {
             slowrx::SstvEvent::VisDetected {
                 mode,
@@ -3696,6 +3778,21 @@ fn reset_imaging_decoders(state: &mut DspState) {
     state.sstv_decoder = None;
     state.sstv_mono_buf.clear();
     state.sstv_init_failed_at_rate = None;
+    // Per-pass SSTV diagnostic summary. Skip the log when the
+    // pass produced no events — a no-op reset between two non-
+    // SSTV passes (e.g. back-to-back LRPT recordings on a
+    // shared SSTV-decoder lifecycle) shouldn't clutter the
+    // trace with a "0 VIS / 0 images" line. Per #648.
+    if state.sstv_pass_stats.saw_any_event() {
+        let stats = &state.sstv_pass_stats;
+        tracing::info!(
+            vis_count = stats.vis_count,
+            image_complete_count = stats.image_complete_count,
+            lines_decoded = stats.lines_decoded,
+            "SSTV pass summary"
+        );
+    }
+    state.sstv_pass_stats = SstvPassStats::default();
 }
 
 /// Rebuild the IQ frontend with the current sample rate, preserving user settings.
@@ -4970,6 +5067,126 @@ mod tests {
         assert!(RECV_TIMEOUT_MS > 0);
         assert!(VFO_OUTPUT_PADDING > 0);
     };
+
+    /// Synthesize a `SstvEvent::VisDetected` for tests. The
+    /// inner field values don't matter for counter-update tests
+    /// — we only care that the event variant is `VisDetected`.
+    fn fake_vis_event() -> slowrx::SstvEvent {
+        slowrx::SstvEvent::VisDetected {
+            mode: slowrx::SstvMode::Robot36,
+            sample_offset: 0,
+            hedr_shift_hz: 0.0,
+        }
+    }
+
+    /// Synthesize a `SstvEvent::LineDecoded` for tests. Empty
+    /// pixel buffer is fine — `record_event` only inspects the
+    /// variant tag, not contents.
+    fn fake_line_event() -> slowrx::SstvEvent {
+        slowrx::SstvEvent::LineDecoded {
+            mode: slowrx::SstvMode::Robot36,
+            line_index: 0,
+            pixels: Vec::new(),
+        }
+    }
+
+    /// Synthesize a `SstvEvent::ImageComplete` for tests. Uses
+    /// `SstvImage::new` (the public constructor — `SstvImage` is
+    /// `#[non_exhaustive]` so direct struct-literal init is
+    /// rejected by the compiler) with a minimal 1×1 size. The
+    /// counter logic doesn't read the image dimensions; the fake
+    /// just has to be a valid variant. `partial: false` matches
+    /// the V1 slowrx contract (only the final clean image surface
+    /// emits this event).
+    fn fake_image_complete_event() -> slowrx::SstvEvent {
+        slowrx::SstvEvent::ImageComplete {
+            image: slowrx::SstvImage::new(slowrx::SstvMode::Robot36, 1, 1),
+            partial: false,
+        }
+    }
+
+    #[test]
+    fn sstv_pass_stats_default_is_empty() {
+        let stats = SstvPassStats::default();
+        assert_eq!(stats.vis_count, 0);
+        assert_eq!(stats.image_complete_count, 0);
+        assert_eq!(stats.lines_decoded, 0);
+        assert!(
+            !stats.saw_any_event(),
+            "default stats must report no events — drives the \
+             skip-summary-log decision in reset_imaging_decoders"
+        );
+    }
+
+    #[test]
+    fn sstv_pass_stats_increments_per_event_kind() {
+        // Counter dispatch table: each event variant maps to
+        // exactly one counter. Per #648.
+        let mut stats = SstvPassStats::default();
+        stats.record_event(&fake_vis_event());
+        assert_eq!(stats.vis_count, 1);
+        assert_eq!(stats.image_complete_count, 0);
+        assert_eq!(stats.lines_decoded, 0);
+
+        stats.record_event(&fake_line_event());
+        stats.record_event(&fake_line_event());
+        assert_eq!(stats.lines_decoded, 2);
+        assert_eq!(stats.vis_count, 1, "line events must not bump vis_count");
+
+        stats.record_event(&fake_image_complete_event());
+        assert_eq!(stats.image_complete_count, 1);
+        assert_eq!(stats.vis_count, 1, "image-complete must not bump vis_count");
+        assert_eq!(
+            stats.lines_decoded, 2,
+            "image-complete must not bump lines_decoded"
+        );
+
+        assert!(
+            stats.saw_any_event(),
+            "stats with non-zero counters must report saw_any_event"
+        );
+    }
+
+    #[test]
+    fn sstv_pass_stats_counts_a_realistic_ariss_pass() {
+        // Realistic Series 32 pass: 3 VIS bursts (ARISS duty
+        // cycle = 36 sec ON / 2 min OFF, typical 7-min pass
+        // catches ~3 windows), 2 complete images, 1 partial
+        // (~80 lines into the 240-line PD120 image when LOS
+        // truncated it). This is the shape we expect post-#648
+        // log analysis to reveal. Per #648.
+        let mut stats = SstvPassStats::default();
+
+        // Burst 1: VIS → 240 lines → ImageComplete
+        stats.record_event(&fake_vis_event());
+        for _ in 0..240 {
+            stats.record_event(&fake_line_event());
+        }
+        stats.record_event(&fake_image_complete_event());
+
+        // Burst 2: VIS → 240 lines → ImageComplete
+        stats.record_event(&fake_vis_event());
+        for _ in 0..240 {
+            stats.record_event(&fake_line_event());
+        }
+        stats.record_event(&fake_image_complete_event());
+
+        // Burst 3: VIS → 80 lines → LOS (partial)
+        stats.record_event(&fake_vis_event());
+        for _ in 0..80 {
+            stats.record_event(&fake_line_event());
+        }
+        // No ImageComplete for burst 3.
+
+        assert_eq!(stats.vis_count, 3);
+        assert_eq!(stats.image_complete_count, 2);
+        assert_eq!(stats.lines_decoded, 240 + 240 + 80);
+        // The "partial image" diagnostic: vis_count > image_complete_count
+        // AND lines_decoded > 0 means we got imagery but lost it
+        // before the final scan-line.
+        assert!(stats.vis_count > stats.image_complete_count);
+        assert!(stats.lines_decoded > 0);
+    }
 
     #[test]
     fn dsp_state_creates_successfully() {

--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -236,9 +236,9 @@ use crate::acars_output::AcarsOutputs;
 /// [`reset_imaging_decoders`] (which logs a summary first). Lets
 /// a post-pass log analysis answer:
 /// - "Did the satellite transmit at all?" (VIS count > 0)
-/// - "How many complete images did we get?" (image_complete_count)
-/// - "Did any decode get cut short?" (lines_decoded > 0 with
-///   image_complete_count == 0 means partial — the duty-cycle
+/// - "How many complete images did we get?" (`image_complete_count`)
+/// - "Did any decode get cut short?" (`lines_decoded` > 0 with
+///   `image_complete_count` == 0 means partial — the duty-cycle
 ///   OFF window or the satellite going below horizon truncated a
 ///   mid-decode image).
 ///
@@ -3784,11 +3784,15 @@ fn reset_imaging_decoders(state: &mut DspState) {
     // shared SSTV-decoder lifecycle) shouldn't clutter the
     // trace with a "0 VIS / 0 images" line. Per #648.
     if state.sstv_pass_stats.saw_any_event() {
-        let stats = &state.sstv_pass_stats;
+        // `stats` triggered `clippy::similar_names` against the
+        // surrounding `state` binding — rename to `pass_stats` for
+        // visual distinctness while keeping the access concise.
+        // Per CI clippy round on PR #658.
+        let pass_stats = &state.sstv_pass_stats;
         tracing::info!(
-            vis_count = stats.vis_count,
-            image_complete_count = stats.image_complete_count,
-            lines_decoded = stats.lines_decoded,
+            vis_count = pass_stats.vis_count,
+            image_complete_count = pass_stats.image_complete_count,
+            lines_decoded = pass_stats.lines_decoded,
             "SSTV pass summary"
         );
     }
@@ -5155,32 +5159,54 @@ mod tests {
         // (~80 lines into the 240-line PD120 image when LOS
         // truncated it). This is the shape we expect post-#648
         // log analysis to reveal. Per #648.
+        //
+        // Burst-shape constants extracted per CR round 1 — keeps a
+        // future test reader from wondering whether 240 / 80 / 3 / 2
+        // are arbitrary or load-bearing. Each constant carries the
+        // PD120 / Series 32 reference so a rebase against a future
+        // mode change updates one place.
+        /// VIS bursts captured in the pass — Series 32 duty cycle
+        /// fits ~3 windows in a typical 7-minute overpass.
+        const ARISS_EXPECTED_VIS_BURSTS: u32 = 3;
+        /// Complete images decoded — bursts 1 + 2 finished, burst
+        /// 3 was truncated by LOS.
+        const ARISS_EXPECTED_COMPLETE_IMAGES: u32 = 2;
+        /// PD120 image height in scan lines. Used here to fully
+        /// populate bursts 1 + 2 in the synthetic event stream.
+        const ARISS_FULL_IMAGE_LINES: usize = 240;
+        /// Partial-image scan-line count for burst 3 — mid-frame
+        /// when LOS / duty-cycle OFF cut the decode short. ~1/3
+        /// of the way into the PD120 image.
+        const ARISS_PARTIAL_IMAGE_LINES: usize = 80;
+
         let mut stats = SstvPassStats::default();
 
-        // Burst 1: VIS → 240 lines → ImageComplete
+        // Burst 1: VIS → full image lines → ImageComplete
         stats.record_event(&fake_vis_event());
-        for _ in 0..240 {
+        for _ in 0..ARISS_FULL_IMAGE_LINES {
             stats.record_event(&fake_line_event());
         }
         stats.record_event(&fake_image_complete_event());
 
-        // Burst 2: VIS → 240 lines → ImageComplete
+        // Burst 2: VIS → full image lines → ImageComplete
         stats.record_event(&fake_vis_event());
-        for _ in 0..240 {
+        for _ in 0..ARISS_FULL_IMAGE_LINES {
             stats.record_event(&fake_line_event());
         }
         stats.record_event(&fake_image_complete_event());
 
-        // Burst 3: VIS → 80 lines → LOS (partial)
+        // Burst 3: VIS → partial lines → LOS (no ImageComplete)
         stats.record_event(&fake_vis_event());
-        for _ in 0..80 {
+        for _ in 0..ARISS_PARTIAL_IMAGE_LINES {
             stats.record_event(&fake_line_event());
         }
-        // No ImageComplete for burst 3.
 
-        assert_eq!(stats.vis_count, 3);
-        assert_eq!(stats.image_complete_count, 2);
-        assert_eq!(stats.lines_decoded, 240 + 240 + 80);
+        assert_eq!(stats.vis_count, ARISS_EXPECTED_VIS_BURSTS);
+        assert_eq!(stats.image_complete_count, ARISS_EXPECTED_COMPLETE_IMAGES);
+        assert_eq!(
+            stats.lines_decoded,
+            (ARISS_FULL_IMAGE_LINES * 2 + ARISS_PARTIAL_IMAGE_LINES) as u64,
+        );
         // The "partial image" diagnostic: vis_count > image_complete_count
         // AND lines_decoded > 0 means we got imagery but lost it
         // before the final scan-line.

--- a/docs/guides/sstv-reception.md
+++ b/docs/guides/sstv-reception.md
@@ -73,6 +73,35 @@ station activities so some passes during the window will be silent.
 Plan to attempt several passes per day during an event rather than
 relying on any one.
 
+### Duty cycles change between events
+
+ARISS Series 32 (May 8-12, 2026) ran on a **36-second ON / 2-minute
+OFF** duty cycle — the SSTV transmitter keys for 36 seconds
+(approximately one full Robot 36 frame), then sleeps for 2 minutes,
+then keys again. A typical 7-10 minute pass over your station catches
+**2-3 burst windows**, not the continuous transmission older guides
+describe. That puts a hard ceiling on per-pass yield: at one image
+per burst, a single pass produces **at most 2-3 images**, not the
+12+ you might see referenced in older ARISS event documentation.
+
+Other recent series have run different duty cycles, including
+continuous transmission (Series 27) and 1-minute / 2-minute
+splits (Series 30). The current series's duty cycle is documented
+in the ARISS event flyer — always check the flyer for the active
+series before assuming a continuous transmit.
+
+**Practical implication for log analysis.** The auto-record path
+emits a per-pass `SSTV pass summary` log line at LOS with three
+counters: `vis_count`, `image_complete_count`, `lines_decoded`.
+A successful Series 32 pass might log `vis_count = 3,
+image_complete_count = 2, lines_decoded = 560` — three burst
+detections, two complete images, the third burst truncated by LOS
+or the duty-cycle OFF period before image completion. Use these
+counters to distinguish "satellite was off / out of range"
+(`vis_count = 0`) from "satellite was on but partial decode"
+(`vis_count > image_complete_count`) — the diagnostic surface that
+shipped in #648.
+
 ---
 
 ## Antenna


### PR DESCRIPTION
## Summary

Closes #648. Two coupled changes that surface the ARISS Series 32 duty-cycle reality (36 sec ON / 2 min OFF) without requiring a rewrite of the SSTV decoder. Diagnostic-only — no decoder behavior change.

## What changed

### 1. Per-pass SSTV stats counter (`SstvPassStats` struct, new `DspState` field)

Three pure observational counters updated from the existing `sstv_decode_tap` event loop:

| Counter | Increments on |
|---|---|
| `vis_count` | `SstvEvent::VisDetected` — start of each Robot 36 / PD120 / Scottie image |
| `image_complete_count` | `SstvEvent::ImageComplete` — full image emitted |
| `lines_decoded` | `SstvEvent::LineDecoded` — every scan line across all images (complete + partial) |

`SstvPassStats::record_event(&event)` is a pure dispatch-table function — counter logic is testable without spinning up a real `SstvDecoder` (which would need synthetic SSTV-mode tone generation, a significant scaffolding investment that's deferred per the issue's optional-followups list).

### 2. LOS-time pass summary log

In `reset_imaging_decoders` (and indirectly `cleanup`, which calls it), emit a single `tracing::info!` line with the three counters before resetting for the next pass:

```text
SSTV pass summary vis_count=3 image_complete_count=2 lines_decoded=560
```

That's the diagnostic surface the original ARISS Series 32 silent-pass investigation was missing: it distinguishes **"satellite was off / weak signal / wrong band"** (`vis_count = 0`) from **"satellite was on but partial decode"** (`vis_count > image_complete_count`) without requiring offline IQ analysis. The skip-when-empty guard (`saw_any_event()`) prevents a chatty no-op reset between back-to-back non-SSTV passes from cluttering the trace.

### 3. `docs/guides/sstv-reception.md` — "Duty cycles change between events" subsection

Documents the Series 32 36s/2min duty cycle explicitly. Sets the realistic per-pass yield expectation (2-3 images, not 12+). Cross-references the new pass summary log line so users running offline log analysis know what to grep for.

## Tests

3 new unit tests in `controller::tests`:

- `sstv_pass_stats_default_is_empty` — verifies `Default` returns all-zeros and `saw_any_event()` correctly reports false (drives the skip-summary-log decision)
- `sstv_pass_stats_increments_per_event_kind` — pins the counter dispatch table: VIS → vis_count only, LineDecoded → lines_decoded only, ImageComplete → image_complete_count only. Catches a regression that re-routes one event into the wrong counter.
- `sstv_pass_stats_counts_a_realistic_ariss_pass` — synthesises the exact shape we expect to see post-#648 in real-world Series 32 logs: 3 VIS bursts, 2 complete images, 1 partial (~80 lines truncated by LOS or duty-cycle OFF window). Asserts `vis_count > image_complete_count` and `lines_decoded > 0` — the hallmark of "got imagery but lost it before final scan-line."

Helper functions construct fake `SstvEvent` variants; `SstvImage` is `#[non_exhaustive]` in slowrx 0.5 so the test helper uses `SstvImage::new` rather than direct struct-literal init.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --features whisper-cuda --workspace -- -D warnings` clean
- [x] `cargo build --features whisper-cuda` green
- [x] `cargo test --workspace --features whisper-cuda` — 1928 passed / 0 failed / 14 ignored (3 more than 1925 baseline, matches the new tests)
- [x] `make install CARGO_FLAGS="--release --features whisper-cuda"` completes
- [x] Live UI smoke: no regressions on existing LRPT / APT / SSTV paths; new counters increment in `sstv_decode_tap`'s event loop without affecting decoder behavior

## Out of scope (filed as follow-up issues if pursued)

The original issue listed five sub-tasks; this PR ships the three highest-leverage ones (#1 burst-detection logging via the summary counters, #3 docs update, plus the testable helper). Two are intentionally deferred:

- **VIS re-detection synthetic test** — would need a Robot 36 audio generator to feed the decoder, significant test scaffolding. The issue lists this as "Suggested investigation" rather than required.
- **Per-burst WAV segmentation** — recorder state-machine change. Bigger surface, separate concern from event-counter diagnostics.
- **ARISS event-window catalog tracking** — schema change to `KnownSatellite` + recorder logic. Speculative feature; defer until we have more event-window data to design against.

## Files changed

| File | What |
|---|---|
| `crates/sdr-core/src/controller.rs` | New `SstvPassStats` struct + `DspState` field, `record_event` helper, summary log in `reset_imaging_decoders`, 3 new unit tests |
| `docs/guides/sstv-reception.md` | New "Duty cycles change between events" subsection under "Knowing when to listen" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-pass SSTV diagnostic statistics added (detection events, decoded lines, image completion); summaries emitted only when events occurred and counters reset between passes.

* **Documentation**
  * SSTV reception guide updated to explain burst/ duty-cycle reception patterns and how to interpret per-pass summary counters.

* **Tests**
  * Added unit tests validating counter defaults, per-event increments, and realistic pass accounting scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/rtl-sdr/pull/658)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->