### PR TITLE
fix: lock Whisper to English-only output via translate + greedy decode

### DIFF
--- a/crates/sdr-transcription/src/backends/whisper.rs
+++ b/crates/sdr-transcription/src/backends/whisper.rs
@@ -340,6 +340,38 @@ fn decode_and_emit_segment(
 
     let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
     params.set_language(Some("en"));
+    // Force English output regardless of the model's per-segment
+    // language detection. The `.en` Whisper variants (Tiny / Base /
+    // Small / Medium .en) ignore this — they have no non-English
+    // tokens and `set_translate` is a no-op. Multilingual models
+    // (Large v3, Large v3 Turbo, CrisperWhisper) without this would
+    // sometimes output non-English on noisy radio chatter — the
+    // detector picks up phonetic similarities to other languages
+    // when audio is below the SNR threshold and the `language=en`
+    // hint is treated as soft. CrisperWhisper specifically (per #385
+    // smoke test) was producing Turkish / Greek / Spanish output on
+    // marginal scanner audio without this. Our app is English-radio
+    // focused; forcing English transcription is always correct.
+    params.set_translate(true);
+    // Lock down sampling to deterministic greedy decode — disables
+    // whisper.cpp's temperature fallback schedule (0.0 → 0.2 → 0.4
+    // → 0.6 → 0.8 on compression-ratio / log-prob failures). On
+    // marginal SNR audio the higher-temperature steps sample
+    // foreign-language alternatives that slip through `set_translate`
+    // (per #385 smoke: `Le order, Sami, physical h많. Oneary.` mixed
+    // French / Korean / English in one segment). Disabling the
+    // fallback means uncertain segments produce a low-confidence
+    // English guess (or nothing if hallucination filtering catches
+    // it) rather than a confident foreign-language sample.
+    params.set_temperature(0.0);
+    params.set_temperature_inc(0.0);
+    // Suppress the non-speech token bank (background-music notation,
+    // sound effects, etc.) and blank tokens. Reduces the
+    // hallucination surface further — every non-speech token the
+    // decoder picks is a token it didn't pick from the English
+    // vocabulary. Per #385.
+    params.set_suppress_blank(true);
+    params.set_suppress_nst(true);
     params.set_print_progress(false);
     params.set_print_realtime(false);
     params.set_print_timestamps(false);


### PR DESCRIPTION
## Summary

Multilingual Whisper variants (Large v3, Large v3 Turbo) sometimes produced non-English output on noisy radio chatter — the existing `set_language(Some("en"))` hint is treated as soft when audio falls below the SNR threshold, and the per-segment language detector samples phonetically-similar alternatives (Turkish, German, Greek, etc.). The `.en` variants weren't affected because they have no non-English tokens.

This PR locks the decoder down for English-only output regardless of acoustic uncertainty.

## Investigation context

This work originated in the CrisperWhisper investigation (#385). While debugging CrisperWhisper's mixed-language output, the same behavior was observed on Large v3 / Large v3 Turbo on marginal scanner audio. The fixes here address the multilingual-Whisper drift directly. CrisperWhisper itself turned out to be unreachable via our GGML pipeline due to its custom tokenizer — that's documented in the closing comment on #385 and the follow-up issue references the Sherpa-onnx path forward.

## Changes

Three coordinated parameter changes in `decode_and_emit_segment`:

### 1. `set_translate(true)`

Switches whisper.cpp's task token from "transcribe in source language" to "translate to English." 

- **`.en` variants** (Tiny / Base / Small / Medium .en): no-op — these models have no non-English tokens
- **Multilingual variants** (Large v3, Large v3 Turbo): forces English output regardless of detected source

### 2. `set_temperature(0.0) + set_temperature_inc(0.0)`

Disables whisper.cpp's temperature fallback schedule (0.0 → 0.2 → 0.4 → 0.6 → 0.8 on compression-ratio / log-prob failures).

The higher-temperature steps were the actual sampling site for the foreign-language tokens that were slipping through `set_translate` on the most marginal segments. With fallback disabled:
- Uncertain segments produce a low-confidence English guess
- Or get caught by the existing hallucination filter downstream
- Either way: never produce a confident foreign-language sample

### 3. `set_suppress_blank(true) + set_suppress_nst(true)`

Suppresses blank tokens and the non-speech token bank (background-music notation, sound effects, etc.). Reduces the hallucination surface — every non-speech token the decoder skips is a token it didn't pick from the English vocabulary.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean (CI form, no features)
- [x] `cargo clippy --all-targets --features whisper-cuda --workspace -- -D warnings` clean
- [x] `cargo build --features whisper-cuda` green
- [x] `cargo test --workspace --features whisper-cuda` — 1928 passed / 0 failed / 14 ignored (same as baseline; this is a parameter change inside the existing decode path with no new test surface)
- [x] `make install CARGO_FLAGS="--release --features whisper-cuda"` completes
- [x] Live UI smoke: Large v3 transcription on real police-dispatch audio stays English on weak signals (was producing mixed-language drift before this fix)
- [x] Live UI smoke: Tiny / Base / Small / Medium `.en` variants unchanged (no-ops for English-only models)

## Files changed

| File | What |
|---|---|
| `crates/sdr-transcription/src/backends/whisper.rs` | Five new `params.set_*` calls in `decode_and_emit_segment` with rationale comments |

## Out of scope

- **CrisperWhisper integration via Sherpa-onnx** — filed as follow-up. The original #385 plan ("add CrisperWhisper to the Whisper backend") is unreachable because CrisperWhisper uses a non-standard tokenizer that whisper.cpp's GGML format can't represent. The Sherpa-onnx `OfflineWhisper` path preserves the custom tokenizer via the ONNX bundle at `onnx-community/CrisperWhisper-ONNX` and is the right architecture for future work.
- **Per-model parameter overrides** — current PR applies the lockdown uniformly. If a future user wants non-English transcription, that's a feature request, not a regression.

## Related

- Investigation that surfaced this: #385
- CrisperWhisper-via-Sherpa follow-up issue: filed separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription consistency and reliability by enforcing deterministic decoding parameters
  * Reduced non-speech hallucinations and blank token generation during transcription
  * Constrained transcription behavior to English language processing

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/rtl-sdr/pull/660)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->