### PR TITLE
feat(sdr-dsp): port dbdexter OQPSK demod for current METEOR-M2 (#662)

### DIFF
--- a/crates/sdr-core/src/controller.rs
+++ b/crates/sdr-core/src/controller.rs
@@ -610,6 +610,16 @@ struct DspState {
     /// log at the IQ block rate (~100 Hz) until source-stop.
     /// Per `CodeRabbit` round 12 on PR #543.
     lrpt_init_failed: bool,
+    /// Modulation the LRPT decoder should be built with on the
+    /// next lazy-init. Set by `UiToDsp::SetLrptModulation` from
+    /// the wiring layer (which knows the current satellite from
+    /// the `KnownSatellite` catalog). Defaults to OQPSK because
+    /// every active Meteor satellite (M2-3, M2-4) transmits
+    /// OQPSK — manual LRPT-mode use without a satellite-aware
+    /// caller still works for current Meteors. A change here
+    /// drops the existing decoder so the next IQ chunk re-inits
+    /// at the new modulation. Per #662.
+    lrpt_modulation: sdr_dsp::lrpt::LrptMode,
     /// ISS SSTV decoder. Lazy-init on first `sstv_decode_tap` call
     /// at the `RadioModule`'s current audio sample rate (typically
     /// 48 kHz). The decoder internally resamples to `11_025` Hz, so
@@ -785,6 +795,7 @@ impl DspState {
             lrpt_decoder: None,
             lrpt_image: None,
             lrpt_init_failed: false,
+            lrpt_modulation: sdr_dsp::lrpt::LrptMode::Oqpsk,
             sstv_decoder: None,
             sstv_mono_buf: Vec::new(),
             sstv_init_failed_at_rate: None,
@@ -901,6 +912,7 @@ fn lrpt_decode_tap(
     image: Option<&sdr_radio::lrpt_image::LrptImage>,
     radio_input: &[Complex],
     init_failed: &mut bool,
+    modulation: sdr_dsp::lrpt::LrptMode,
 ) {
     let Some(image) = image else {
         return;
@@ -914,10 +926,10 @@ fn lrpt_decode_tap(
         return;
     }
     if decoder_slot.is_none() {
-        match LrptDecoder::new(image.clone()) {
+        match LrptDecoder::new(image.clone(), modulation) {
             Ok(decoder) => {
                 tracing::info!(
-                    "LRPT decoder initialised at {} Hz IF rate",
+                    "LRPT decoder initialised at {} Hz IF rate, modulation = {modulation:?}",
                     sdr_dsp::lrpt::SAMPLE_RATE_HZ
                 );
                 *decoder_slot = Some(decoder);
@@ -2560,6 +2572,20 @@ fn handle_command(state: &mut DspState, dsp_tx: &mpsc::Sender<DspToUi>, cmd: UiT
             // same contract `ClearLrptImage` codifies (round 1).
         }
 
+        UiToDsp::SetLrptModulation(mode) => {
+            tracing::info!("LRPT modulation set to {mode:?}");
+            // Drop the existing decoder iff the modulation
+            // actually changed — re-init lazily on the next IQ
+            // chunk against the new mode. A no-op repeat (auto-
+            // record re-sending the same modulation across
+            // overlapping passes) won't cost a Viterbi reset.
+            if state.lrpt_modulation != mode {
+                state.lrpt_modulation = mode;
+                state.lrpt_decoder = None;
+                state.lrpt_init_failed = false;
+            }
+        }
+
         UiToDsp::ClearLrptImage => {
             tracing::info!("LRPT image handle cleared — decoder tap is silent");
             state.lrpt_image = None;
@@ -4060,6 +4086,7 @@ fn process_iq_block(
                         state.lrpt_image.as_ref(),
                         radio_input,
                         &mut state.lrpt_init_failed,
+                        state.lrpt_modulation,
                     );
                 }
 

--- a/crates/sdr-core/src/messages.rs
+++ b/crates/sdr-core/src/messages.rs
@@ -448,6 +448,14 @@ pub enum UiToDsp {
     /// next source-stop, mirroring the APT decoder's
     /// "decoder kept across mode toggles" behavior.
     ClearLrptImage,
+    /// Tell the DSP thread which Meteor LRPT modulation to use
+    /// for the next decoder init. METEOR-M N2 is QPSK; the
+    /// active METEOR-M2 3 / METEOR-M2 4 satellites transmit
+    /// OQPSK. Sent by the wiring layer at AOS based on the
+    /// `KnownSatellite::lrpt_modulation` catalog field. Drops
+    /// any existing LRPT decoder so the next IQ chunk re-inits
+    /// at the new modulation; safe to send mid-pass. Per #662.
+    SetLrptModulation(sdr_dsp::lrpt::LrptMode),
     /// Hand the DSP thread a clone of the shared
     /// `sdr_radio::sstv_image::SstvImageHandle` the live SSTV
     /// viewer reads from. Sent by the wiring layer at AOS for

--- a/crates/sdr-dsp/benches/lrpt_demod.rs
+++ b/crates/sdr-dsp/benches/lrpt_demod.rs
@@ -43,7 +43,12 @@ fn bench_demod_qpsk(c: &mut Criterion) {
 
     c.bench_function("lrpt_demod_qpsk_1s_144ksps", |b| {
         b.iter(|| {
-            let mut demod = LrptDemod::new().expect("LrptDemod::new");
+            // Explicit-mode constructor so a future change to
+            // `LrptDemod::new`'s default can't silently flip
+            // this bench to the OQPSK pipeline. Per CR round 2
+            // on PR #663.
+            let mut demod = LrptDemod::new_with_mode(LrptMode::Qpsk)
+                .expect("LrptDemod::new_with_mode");
             let mut emitted = 0_u32;
             for s in &buf {
                 if demod.process(black_box(*s)).is_some() {

--- a/crates/sdr-dsp/benches/lrpt_demod.rs
+++ b/crates/sdr-dsp/benches/lrpt_demod.rs
@@ -47,8 +47,8 @@ fn bench_demod_qpsk(c: &mut Criterion) {
             // `LrptDemod::new`'s default can't silently flip
             // this bench to the OQPSK pipeline. Per CR round 2
             // on PR #663.
-            let mut demod = LrptDemod::new_with_mode(LrptMode::Qpsk)
-                .expect("LrptDemod::new_with_mode");
+            let mut demod =
+                LrptDemod::new_with_mode(LrptMode::Qpsk).expect("LrptDemod::new_with_mode");
             let mut emitted = 0_u32;
             for s in &buf {
                 if demod.process(black_box(*s)).is_some() {

--- a/crates/sdr-dsp/benches/lrpt_demod.rs
+++ b/crates/sdr-dsp/benches/lrpt_demod.rs
@@ -1,17 +1,18 @@
-//! LRPT stage-1 demod throughput bench (epic #469).
+//! LRPT stage-1 demod throughput bench (epic #469 + issue #662).
 //!
 //! Measures the end-to-end demod chain on 1 second of synthetic
-//! 144 ksps QPSK input. Establishes the perf floor for stage-1
-//! regression detection.
+//! 144 ksps input — both the QPSK pipeline (epic #469 baseline)
+//! and the OQPSK pipeline (#662, dbdexter port). Establishes the
+//! perf floor for regression detection on either path.
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use sdr_dsp::lrpt::LrptDemod;
+use sdr_dsp::lrpt::{LrptDemod, LrptMode};
 use sdr_types::Complex;
 
 /// 1 second of input at the demod's 144 ksps working sample rate.
 const SAMPLES_1S: usize = 144_000;
 
-fn bench_demod(c: &mut Criterion) {
+fn bench_demod_qpsk(c: &mut Criterion) {
     let symbols = [
         Complex::new(0.707, 0.707),
         Complex::new(-0.707, 0.707),
@@ -28,7 +29,7 @@ fn bench_demod(c: &mut Criterion) {
         })
         .collect();
 
-    c.bench_function("lrpt_demod_1s_144ksps", |b| {
+    c.bench_function("lrpt_demod_qpsk_1s_144ksps", |b| {
         b.iter(|| {
             let mut demod = LrptDemod::new().expect("LrptDemod::new");
             let mut emitted = 0_u32;
@@ -42,5 +43,37 @@ fn bench_demod(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_demod);
+fn bench_demod_oqpsk(c: &mut Criterion) {
+    // OQPSK input: I-only sample on even indices, Q-only on odd
+    // (the canonical "Q delayed by Tsym/2" representation at
+    // 2 sps).
+    let i_vals = [0.707_f32, -0.707, 0.707, -0.707];
+    let q_vals = [0.707_f32, 0.707, -0.707, -0.707];
+    let buf: Vec<Complex> = (0..SAMPLES_1S)
+        .map(|n| {
+            let sym_idx = (n / 2) % 4;
+            if n % 2 == 0 {
+                Complex::new(i_vals[sym_idx], 0.0)
+            } else {
+                Complex::new(0.0, q_vals[sym_idx])
+            }
+        })
+        .collect();
+
+    c.bench_function("lrpt_demod_oqpsk_1s_144ksps", |b| {
+        b.iter(|| {
+            let mut demod =
+                LrptDemod::new_with_mode(LrptMode::Oqpsk).expect("LrptDemod::new_with_mode");
+            let mut emitted = 0_u32;
+            for s in &buf {
+                if demod.process(black_box(*s)).is_some() {
+                    emitted += 1;
+                }
+            }
+            black_box(emitted);
+        });
+    });
+}
+
+criterion_group!(benches, bench_demod_qpsk, bench_demod_oqpsk);
 criterion_main!(benches);

--- a/crates/sdr-dsp/benches/lrpt_demod.rs
+++ b/crates/sdr-dsp/benches/lrpt_demod.rs
@@ -12,17 +12,29 @@ use sdr_types::Complex;
 /// 1 second of input at the demod's 144 ksps working sample rate.
 const SAMPLES_1S: usize = 144_000;
 
+/// Per-rail amplitude for a unit-power QPSK / OQPSK constellation
+/// point: 1/√2 ≈ 0.707, so each corner sits on the unit circle.
+const RAIL_AMP: f32 = core::f32::consts::FRAC_1_SQRT_2;
+
+/// Synthetic stream cadence for these benches: 2 input samples
+/// per symbol, matching the LRPT demod chain's working rate.
+const SAMPLES_PER_SYMBOL: usize = 2;
+
+/// Length of the deterministic constellation pattern fed into the
+/// demod (one entry per QPSK quadrant).
+const PATTERN_LEN: usize = 4;
+
 fn bench_demod_qpsk(c: &mut Criterion) {
     let symbols = [
-        Complex::new(0.707, 0.707),
-        Complex::new(-0.707, 0.707),
-        Complex::new(0.707, -0.707),
-        Complex::new(-0.707, -0.707),
+        Complex::new(RAIL_AMP, RAIL_AMP),
+        Complex::new(-RAIL_AMP, RAIL_AMP),
+        Complex::new(RAIL_AMP, -RAIL_AMP),
+        Complex::new(-RAIL_AMP, -RAIL_AMP),
     ];
     let buf: Vec<Complex> = (0..SAMPLES_1S)
         .map(|n| {
-            if n % 2 == 0 {
-                symbols[(n / 2) % 4]
+            if n % SAMPLES_PER_SYMBOL == 0 {
+                symbols[(n / SAMPLES_PER_SYMBOL) % PATTERN_LEN]
             } else {
                 Complex::new(0.0, 0.0)
             }
@@ -47,12 +59,12 @@ fn bench_demod_oqpsk(c: &mut Criterion) {
     // OQPSK input: I-only sample on even indices, Q-only on odd
     // (the canonical "Q delayed by Tsym/2" representation at
     // 2 sps).
-    let i_vals = [0.707_f32, -0.707, 0.707, -0.707];
-    let q_vals = [0.707_f32, 0.707, -0.707, -0.707];
+    let i_vals = [RAIL_AMP, -RAIL_AMP, RAIL_AMP, -RAIL_AMP];
+    let q_vals = [RAIL_AMP, RAIL_AMP, -RAIL_AMP, -RAIL_AMP];
     let buf: Vec<Complex> = (0..SAMPLES_1S)
         .map(|n| {
-            let sym_idx = (n / 2) % 4;
-            if n % 2 == 0 {
+            let sym_idx = (n / SAMPLES_PER_SYMBOL) % PATTERN_LEN;
+            if n % SAMPLES_PER_SYMBOL == 0 {
                 Complex::new(i_vals[sym_idx], 0.0)
             } else {
                 Complex::new(0.0, q_vals[sym_idx])

--- a/crates/sdr-dsp/src/lrpt/meteor_agc.rs
+++ b/crates/sdr-dsp/src/lrpt/meteor_agc.rs
@@ -1,0 +1,197 @@
+//! Meteor-M AGC — faithful port of `dbdexter/meteor_demod/dsp/agc.c`.
+//!
+//! dbdexter's PLL is calibrated for an input that's been normalized
+//! to **|sample| = 190** by this AGC stage (the constellation rails
+//! land at ~134 = 190/√2). All of the carrier-recovery loop's
+//! tuning — alpha/beta from the loop bandwidth, the lock detector's
+//! 85 / 105 EMA hysteresis, the integer-bin tanh LUT, the free-run
+//! frequency-sweep step — assumes that scale.
+//!
+//! Skipping the AGC and feeding the PLL a unit-magnitude
+//! constellation (rails at ±0.707) silently breaks two things:
+//!
+//! 1. The integer-bin tanh LUT becomes useless — values in (−1, 1)
+//!    round to index 16 = `tanh(0)` = 0, so `compute_error` always
+//!    returns 0 and the loop never tracks phase.
+//! 2. The lock detector's `|error|` EMA decays from `1000` toward
+//!    `0` with pole `0.001`, crossing the lock threshold of `85`
+//!    after ~2700 update calls — purely from time elapsed. Even a
+//!    zero-IQ input "locks" eventually, and the free-run frequency
+//!    sweep stops scanning before the carrier is found.
+//!
+//! With the AGC in place: zero-IQ silence drives the gain up
+//! toward saturation, the (post-AGC) noise becomes random with
+//! magnitude ~190, the PLL error is non-zero noise (not literal
+//! 0), the EMA stays high, and `locked` stays false until a real
+//! carrier shows up. dbdexter's tuning works as designed.
+//!
+//! Per CR round 2 on PR #663.
+
+use sdr_types::Complex;
+
+/// Target post-AGC sample magnitude. Per dbdexter
+/// (`agc.c:5` — `FLOAT_TARGET_MAG`).
+pub const TARGET_MAG: f32 = 190.0;
+
+/// Pole of the leaky integrator that estimates the DC bias to
+/// subtract before applying gain. Per dbdexter (`agc.c:6`).
+const BIAS_POLE: f32 = 0.001;
+
+/// Pole of the gain-update loop. Per dbdexter (`agc.c:7`).
+const GAIN_POLE: f32 = 0.0001;
+
+/// Single-sample AGC. Tracks DC bias + a gain that drives the
+/// post-bias-subtraction sample magnitude toward [`TARGET_MAG`].
+pub struct MeteorAgc {
+    /// Multiplicative gain applied to the bias-corrected sample.
+    /// Per dbdexter `_float_gain` (`agc.c:9`).
+    gain: f32,
+    /// Running DC-bias estimate. Per dbdexter `_float_bias`
+    /// (`agc.c:10`).
+    bias: Complex,
+}
+
+impl Default for MeteorAgc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MeteorAgc {
+    /// Build an AGC at unity gain and zero bias. Same initial
+    /// state as dbdexter's static globals.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            gain: 1.0,
+            bias: Complex::new(0.0, 0.0),
+        }
+    }
+
+    /// Process one sample. Updates DC-bias and gain estimates as
+    /// side effects; returns the bias-subtracted, gain-scaled
+    /// sample.
+    pub fn process(&mut self, sample: Complex) -> Complex {
+        // Leaky-integrator DC-bias estimate: subtract before
+        // applying gain so a static offset doesn't grow into a
+        // huge DC excursion as the gain ramps up.
+        self.bias = self.bias * (1.0 - BIAS_POLE) + sample * BIAS_POLE;
+        let centered = sample - self.bias;
+        // Gain stage. Update is "post-multiply": the current gain
+        // applies to *this* sample; the gain update from this
+        // sample's magnitude error affects the *next* sample.
+        // Mirrors dbdexter `agc.c:20-22`.
+        let scaled = centered * self.gain;
+        let mag = (scaled.re * scaled.re + scaled.im * scaled.im).sqrt();
+        self.gain += GAIN_POLE * (TARGET_MAG - mag);
+        if self.gain < 0.0 {
+            self.gain = 0.0;
+        }
+        scaled
+    }
+
+    /// Current gain — useful for diagnostics and tests.
+    #[must_use]
+    pub fn gain(&self) -> f32 {
+        self.gain
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::cast_precision_loss)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unity_gain_at_construction() {
+        let agc = MeteorAgc::new();
+        assert!((agc.gain() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn ramps_gain_up_for_small_input() {
+        // Input magnitude of 1.0 is far below the 190 target —
+        // the gain should grow over time toward whatever value
+        // brings the output to ~190. Use a mean-zero alternating
+        // pattern so the DC-bias filter tracks ~zero rather than
+        // chasing a constant input (which would suppress the
+        // signal entirely — that's a separate test below).
+        let mut agc = MeteorAgc::new();
+        let s_pos = Complex::new(0.707, 0.707);
+        let s_neg = Complex::new(-0.707, -0.707);
+        for n in 0..100_000 {
+            let _ = agc.process(if n % 2 == 0 { s_pos } else { s_neg });
+        }
+        // After 100k samples, post-AGC magnitude should be near
+        // the target. Convergence isn't instant (GAIN_POLE is
+        // tiny), so allow generous slack.
+        let final_out = agc.process(s_pos);
+        let mag = (final_out.re * final_out.re + final_out.im * final_out.im).sqrt();
+        assert!(
+            (mag - TARGET_MAG).abs() < 30.0,
+            "AGC should normalize |sample|=1 to ~{TARGET_MAG}, got {mag}",
+        );
+    }
+
+    #[test]
+    fn ramps_gain_up_on_zero_iq() {
+        // Zero IQ should still drive the gain up (toward
+        // saturation), because the gain update is `gain += pole *
+        // (target - |output|)` and |output| stays at 0. dbdexter's
+        // AGC has no upper bound on gain — that's by design, so a
+        // signal that fades in late in a pass still gets amplified
+        // properly.
+        let mut agc = MeteorAgc::new();
+        let zero = Complex::new(0.0, 0.0);
+        for _ in 0..10_000 {
+            let _ = agc.process(zero);
+        }
+        // Each call: gain += 0.0001 * 190 = 0.019. After 10k
+        // calls: gain ≈ 1 + 190 ≈ 191.
+        assert!(
+            agc.gain() > 50.0,
+            "gain should ramp up on zero input (no signal to bring it back down), got {}",
+            agc.gain(),
+        );
+    }
+
+    #[test]
+    fn removes_dc_bias() {
+        // Constant DC-only input — after the bias filter settles,
+        // the output should approach 0 (bias subtracted, no AC
+        // content for the gain stage to amplify).
+        let mut agc = MeteorAgc::new();
+        let dc = Complex::new(5.0, -3.0);
+        for _ in 0..50_000 {
+            let _ = agc.process(dc);
+        }
+        let out = agc.process(dc);
+        let mag = (out.re * out.re + out.im * out.im).sqrt();
+        // The bias estimate converges geometrically; at 50k
+        // samples with a pole of 0.001 it's well within 1% of the
+        // input value, so the residual should be a small fraction
+        // of the original magnitude.
+        let dc_mag = (dc.re * dc.re + dc.im * dc.im).sqrt();
+        assert!(
+            mag < dc_mag,
+            "AGC should subtract the DC bias, got residual mag {mag} vs original {dc_mag}",
+        );
+    }
+
+    #[test]
+    fn gain_clamped_non_negative() {
+        // Force a scenario where the gain would otherwise drop
+        // below zero (huge over-amplitude input). gain should
+        // clamp at 0, not overshoot negative.
+        let mut agc = MeteorAgc::new();
+        let huge = Complex::new(1.0e6, 1.0e6);
+        for _ in 0..100 {
+            let _ = agc.process(huge);
+        }
+        assert!(
+            agc.gain() >= 0.0,
+            "gain must clamp at zero, got {}",
+            agc.gain()
+        );
+    }
+}

--- a/crates/sdr-dsp/src/lrpt/meteor_pll.rs
+++ b/crates/sdr-dsp/src/lrpt/meteor_pll.rs
@@ -67,6 +67,17 @@ const LOCK_THRESHOLD_HIGH: f32 = 105.0;
 /// the user perceives at the start of a Meteor pass.
 const FREE_RUN_STEP: f32 = 1e-6;
 
+/// Minimum signal-magnitude EMA required before the lock detector
+/// is allowed to declare lock. Belt-and-suspenders complement to
+/// the AGC stage upstream: if the input is literally zero IQ the
+/// AGC's output is also zero (any gain × 0 = 0), so the
+/// `compute_error` metric returns 0 each call, and the |error|
+/// EMA decays from 1000 toward 0 — silently crossing
+/// [`LOCK_THRESHOLD_LOW`] purely from time elapsed. Gating lock on
+/// signal-magnitude EMA above this floor (≈ a quarter of the AGC
+/// target) closes that loophole. Per CR round 2 on PR #663.
+const LOCK_SIG_FLOOR: f32 = 47.5;
+
 /// Critically-damped 2nd-order loop alpha/beta from a normalized
 /// loop bandwidth. Same formula as
 /// [`crate::loops::PhaseControlLoop::critically_damped`], duplicated
@@ -95,6 +106,10 @@ pub struct MeteorPll {
     /// unlocked and the free-run sweep takes over until the EMA
     /// settles.
     err_ema: f32,
+    /// Exponential moving average of input signal magnitude.
+    /// Compared against [`LOCK_SIG_FLOOR`] to gate lock — see
+    /// that constant's docs for the failure mode this prevents.
+    sig_ema: f32,
     locked: bool,
     locked_once: bool,
     fmax: f32,
@@ -174,6 +189,7 @@ impl MeteorPll {
             alpha,
             beta,
             err_ema: 1000.0,
+            sig_ema: 0.0,
             locked: false,
             locked_once: false,
             fmax,
@@ -226,6 +242,11 @@ impl MeteorPll {
     /// [`Self::mix`] output.
     pub fn update_estimate(&mut self, i: f32, q: f32) {
         let error = self.compute_error(i, q);
+        // Track signal magnitude so the lock detector can refuse
+        // to declare lock on near-zero input. Same EMA pole as
+        // err_ema so the two settle on comparable timescales.
+        let mag = (i * i + q * q).sqrt();
+        self.sig_ema = self.sig_ema * (1.0 - ERR_POLE) + mag * ERR_POLE;
         self.apply_loop_update(error);
     }
 
@@ -283,12 +304,19 @@ impl MeteorPll {
         self.freq += self.beta * error;
 
         // Lock detector — exponential moving average of |error|
-        // with hysteresis at the dbdexter thresholds.
+        // with hysteresis at the dbdexter thresholds, plus a
+        // signal-magnitude floor so a literal-zero input can't
+        // trigger lock just by letting the |error| EMA decay
+        // (the EMA starts at 1000 and decays toward 0 with pole
+        // 0.001; without the floor it crosses LOW after ~2700
+        // updates regardless of signal). Per CR round 2 on
+        // PR #663.
         self.err_ema = self.err_ema * (1.0 - ERR_POLE) + error.abs() * ERR_POLE;
-        if self.err_ema < LOCK_THRESHOLD_LOW && !self.locked {
+        let has_signal = self.sig_ema >= LOCK_SIG_FLOOR;
+        if self.err_ema < LOCK_THRESHOLD_LOW && has_signal && !self.locked {
             self.locked = true;
             self.locked_once = true;
-        } else if self.err_ema > LOCK_THRESHOLD_HIGH && self.locked {
+        } else if (self.err_ema > LOCK_THRESHOLD_HIGH || !has_signal) && self.locked {
             self.locked = false;
         }
 
@@ -444,16 +472,31 @@ mod tests {
     #[test]
     fn locks_onto_clean_qpsk_constellation() {
         // Drive the PLL with synthetic clean QPSK at zero offset.
-        // After a few thousand symbols the lock detector should
-        // trip.
-        let mut pll = MeteorPll::new(TEST_BW, false, None).unwrap();
+        // Two production-realistic inputs:
+        //
+        // 1. Constellation pre-scaled to dbdexter's post-AGC
+        //    magnitude (190/√2 ≈ 134.35 per rail) so the signal-
+        //    magnitude lock gate sees enough power. In
+        //    production the upstream [`MeteorAgc`] applies this
+        //    scaling automatically; the unit test bypasses AGC.
+        // 2. The realistic loop bandwidth (`PROD_BW`) — wider
+        //    `TEST_BW = 0.01` overshoots wildly when paired with
+        //    AGC-scale errors and the loop oscillates instead of
+        //    locking. The production OQPSK PLL bandwidth was
+        //    derived to be stable at this input scale; honour it.
+        const RAIL: f32 = 134.35;
+        const PROD_BW: f32 = 8.726_646e-5; // 2π × 1 Hz / 72_000 Hz, matches OQPSK_PLL_BW
+        let mut pll = MeteorPll::new(PROD_BW, false, None).unwrap();
         let symbols = [
-            Complex::new(0.707, 0.707),
-            Complex::new(-0.707, 0.707),
-            Complex::new(0.707, -0.707),
-            Complex::new(-0.707, -0.707),
+            Complex::new(RAIL, RAIL),
+            Complex::new(-RAIL, RAIL),
+            Complex::new(RAIL, -RAIL),
+            Complex::new(-RAIL, -RAIL),
         ];
-        for n in 0..20_000 {
+        // The narrow loop takes longer to converge — pump enough
+        // samples that both the |error| EMA and the signal
+        // magnitude EMA settle into the lock window.
+        for n in 0..200_000 {
             let s = symbols[n % 4];
             let mixed = pll.mix(s);
             pll.update_estimate(mixed.re, mixed.im);

--- a/crates/sdr-dsp/src/lrpt/meteor_pll.rs
+++ b/crates/sdr-dsp/src/lrpt/meteor_pll.rs
@@ -124,11 +124,23 @@ impl MeteorPll {
     /// # Errors
     ///
     /// Returns `DspError::InvalidParameter` if `bandwidth` is not
-    /// finite or not positive.
+    /// finite or not positive, or if `freq_max` is `Some(value)`
+    /// with a non-finite `value` (NaN / ±∞ would propagate
+    /// silently into `fmax`, then through the unlocked-state
+    /// frequency sweep and `clamp` calls — every comparison
+    /// against NaN evaluates `false`, so the loop would corrupt
+    /// silently rather than fail loudly).
     pub fn new(bandwidth: f32, oqpsk: bool, freq_max: Option<f32>) -> Result<Self, DspError> {
         if !bandwidth.is_finite() || bandwidth <= 0.0 {
             return Err(DspError::InvalidParameter(format!(
                 "bandwidth must be finite and positive, got {bandwidth}"
+            )));
+        }
+        if let Some(fm) = freq_max
+            && !fm.is_finite()
+        {
+            return Err(DspError::InvalidParameter(format!(
+                "freq_max must be finite when provided, got {fm}"
             )));
         }
         // dbdexter (`pll.c:30`): negative `freq_max` selects the
@@ -330,6 +342,18 @@ mod tests {
         assert!(MeteorPll::new(-0.1, false, None).is_err());
         assert!(MeteorPll::new(f32::NAN, false, None).is_err());
         assert!(MeteorPll::new(f32::INFINITY, false, None).is_err());
+    }
+
+    #[test]
+    fn rejects_non_finite_freq_max() {
+        // Per CR round 1 on PR #663 — without this guard,
+        // `Some(NaN)` slipped past the negative-or-clamp branch
+        // and poisoned `fmax`, silently breaking the unlocked-
+        // state frequency sweep (every `>= fmax` and `<= -fmax`
+        // comparison against NaN returns `false`).
+        assert!(MeteorPll::new(TEST_BW, false, Some(f32::NAN)).is_err());
+        assert!(MeteorPll::new(TEST_BW, false, Some(f32::INFINITY)).is_err());
+        assert!(MeteorPll::new(TEST_BW, true, Some(f32::NEG_INFINITY)).is_err());
     }
 
     #[test]

--- a/crates/sdr-dsp/src/lrpt/meteor_pll.rs
+++ b/crates/sdr-dsp/src/lrpt/meteor_pll.rs
@@ -1,0 +1,442 @@
+//! Meteor-M Costas / carrier-recovery PLL — faithful port of
+//! `dbdexter/meteor_demod/dsp/pll.c`.
+//!
+//! The dbdexter PLL is the gold-standard carrier-recovery loop for
+//! Meteor-M LRPT (and is what `SatDump` uses under the hood). It
+//! differs from a textbook Costas loop in three key ways:
+//!
+//! 1. **Separate I-only and Q-only mix paths** — required for OQPSK,
+//!    where the in-phase and quadrature symbols land at different
+//!    time instants (Tsym/2 apart). Each `mix_i` / `mix_q` call
+//!    advances the NCO phase, but only computes the half of the
+//!    rotated sample the timing loop actually wants.
+//! 2. **Lock detector** — an exponential moving average of the
+//!    absolute phase error switches the loop between locked and
+//!    unlocked states (hysteresis at 85 / 105). The QPSK Costas in
+//!    `costas.rs` doesn't have one.
+//! 3. **Free-run frequency sweep** — when unlocked, the loop slews
+//!    the frequency estimate up and down at ±1e-6 / call between
+//!    `±freq_max`, scanning the carrier-offset range for the actual
+//!    signal. Without this, a far-offset signal can leave the loop
+//!    stuck at zero hertz forever.
+//!
+//! For OQPSK, `freq_max` is halved internally (per dbdexter), since
+//! `mix_i` and `mix_q` together advance phase twice per symbol —
+//! the per-call frequency budget halves to keep the per-symbol
+//! tracking range the same.
+//!
+//! Tuning differs from `Costas` (which uses SDR++'s wide loops):
+//! dbdexter ships a much tighter PLL bandwidth (1 Hz at the symbol
+//! rate vs SDR++'s ~720 Hz) so the loop averages out more noise
+//! once locked. The free-run sweep solves the slow-lock cost of
+//! the narrow loop.
+
+use core::f32::consts::PI;
+
+use sdr_types::{Complex, DspError};
+
+/// Default maximum carrier deviation passed to the PLL when the
+/// caller doesn't supply one. Same value as dbdexter's `FREQ_MAX`
+/// (`pll.c:6`). In radians per `mix*` call before the OQPSK halving.
+pub const FREQ_MAX_DEFAULT: f32 = 0.3;
+
+/// Pole frequency of the lock-detector's error-magnitude EMA.
+/// Per dbdexter (`pll.c:7`).
+const ERR_POLE: f32 = 0.001;
+
+/// Tanh LUT length — covers integer arguments from -16 to +15.
+const LUT_TANH_LEN: usize = 32;
+
+/// Index offset so `lut[(val as i32 + LUT_TANH_OFFSET) as usize]`
+/// resolves the integer-bin tanh value for `val`.
+const LUT_TANH_OFFSET: i32 = 16;
+
+/// Lock-detector hysteresis — when the EMA of `|error|` falls below
+/// this threshold the loop is declared locked. Per dbdexter
+/// (`pll.c:118`).
+const LOCK_THRESHOLD_LOW: f32 = 85.0;
+
+/// Lock-detector hysteresis — when the EMA exceeds this threshold
+/// the loop is declared unlocked again. Per dbdexter (`pll.c:121`).
+const LOCK_THRESHOLD_HIGH: f32 = 105.0;
+
+/// Per-call frequency-sweep step applied while unlocked. Per
+/// dbdexter (`pll.c:126`). At 144 ksps and dbdexter's loop tuning
+/// the sweep covers ±0.15 rad in ~150k samples (≈ 1 second of
+/// real-time signal), which lines up with the typical lock latency
+/// the user perceives at the start of a Meteor pass.
+const FREE_RUN_STEP: f32 = 1e-6;
+
+/// Critically-damped 2nd-order loop alpha/beta from a normalized
+/// loop bandwidth. Same formula as
+/// [`crate::loops::PhaseControlLoop::critically_damped`], duplicated
+/// here as a free function so the PLL doesn't pull in the whole
+/// PCL just for two coefficients (and so the alpha/beta lifecycle
+/// stays in this file alongside the rest of the dbdexter port).
+fn critically_damped(bandwidth: f32) -> (f32, f32) {
+    let damping = core::f32::consts::FRAC_1_SQRT_2;
+    let denom = 1.0 + 2.0 * damping * bandwidth + bandwidth * bandwidth;
+    let alpha = 4.0 * damping * bandwidth / denom;
+    let beta = 4.0 * bandwidth * bandwidth / denom;
+    (alpha, beta)
+}
+
+/// Meteor-M Costas / carrier-recovery PLL. Holds the NCO phase /
+/// frequency, the lock state, and a tanh LUT used by the Costas
+/// error metric.
+pub struct MeteorPll {
+    freq: f32,
+    phase: f32,
+    alpha: f32,
+    beta: f32,
+    /// Exponential moving average of `|phase error|`. Drives the
+    /// lock detector. Initialized to a deliberately-large value
+    /// (matches dbdexter's `_err = 1000`) so the loop starts
+    /// unlocked and the free-run sweep takes over until the EMA
+    /// settles.
+    err_ema: f32,
+    locked: bool,
+    locked_once: bool,
+    fmax: f32,
+    /// Direction of the current free-run frequency sweep (+1 or
+    /// −1). Toggles when the swept frequency hits ±`fmax`.
+    sweep_dir: i8,
+    /// Pre-computed integer-bin tanh table — `lut[i]` = tanh(i − 16)
+    /// for `i ∈ [0, 32)`. Per dbdexter (`pll.c:40`), the cheap
+    /// quantization replaces a per-sample `tanhf` call.
+    lut_tanh: [f32; LUT_TANH_LEN],
+}
+
+impl MeteorPll {
+    /// Build a PLL.
+    ///
+    /// - `bandwidth` — normalized loop bandwidth (radians per
+    ///   `mix*` call). For Meteor at 72 ksym/s and dbdexter's
+    ///   default `pll_bw = 1` Hz, this is `2π / 72_000 ≈ 8.7e-5`
+    ///   for OQPSK and half that for QPSK (one mix per symbol vs
+    ///   two).
+    /// - `oqpsk` — `true` halves the internal `fmax` so the
+    ///   per-symbol tracking range is the same in either mode.
+    /// - `freq_max` — maximum carrier-frequency deviation in
+    ///   radians per `mix*` call. `None` selects
+    ///   [`FREQ_MAX_DEFAULT`] (= 0.3, matching dbdexter).
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if `bandwidth` is not
+    /// finite or not positive.
+    pub fn new(bandwidth: f32, oqpsk: bool, freq_max: Option<f32>) -> Result<Self, DspError> {
+        if !bandwidth.is_finite() || bandwidth <= 0.0 {
+            return Err(DspError::InvalidParameter(format!(
+                "bandwidth must be finite and positive, got {bandwidth}"
+            )));
+        }
+        // dbdexter (`pll.c:30`): negative `freq_max` selects the
+        // default; values > 1 are clamped to 1.
+        let raw = freq_max.unwrap_or(FREQ_MAX_DEFAULT);
+        let bounded = if raw < 0.0 {
+            FREQ_MAX_DEFAULT
+        } else {
+            raw.min(1.0)
+        };
+        let fmax = if oqpsk { bounded / 2.0 } else { bounded };
+
+        let (alpha, beta) = critically_damped(bandwidth);
+
+        let mut lut_tanh = [0.0_f32; LUT_TANH_LEN];
+        for (i, slot) in lut_tanh.iter_mut().enumerate() {
+            #[allow(
+                clippy::cast_possible_wrap,
+                clippy::cast_possible_truncation,
+                clippy::cast_precision_loss,
+                reason = "i < LUT_TANH_LEN (= 32) fits in i32 with no truncation, and \
+                          (i - 16) is exactly representable in f32"
+            )]
+            let x = (i as i32 - LUT_TANH_OFFSET) as f32;
+            *slot = x.tanh();
+        }
+
+        Ok(Self {
+            freq: 0.0,
+            phase: 0.0,
+            alpha,
+            beta,
+            err_ema: 1000.0,
+            locked: false,
+            locked_once: false,
+            fmax,
+            sweep_dir: 1,
+            lut_tanh,
+        })
+    }
+
+    /// Mix one complex sample with the local oscillator (full
+    /// rotation). Use this for QPSK; OQPSK uses the split
+    /// [`Self::mix_i`] / [`Self::mix_q`] pair instead.
+    ///
+    /// Advances the NCO phase as a side effect, even when the
+    /// caller discards the rotated sample.
+    pub fn mix(&mut self, sample: Complex) -> Complex {
+        let (sine, cosine) = (-self.phase).sin_cos();
+        let re = sample.re;
+        let im = sample.im;
+        let mixed = Complex::new(re * cosine - im * sine, re * sine + im * cosine);
+        self.advance_phase();
+        mixed
+    }
+
+    /// Mix one complex sample and return only the real (in-phase)
+    /// component. Used for the OQPSK "intersample" tick — the
+    /// Q half is sampled half a symbol later via [`Self::mix_q`].
+    /// Advances the NCO phase as a side effect.
+    pub fn mix_i(&mut self, sample: Complex) -> f32 {
+        let (sine, cosine) = (-self.phase).sin_cos();
+        let result = sample.re * cosine - sample.im * sine;
+        self.advance_phase();
+        result
+    }
+
+    /// Mix one complex sample and return only the imaginary
+    /// (quadrature) component. Used for the OQPSK symbol tick —
+    /// the I half was sampled half a symbol earlier via
+    /// [`Self::mix_i`]. Advances the NCO phase as a side effect.
+    pub fn mix_q(&mut self, sample: Complex) -> f32 {
+        let (sine, cosine) = (-self.phase).sin_cos();
+        let result = sample.re * sine + sample.im * cosine;
+        self.advance_phase();
+        result
+    }
+
+    /// Update the carrier estimate from a decimated I/Q symbol pair.
+    /// In OQPSK the two arguments come from separate [`Self::mix_i`]
+    /// and [`Self::mix_q`] calls (sampled Tsym/2 apart); in QPSK
+    /// they're the real and imaginary parts of a single
+    /// [`Self::mix`] output.
+    pub fn update_estimate(&mut self, i: f32, q: f32) {
+        let error = self.compute_error(i, q);
+        self.apply_loop_update(error);
+    }
+
+    /// Current NCO frequency estimate, in radians per `mix*` call.
+    pub fn frequency(&self) -> f32 {
+        self.freq
+    }
+
+    /// `true` while the lock detector reports the loop is locked.
+    pub fn is_locked(&self) -> bool {
+        self.locked
+    }
+
+    /// `true` once the loop has locked at least once since
+    /// construction. Sticky.
+    pub fn locked_once(&self) -> bool {
+        self.locked_once
+    }
+
+    fn compute_error(&self, re: f32, im: f32) -> f32 {
+        // dbdexter's Costas error metric (`pll.c:147`):
+        // `tanh(re)*im - tanh(im)*re`. Quantized via the integer-bin
+        // tanh LUT — saturates to ±1 outside the LUT range.
+        self.lut_tanh_lookup(re) * im - self.lut_tanh_lookup(im) * re
+    }
+
+    fn lut_tanh_lookup(&self, val: f32) -> f32 {
+        // Saturation matches dbdexter `pll.c:156`: `> 15 → 1`,
+        // `< -16 → -1`. The asymmetric upper bound is faithful — the
+        // LUT covers `i = 0..32` mapping to `tanh(-16..15)`, so values
+        // in `[15, 16]` clip to 1 rather than indexing past the end.
+        if val > 15.0 {
+            return 1.0;
+        }
+        if val < -16.0 {
+            return -1.0;
+        }
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "val is bounded to (-16, 15] so (val + 16) is in (0, 31] — fits in usize"
+        )]
+        let idx = (val as i32 + LUT_TANH_OFFSET) as usize;
+        self.lut_tanh[idx]
+    }
+
+    fn apply_loop_update(&mut self, error: f32) {
+        // Phase-side update, wrapped to [0, 2π). dbdexter uses
+        // C's `fmod` (truncate-toward-zero), but for the bounded
+        // `phase + alpha*error` values the loop produces in
+        // practice, `rem_euclid` differs only when `phase` has
+        // already dipped negative — and gives the [0, 2π)
+        // representation that the `mix*` wrap check expects.
+        self.phase = (self.phase + self.alpha * error).rem_euclid(2.0 * PI);
+        self.freq += self.beta * error;
+
+        // Lock detector — exponential moving average of |error|
+        // with hysteresis at the dbdexter thresholds.
+        self.err_ema = self.err_ema * (1.0 - ERR_POLE) + error.abs() * ERR_POLE;
+        if self.err_ema < LOCK_THRESHOLD_LOW && !self.locked {
+            self.locked = true;
+            self.locked_once = true;
+        } else if self.err_ema > LOCK_THRESHOLD_HIGH && self.locked {
+            self.locked = false;
+        }
+
+        // Free-run sweep while unlocked — slew the frequency
+        // estimate back and forth across ±fmax until the lock
+        // detector trips.
+        if !self.locked {
+            self.freq += FREE_RUN_STEP * f32::from(self.sweep_dir);
+        }
+        if self.freq >= self.fmax {
+            self.sweep_dir = -1;
+        } else if self.freq <= -self.fmax {
+            self.sweep_dir = 1;
+        }
+        self.freq = self.freq.clamp(-self.fmax, self.fmax);
+    }
+
+    fn advance_phase(&mut self) {
+        self.phase += self.freq;
+        // dbdexter only wraps positive (`pll.c:61`); a negative
+        // frequency leaves the phase to grow negative, but
+        // `sin_cos` handles that correctly and the bounded sweep
+        // keeps the magnitude small enough that float precision
+        // doesn't degrade over the length of a pass.
+        if self.phase >= 2.0 * PI {
+            self.phase -= 2.0 * PI;
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::unwrap_used,
+    clippy::many_single_char_names,
+    reason = "test code: short binding names match the C reference's variable names"
+)]
+mod tests {
+    use super::*;
+
+    /// Loop bandwidth used in the tests below — dbdexter's
+    /// default `pll_bw = 1` Hz, normalized to a per-mix-call
+    /// bandwidth at 72 ksym/s with one mix per symbol (QPSK
+    /// scaling). Wider than what we'd actually deploy but the
+    /// tests need to converge in reasonable wall time.
+    const TEST_BW: f32 = 0.01;
+
+    #[test]
+    fn rejects_invalid_bandwidth() {
+        assert!(MeteorPll::new(0.0, false, None).is_err());
+        assert!(MeteorPll::new(-0.1, false, None).is_err());
+        assert!(MeteorPll::new(f32::NAN, false, None).is_err());
+        assert!(MeteorPll::new(f32::INFINITY, false, None).is_err());
+    }
+
+    #[test]
+    fn freq_max_default_used_when_none() {
+        let pll = MeteorPll::new(TEST_BW, false, None).unwrap();
+        // QPSK: fmax stays at FREQ_MAX_DEFAULT.
+        assert!((pll.fmax - FREQ_MAX_DEFAULT).abs() < 1e-6);
+    }
+
+    #[test]
+    fn oqpsk_halves_fmax() {
+        let pll = MeteorPll::new(TEST_BW, true, None).unwrap();
+        assert!((pll.fmax - FREQ_MAX_DEFAULT / 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn freq_max_negative_falls_back_to_default() {
+        // dbdexter (`pll.c:30`): negative selects the default.
+        let pll = MeteorPll::new(TEST_BW, false, Some(-1.0)).unwrap();
+        assert!((pll.fmax - FREQ_MAX_DEFAULT).abs() < 1e-6);
+    }
+
+    #[test]
+    fn freq_max_above_one_clamps_to_one() {
+        // dbdexter (`pll.c:31`): values > 1 are clamped to 1.
+        let pll = MeteorPll::new(TEST_BW, false, Some(2.0)).unwrap();
+        assert!((pll.fmax - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn mix_preserves_magnitude_at_zero_phase() {
+        let mut pll = MeteorPll::new(TEST_BW, false, None).unwrap();
+        let s = Complex::new(0.7, -0.3);
+        let out = pll.mix(s);
+        let mag_in = (s.re * s.re + s.im * s.im).sqrt();
+        let mag_out = (out.re * out.re + out.im * out.im).sqrt();
+        assert!((mag_in - mag_out).abs() < 1e-6);
+    }
+
+    #[test]
+    fn mix_i_and_mix_q_match_full_mix_at_same_phase() {
+        // mix_i + mix_q should reconstruct the full mix output at
+        // the same phase. Per call, however, each advances the
+        // phase — so we have to evaluate them at a known starting
+        // phase using two fresh PLLs.
+        let mut a = MeteorPll::new(TEST_BW, false, None).unwrap();
+        let mut b = MeteorPll::new(TEST_BW, false, None).unwrap();
+        let s = Complex::new(0.5, 0.2);
+        let full = a.mix(s);
+        let i = b.mix_i(s);
+        // Reset the second PLL's phase so mix_q sees the same
+        // starting phase that mix_i did. (mix_i advanced it by
+        // `freq` = 0; nothing to undo for a fresh PLL.)
+        let q = {
+            let mut c = MeteorPll::new(TEST_BW, false, None).unwrap();
+            c.mix_q(s)
+        };
+        assert!((i - full.re).abs() < 1e-6, "mix_i mismatch");
+        assert!((q - full.im).abs() < 1e-6, "mix_q mismatch");
+    }
+
+    #[test]
+    fn lut_tanh_saturates_outside_range() {
+        let pll = MeteorPll::new(TEST_BW, false, None).unwrap();
+        assert!((pll.lut_tanh_lookup(100.0) - 1.0).abs() < 1e-6);
+        assert!((pll.lut_tanh_lookup(-100.0) - (-1.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn lut_tanh_in_range_returns_table_value() {
+        let pll = MeteorPll::new(TEST_BW, false, None).unwrap();
+        // val = 0 → idx = 16 → tanh(0) = 0.
+        assert!(pll.lut_tanh_lookup(0.0).abs() < 1e-6);
+        // val = 1 → idx = 17 → tanh(1).
+        assert!((pll.lut_tanh_lookup(1.0) - 1.0_f32.tanh()).abs() < 1e-6);
+    }
+
+    #[test]
+    fn freq_clamped_to_fmax_after_update() {
+        let mut pll = MeteorPll::new(TEST_BW, false, Some(0.1)).unwrap();
+        // Force-feed a huge error to drive freq beyond fmax.
+        for _ in 0..10_000 {
+            pll.apply_loop_update(1000.0);
+        }
+        assert!(pll.freq.abs() <= 0.1 + 1e-6);
+    }
+
+    #[test]
+    fn locks_onto_clean_qpsk_constellation() {
+        // Drive the PLL with synthetic clean QPSK at zero offset.
+        // After a few thousand symbols the lock detector should
+        // trip.
+        let mut pll = MeteorPll::new(TEST_BW, false, None).unwrap();
+        let symbols = [
+            Complex::new(0.707, 0.707),
+            Complex::new(-0.707, 0.707),
+            Complex::new(0.707, -0.707),
+            Complex::new(-0.707, -0.707),
+        ];
+        for n in 0..20_000 {
+            let s = symbols[n % 4];
+            let mixed = pll.mix(s);
+            pll.update_estimate(mixed.re, mixed.im);
+        }
+        assert!(
+            pll.locked_once(),
+            "PLL should lock onto a clean QPSK constellation"
+        );
+    }
+}

--- a/crates/sdr-dsp/src/lrpt/mm_timing.rs
+++ b/crates/sdr-dsp/src/lrpt/mm_timing.rs
@@ -1,0 +1,313 @@
+//! Mueller-Muller symbol-timing recovery — faithful port of
+//! `dbdexter/meteor_demod/dsp/timing.c`.
+//!
+//! Mueller-Muller (M&M) is a single-rail timing-error metric:
+//!
+//! ```text
+//! err = sgn(prev) * cur − sgn(cur) * prev
+//! ```
+//!
+//! computed on the imaginary part of the recovered symbol. It's
+//! non-data-aided (uses the sign-decision as the local symbol
+//! estimate), needs only one sample per symbol, and locks faster
+//! than Gardner on QPSK / OQPSK because the dual-rail Gardner
+//! error metric assumes I and Q are co-timed — which is exactly
+//! the assumption OQPSK breaks.
+//!
+//! Two timeslot variants drive the loop:
+//!
+//! - [`Self::advance_timeslot`] — one tick per symbol, used by
+//!   QPSK. Returns `true` on the symbol boundary so the caller
+//!   knows to mix + retime + update.
+//! - [`Self::advance_timeslot_dual`] — two ticks per symbol,
+//!   alternating `1 → 2 → 1 → 2`. State 1 is the I-tick (mix the
+//!   in-phase rail half a symbol before the symbol boundary);
+//!   state 2 is the Q-tick (mix the quadrature rail at the symbol
+//!   boundary, retime, update PLL). Used by OQPSK.
+//!
+//! The loop is 2nd-order with critically-damped (damping = 1) loop
+//! coefficients — same shape as the PLL, just a different damping
+//! constant.
+
+use core::f32::consts::PI;
+
+use sdr_types::{Complex, DspError};
+
+/// dbdexter (`timing.c:7`): `freq` is allowed to deviate by at
+/// most `±2^-FREQ_DEV_EXP` × `center_freq` from the configured
+/// symbol period before the loop hard-clamps. With `FREQ_DEV_EXP =
+/// 12` that's ±0.024% — tight enough that the loop tracks symbol-
+/// clock drift but not so tight that initial acquisition is
+/// throttled.
+const FREQ_DEV_EXP: u32 = 12;
+
+/// Mueller-Muller timing recovery state.
+pub struct MmTiming {
+    /// Sample-clock phase accumulator. Increments by `freq` each
+    /// `advance_timeslot*` call; the timeslot fires when `phase`
+    /// crosses the configured threshold (`2π` for single, `state·π`
+    /// for dual).
+    phase: f32,
+    /// Current symbol period estimate, in radians per
+    /// `advance_timeslot*` call. Tracked by the loop.
+    freq: f32,
+    /// Configured nominal symbol period — `freq` is clamped to
+    /// `center_freq ± freq_max_dev`.
+    center_freq: f32,
+    /// Maximum allowed deviation of `freq` from `center_freq`
+    /// (= `center_freq / 2^FREQ_DEV_EXP`).
+    freq_max_dev: f32,
+    /// Loop-filter proportional gain.
+    alpha: f32,
+    /// Loop-filter integral gain.
+    beta: f32,
+    /// Imaginary part of the previously-decimated symbol — the
+    /// `prev` term in the M&M error metric.
+    prev: f32,
+    /// dbdexter `advance_timeslot_dual` (`timing.c:43`) state
+    /// machine: alternates `1 → 2 → 1 → 2`. State 1 returns on
+    /// `phase >= π` (I-tick); state 2 returns on `phase >= 2π`
+    /// (Q-tick / symbol-boundary).
+    state: u8,
+}
+
+impl MmTiming {
+    /// Build an M&M timing loop.
+    ///
+    /// - `sym_freq` — expected symbol period, in radians per
+    ///   `advance_timeslot*` call. For Meteor at 2 sps that's
+    ///   `2π × 72_000 / 144_000 = π`.
+    /// - `bandwidth` — loop bandwidth (dimensionless). dbdexter's
+    ///   default `SYM_BW = 0.00005` (`demod.h:14`) is a good
+    ///   starting point.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if either input is not
+    /// finite or not positive.
+    pub fn new(sym_freq: f32, bandwidth: f32) -> Result<Self, DspError> {
+        if !sym_freq.is_finite() || sym_freq <= 0.0 {
+            return Err(DspError::InvalidParameter(format!(
+                "sym_freq must be finite and positive, got {sym_freq}"
+            )));
+        }
+        if !bandwidth.is_finite() || bandwidth <= 0.0 {
+            return Err(DspError::InvalidParameter(format!(
+                "bandwidth must be finite and positive, got {bandwidth}"
+            )));
+        }
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "FREQ_DEV_EXP < 24 so 1u32 << FREQ_DEV_EXP is exactly representable as f32"
+        )]
+        let freq_max_dev = sym_freq / ((1u32 << FREQ_DEV_EXP) as f32);
+        // dbdexter (`timing.c:97`): `update_alpha_beta(1, bw)` —
+        // damping = 1 here, *different* from the PLL's
+        // damping = 1/√2.
+        let damping = 1.0_f32;
+        let denom = 1.0 + 2.0 * damping * bandwidth + bandwidth * bandwidth;
+        let alpha = 4.0 * damping * bandwidth / denom;
+        let beta = 4.0 * bandwidth * bandwidth / denom;
+        Ok(Self {
+            phase: 0.0,
+            freq: sym_freq,
+            center_freq: sym_freq,
+            freq_max_dev,
+            alpha,
+            beta,
+            prev: 0.0,
+            state: 1,
+        })
+    }
+
+    /// QPSK timeslot tick. Advances the phase accumulator by one
+    /// `freq` step and returns `true` on the symbol boundary
+    /// (`phase >= 2π`). Per dbdexter (`timing.c:32`).
+    ///
+    /// The phase is intentionally not reset here — `retime` does
+    /// the symbol-boundary subtraction, so the loop-filter sees
+    /// the residual error.
+    pub fn advance_timeslot(&mut self) -> bool {
+        self.phase += self.freq;
+        self.phase >= 2.0 * PI
+    }
+
+    /// OQPSK timeslot tick. Advances the phase accumulator and
+    /// returns:
+    ///
+    /// - `0` — no tick this sample.
+    /// - `1` — I-tick: mix the in-phase rail (`mix_i`) and stash
+    ///   the result. State machine flips to expecting state 2
+    ///   next.
+    /// - `2` — Q-tick: mix the quadrature rail (`mix_q`),
+    ///   reassemble the I/Q pair, retime, update the PLL. State
+    ///   machine flips to expecting state 1 next.
+    ///
+    /// Per dbdexter (`timing.c:41`).
+    pub fn advance_timeslot_dual(&mut self) -> u8 {
+        self.phase += self.freq;
+        let threshold = f32::from(self.state) * PI;
+        if self.phase >= threshold {
+            let ret = self.state;
+            // dbdexter (`timing.c:52`): `state = (state % 2) + 1`
+            // — toggles 1 ↔ 2.
+            self.state = if self.state == 1 { 2 } else { 1 };
+            return ret;
+        }
+        0
+    }
+
+    /// Update the timing estimate from one decimated complex
+    /// symbol. Uses only the imaginary part — M&M is single-rail.
+    pub fn retime(&mut self, sample: Complex) {
+        let cur = sample.im;
+        let err = sgn(self.prev) * cur - sgn(cur) * self.prev;
+        self.prev = cur;
+        self.apply_loop_update(err);
+    }
+
+    /// Current symbol-period estimate, in radians per
+    /// `advance_timeslot*` call. Useful for diagnostics — at lock
+    /// it should sit very close to the configured `sym_freq`.
+    pub fn omega(&self) -> f32 {
+        self.freq
+    }
+
+    fn apply_loop_update(&mut self, error: f32) {
+        let mut freq_delta = self.freq - self.center_freq;
+        // dbdexter (`timing.c:80`): `_phase -= 2*M_PI + _alpha*error`.
+        // The `2π` is the symbol-boundary subtraction (so the next
+        // tick fires after another full symbol period); the
+        // `alpha*error` term is the proportional correction.
+        self.phase -= 2.0 * PI + self.alpha * error;
+        freq_delta -= self.beta * error;
+        freq_delta = freq_delta.clamp(-self.freq_max_dev, self.freq_max_dev);
+        self.freq = self.center_freq + freq_delta;
+    }
+}
+
+#[inline]
+fn sgn(x: f32) -> f32 {
+    if x > 0.0 {
+        1.0
+    } else if x < 0.0 {
+        -1.0
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// A representative loop bandwidth for the tests. Wider than
+    /// dbdexter's default 0.00005 so unit tests converge in a
+    /// few thousand samples instead of tens of thousands.
+    const TEST_BW: f32 = 0.005;
+
+    #[test]
+    fn rejects_invalid_inputs() {
+        assert!(MmTiming::new(0.0, TEST_BW).is_err());
+        assert!(MmTiming::new(-1.0, TEST_BW).is_err());
+        assert!(MmTiming::new(f32::NAN, TEST_BW).is_err());
+        assert!(MmTiming::new(PI, 0.0).is_err());
+        assert!(MmTiming::new(PI, -1.0).is_err());
+        assert!(MmTiming::new(PI, f32::INFINITY).is_err());
+    }
+
+    #[test]
+    fn sgn_handles_zero() {
+        assert!((sgn(0.0)).abs() < 1e-9);
+        assert!((sgn(0.5) - 1.0).abs() < 1e-9);
+        assert!((sgn(-0.5) - (-1.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn advance_timeslot_fires_every_two_samples_at_sps_2() {
+        // sym_freq = π → phase += π each call → fires (>= 2π) on
+        // every second call.
+        let mut t = MmTiming::new(PI, TEST_BW).unwrap();
+        let mut fires = 0_usize;
+        for _ in 0..100 {
+            if t.advance_timeslot() {
+                fires += 1;
+                // Reset the phase manually here — the real demod
+                // loop calls `retime` which subtracts 2π. Without
+                // that, every call past the first would fire.
+                // Simulate the subtraction.
+                t.phase -= 2.0 * PI;
+            }
+        }
+        assert_eq!(fires, 50, "expected 50 fires from 100 samples at sps=2");
+    }
+
+    #[test]
+    fn advance_timeslot_dual_alternates_state_1_then_2() {
+        // sym_freq = π → phase crosses π after one sample (state 1
+        // tick), 2π after two (state 2 tick). After the state 2
+        // tick the symbol-boundary subtraction (via `retime`) takes
+        // phase back to ~0, and the cycle repeats.
+        let mut t = MmTiming::new(PI, TEST_BW).unwrap();
+        let mut history = Vec::new();
+        for _ in 0..20 {
+            let r = t.advance_timeslot_dual();
+            history.push(r);
+            // Simulate `retime`'s symbol-boundary subtraction so
+            // we don't keep firing forever.
+            if r == 2 {
+                t.phase -= 2.0 * PI;
+            }
+        }
+        // Expected pattern: every second call yields a tick. The
+        // first sample brings phase from 0 to π → state 1 tick;
+        // the next brings it to 2π → state 2 tick; then we
+        // subtract 2π and repeat.
+        let ticks: Vec<u8> = history.into_iter().filter(|&r| r != 0).collect();
+        assert_eq!(ticks.len(), 20, "expected one tick per sample");
+        for (i, &r) in ticks.iter().enumerate() {
+            let expected = if i % 2 == 0 { 1 } else { 2 };
+            assert_eq!(r, expected, "tick {i} expected state {expected}, got {r}");
+        }
+    }
+
+    #[test]
+    fn retime_zero_error_at_perfect_constellation() {
+        // Mueller-Muller error: sgn(prev)*cur - sgn(cur)*prev.
+        // When prev == cur both terms cancel → error = 0 → no
+        // freq update.
+        let mut t = MmTiming::new(PI, TEST_BW).unwrap();
+        let s = Complex::new(0.0, 1.0);
+        t.retime(s); // prev = 1.0
+        let omega_before = t.omega();
+        // Drive phase up so retime's `-= 2π + alpha*error` doesn't
+        // wrap to a wildly different state.
+        t.phase = 2.0 * PI;
+        t.retime(s); // err should be 0
+        // Center-freq clamp means freq returns to center if delta == 0;
+        // omega should equal center_freq.
+        assert!(
+            (t.omega() - omega_before).abs() < 1e-9,
+            "zero-error retime must not perturb omega"
+        );
+    }
+
+    #[test]
+    fn freq_clamped_to_max_dev() {
+        let mut t = MmTiming::new(PI, TEST_BW).unwrap();
+        // Force-feed a huge error directly to apply_loop_update.
+        for _ in 0..10_000 {
+            t.apply_loop_update(1000.0);
+        }
+        let max_freq = t.center_freq + t.freq_max_dev;
+        let min_freq = t.center_freq - t.freq_max_dev;
+        assert!(
+            t.freq <= max_freq && t.freq >= min_freq,
+            "freq {} out of clamp range [{}, {}]",
+            t.freq,
+            min_freq,
+            max_freq
+        );
+    }
+}

--- a/crates/sdr-dsp/src/lrpt/mod.rs
+++ b/crates/sdr-dsp/src/lrpt/mod.rs
@@ -25,6 +25,7 @@
 //!   `original/meteor_demod/demod.c::demod_oqpsk`.
 
 pub mod costas;
+pub mod meteor_agc;
 pub mod meteor_pll;
 pub mod mm_timing;
 pub mod rrc_filter;
@@ -32,6 +33,7 @@ pub mod slicer;
 pub mod timing;
 
 pub use costas::Costas;
+pub use meteor_agc::MeteorAgc;
 pub use meteor_pll::MeteorPll;
 pub use mm_timing::MmTiming;
 pub use rrc_filter::RrcFilter;
@@ -93,6 +95,15 @@ const OQPSK_PLL_BW: f32 = 2.0 * core::f32::consts::PI * DBDEXTER_PLL_BW_HZ / SYM
 /// exactly `π`.
 const MM_SYM_FREQ: f32 = 2.0 * core::f32::consts::PI * SYMBOL_RATE_HZ / SAMPLE_RATE_HZ;
 
+/// Reciprocal of the AGC target magnitude. The OQPSK chain's PLL +
+/// timing loops are calibrated for dbdexter's |sample| ≈ 190
+/// post-AGC scale, but [`slice_soft`] is calibrated for unit-
+/// magnitude input (rails at ±0.707 → ±90 after the ×127 scaling).
+/// Multiplying the assembled symbol by this constant just before
+/// the slicer brings it back to unit magnitude without disturbing
+/// the loop scales upstream.
+const OQPSK_SLICER_DESCALE: f32 = 1.0 / meteor_agc::TARGET_MAG;
+
 /// Modulation modes supported by [`LrptDemod`]. The catalog layer
 /// (`sdr-sat`) carries its own equivalent enum — the controller is
 /// the seam that maps from one to the other.
@@ -124,6 +135,12 @@ enum DemodInner {
         gardner: Gardner,
     },
     Oqpsk {
+        /// AGC stage between the RRC filter and the carrier-
+        /// recovery PLL. dbdexter's PLL is calibrated for
+        /// |sample| = 190 post-AGC; without this the lock
+        /// detector mis-fires (see [`MeteorAgc`]'s module
+        /// docs for the full chain of consequences).
+        agc: MeteorAgc,
         pll: MeteorPll,
         timing: MmTiming,
         /// In-phase sample stashed between the I-tick and the
@@ -188,13 +205,29 @@ impl LrptDemod {
     }
 
     fn build_oqpsk_inner() -> Result<DemodInner, DspError> {
+        let agc = MeteorAgc::new();
         let pll = MeteorPll::new(OQPSK_PLL_BW, true, None)?;
         let timing = MmTiming::new(MM_SYM_FREQ, DBDEXTER_SYM_BW)?;
         Ok(DemodInner::Oqpsk {
+            agc,
             pll,
             timing,
             pending_i: 0.0,
         })
+    }
+
+    /// Whether the OQPSK carrier-recovery PLL has ever locked since
+    /// construction. `None` for the QPSK mode (the SDR++-style
+    /// Costas loop in that path doesn't expose a lock detector).
+    /// Useful for diagnostics and for the `oqpsk_zero_iq_*`
+    /// regression tests that pin the AGC + lock-detector
+    /// interaction. Per CR round 2 on PR #663.
+    #[must_use]
+    pub fn oqpsk_locked_once(&self) -> Option<bool> {
+        match &self.inner {
+            DemodInner::Qpsk { .. } => None,
+            DemodInner::Oqpsk { pll, .. } => Some(pll.locked_once()),
+        }
     }
 
     /// Push one complex baseband sample. Returns up to one soft-
@@ -207,10 +240,17 @@ impl LrptDemod {
                 gardner.process(derotated).map(slice_soft)
             }
             DemodInner::Oqpsk {
+                agc,
                 pll,
                 timing,
                 pending_i,
             } => {
+                // AGC normalizes magnitude to dbdexter's
+                // expected ~190 rail amplitude before the PLL —
+                // without this the lock detector and tanh LUT
+                // are calibrated to the wrong scale. Per CR
+                // round 2 on PR #663.
+                let scaled = agc.process(filtered);
                 // Advance the carrier NCO on every input sample,
                 // not only on timing ticks. dbdexter's polyphase
                 // pipeline (interp_factor=5) skips the PLL on
@@ -223,7 +263,7 @@ impl LrptDemod {
                 // PLL frozen for that sample, and the next
                 // mix_i / mix_q would run at the wrong phase.
                 // Per CR round 1 on PR #663.
-                let mixed = pll.mix(filtered);
+                let mixed = pll.mix(scaled);
                 match timing.advance_timeslot_dual() {
                     1 => {
                         // I-tick: stash the in-phase rail. The
@@ -237,10 +277,15 @@ impl LrptDemod {
                         // Q-tick: reassemble the I/Q pair,
                         // retime the symbol clock, update the
                         // carrier estimate, emit the soft symbol.
+                        // The retime + update_estimate calls run
+                        // on the AGC-scale symbol (dbdexter's
+                        // calibration); the slicer gets a
+                        // descaled copy (unit magnitude, what
+                        // [`slice_soft`] expects).
                         let symbol = Complex::new(*pending_i, mixed.im);
                         timing.retime(symbol);
                         pll.update_estimate(*pending_i, mixed.im);
-                        Some(slice_soft(symbol))
+                        Some(slice_soft(symbol * OQPSK_SLICER_DESCALE))
                     }
                     _ => None,
                 }
@@ -327,6 +372,34 @@ mod tests {
         // chain's inner constructors is finite + positive, so
         // construction should never fail.
         assert!(LrptDemod::new_with_mode(LrptMode::Oqpsk).is_ok());
+    }
+
+    #[test]
+    fn oqpsk_zero_iq_never_acquires_lock() {
+        // Regression for CR round 2 on PR #663. Without the AGC
+        // stage and dbdexter's amplitude calibration, the
+        // MeteorPll lock detector's |error| EMA decays from 1000
+        // toward 0 with pole 0.001 and crosses the lock threshold
+        // (85) after ~2700 update_estimate() calls — purely from
+        // time elapsed — declaring lock on silence and disabling
+        // the free-run frequency sweep before the carrier is
+        // found. With the AGC in place, zero-IQ silence drives
+        // the gain to saturation and any post-AGC noise produces
+        // non-zero phase error; the EMA stays high and
+        // `locked_once` stays false.
+        let mut demod = LrptDemod::new_with_mode(LrptMode::Oqpsk).unwrap();
+        // 100k samples is well past the ~5400-sample point
+        // (= 2700 update_estimate calls × 2 input samples per
+        // call) at which the bug would have triggered.
+        for _ in 0..100_000 {
+            demod.process(Complex::default());
+        }
+        assert_eq!(
+            demod.oqpsk_locked_once(),
+            Some(false),
+            "zero-IQ silence must not trigger the OQPSK lock detector — \
+             AGC + lock-detector interaction has regressed",
+        );
     }
 
     #[test]

--- a/crates/sdr-dsp/src/lrpt/mod.rs
+++ b/crates/sdr-dsp/src/lrpt/mod.rs
@@ -210,26 +210,41 @@ impl LrptDemod {
                 pll,
                 timing,
                 pending_i,
-            } => match timing.advance_timeslot_dual() {
-                1 => {
-                    // I-tick: mix and stash the in-phase sample.
-                    // The Q-tick half a symbol from now will pair
-                    // with this and drive the per-symbol updates.
-                    *pending_i = pll.mix_i(filtered);
-                    None
+            } => {
+                // Advance the carrier NCO on every input sample,
+                // not only on timing ticks. dbdexter's polyphase
+                // pipeline (interp_factor=5) skips the PLL on
+                // non-tick polyphase positions because those are
+                // filter intermediates, not real samples — but at
+                // our 2 sps with no interpolation, every input is
+                // a real sample and the NCO must track wall-clock
+                // continuously. Without this, a 0-tick from the
+                // M&M loop during timing correction leaves the
+                // PLL frozen for that sample, and the next
+                // mix_i / mix_q would run at the wrong phase.
+                // Per CR round 1 on PR #663.
+                let mixed = pll.mix(filtered);
+                match timing.advance_timeslot_dual() {
+                    1 => {
+                        // I-tick: stash the in-phase rail. The
+                        // Q-tick half a symbol from now will
+                        // pair with this and drive the per-symbol
+                        // updates.
+                        *pending_i = mixed.re;
+                        None
+                    }
+                    2 => {
+                        // Q-tick: reassemble the I/Q pair,
+                        // retime the symbol clock, update the
+                        // carrier estimate, emit the soft symbol.
+                        let symbol = Complex::new(*pending_i, mixed.im);
+                        timing.retime(symbol);
+                        pll.update_estimate(*pending_i, mixed.im);
+                        Some(slice_soft(symbol))
+                    }
+                    _ => None,
                 }
-                2 => {
-                    // Q-tick: mix, reassemble the I/Q pair, retime
-                    // the symbol clock, update the carrier
-                    // estimate, emit the soft symbol.
-                    let q = pll.mix_q(filtered);
-                    let symbol = Complex::new(*pending_i, q);
-                    timing.retime(symbol);
-                    pll.update_estimate(*pending_i, q);
-                    Some(slice_soft(symbol))
-                }
-                _ => None,
-            },
+            }
         }
     }
 }

--- a/crates/sdr-dsp/src/lrpt/mod.rs
+++ b/crates/sdr-dsp/src/lrpt/mod.rs
@@ -1,23 +1,39 @@
-//! Meteor-M LRPT QPSK demodulator (epic #469, stage 1).
+//! Meteor-M LRPT QPSK / OQPSK demodulator (epic #469 + issue #662).
 //!
-//! Pipeline: RRC matched filter → Costas loop → Gardner symbol-
-//! timing recovery → hard slicer → soft symbols (i8 ±127). No AGC
-//! in v1 — RRC normalization handles unity gain.
+//! Two pipelines live here, dispatched from [`LrptDemod`] by mode:
 //!
-//! Each module is small, pure, and unit-testable in isolation. The
-//! `LrptDemod` chain wires them together; callers push complex
-//! baseband samples and pull soft symbol pairs out.
+//! - **QPSK** (legacy METEOR-M N2, decommissioned but kept for any
+//!   archival recordings): RRC matched filter → SDR++-style Costas
+//!   → Gardner timing → hard slicer.
+//! - **OQPSK** (current METEOR-M2 3 / METEOR-M2 4): RRC matched
+//!   filter → dbdexter-style [`MeteorPll`] → dbdexter-style
+//!   [`MmTiming`] (Mueller-Muller, dual-rail timeslot machine) →
+//!   hard slicer.
 //!
-//! Reference (read-only):
-//! `original/SDRPlusPlus/decoder_modules/meteor_demodulator/src/`
-//! and `original/meteor_demod/dsp/`.
+//! See [`meteor_pll`] and [`mm_timing`] for the OQPSK math; see
+//! [`costas`] and [`timing`] for the QPSK math. The QPSK and
+//! OQPSK paths are kept separate (rather than collapsing onto a
+//! single primitive) so the QPSK chain stays unchanged from the
+//! pre-#662 baseline — no regression risk for archival N2
+//! recordings, and OQPSK gets dbdexter's tight loops + lock
+//! detector + free-run frequency sweep without bolting them onto
+//! a previously-tuned QPSK loop.
+//!
+//! References (read-only):
+//! - QPSK chain: `original/SDRPlusPlus/decoder_modules/meteor_demodulator/src/`.
+//! - OQPSK chain: `original/meteor_demod/dsp/{pll,timing}.{c,h}` and
+//!   `original/meteor_demod/demod.c::demod_oqpsk`.
 
 pub mod costas;
+pub mod meteor_pll;
+pub mod mm_timing;
 pub mod rrc_filter;
 pub mod slicer;
 pub mod timing;
 
 pub use costas::Costas;
+pub use meteor_pll::MeteorPll;
+pub use mm_timing::MmTiming;
 pub use rrc_filter::RrcFilter;
 pub use slicer::slice_soft;
 pub use timing::Gardner;
@@ -52,17 +68,76 @@ pub const GARDNER_MU_GAIN: f32 = 0.01;
 /// every magic numeric configuration value.
 pub const SAMPLES_PER_SYMBOL: usize = 2;
 
-/// Top-level LRPT demodulator chain.
+/// dbdexter `pll_bw` default — `1` Hz of effective loop bandwidth
+/// at the Meteor symbol rate. `meteor_demod/demod.h:15`.
+const DBDEXTER_PLL_BW_HZ: f32 = 1.0;
+
+/// dbdexter `SYM_BW` default — Mueller-Muller loop bandwidth.
+/// `meteor_demod/demod.h:14`. Already normalized; in dbdexter's
+/// pipeline this is divided by the polyphase `interp_factor`
+/// before being passed to the timing loop, but we run with no
+/// interpolation (1 filtered output per input at 2 sps), so we
+/// use the value directly.
+const DBDEXTER_SYM_BW: f32 = 0.000_05;
+
+/// OQPSK PLL loop bandwidth in radians per `mix_*` call. Mirrors
+/// dbdexter's `2π * pll_bw / (1 * symrate)` formula
+/// (`demod.c:12`, with `multiplier = 1` for OQPSK). At 1 Hz of
+/// effective loop bandwidth and 72 ksym/s, this is
+/// `2π × 1 / 72_000 ≈ 8.7266e-5`.
+const OQPSK_PLL_BW: f32 = 2.0 * core::f32::consts::PI * DBDEXTER_PLL_BW_HZ / SYMBOL_RATE_HZ;
+
+/// Mueller-Muller initial symbol period, in radians per timeslot
+/// tick. Mirrors dbdexter's `2π * symrate / (samplerate * interp)`
+/// formula (`demod.c:13`, with `interp = 1`). At 2 sps this is
+/// exactly `π`.
+const MM_SYM_FREQ: f32 = 2.0 * core::f32::consts::PI * SYMBOL_RATE_HZ / SAMPLE_RATE_HZ;
+
+/// Modulation modes supported by [`LrptDemod`]. The catalog layer
+/// (`sdr-sat`) carries its own equivalent enum — the controller is
+/// the seam that maps from one to the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LrptMode {
+    /// Standard QPSK. Used by legacy METEOR-M N2 recordings.
+    Qpsk,
+    /// Offset QPSK — Q delayed by Tsym/2 from I. Used by
+    /// METEOR-M2 3 and METEOR-M2 4.
+    Oqpsk,
+}
+
+/// Top-level LRPT demodulator chain. The mode is picked at
+/// construction (defaulting to QPSK for backward compatibility);
+/// `process()` dispatches each input sample down the appropriate
+/// inner pipeline.
 pub struct LrptDemod {
     rrc: RrcFilter,
-    costas: Costas,
-    gardner: Gardner,
+    inner: DemodInner,
+}
+
+/// Per-mode demod state. Boxing isn't necessary — both variants
+/// are small enough that the size difference is irrelevant, and
+/// the sum-type representation makes the dispatch in `process`
+/// trivially branch-predictable.
+enum DemodInner {
+    Qpsk {
+        costas: Costas,
+        gardner: Gardner,
+    },
+    Oqpsk {
+        pll: MeteorPll,
+        timing: MmTiming,
+        /// In-phase sample stashed between the I-tick and the
+        /// Q-tick. Per dbdexter `demod.c::demod_oqpsk`'s `static
+        /// float inphase`.
+        pending_i: f32,
+    },
 }
 
 impl LrptDemod {
-    /// Build a demod chain at the standard Meteor parameters
-    /// ([`SAMPLES_PER_SYMBOL`], [`COSTAS_LOOP_BW`],
-    /// [`GARDNER_OMEGA_GAIN`], [`GARDNER_MU_GAIN`]).
+    /// Build a QPSK demod chain. Equivalent to
+    /// `new_with_mode(LrptMode::Qpsk)` — kept as a no-arg
+    /// constructor for backward compatibility with all the
+    /// existing call sites that predate the modulation enum.
     ///
     /// # Errors
     ///
@@ -74,15 +149,51 @@ impl LrptDemod {
     /// the propagation is here for defensive consistency with the
     /// rest of the DSP module.
     pub fn new() -> Result<Self, DspError> {
+        Self::new_with_mode(LrptMode::Qpsk)
+    }
+
+    /// Build a demod chain in the requested mode.
+    ///
+    /// QPSK uses the existing SDR++-style Costas + Gardner; OQPSK
+    /// uses the dbdexter-style [`MeteorPll`] + [`MmTiming`]. Each mode
+    /// brings its own loop tuning (see the `*_BW` / `*_GAIN`
+    /// constants in this module for the chosen values).
+    ///
+    /// # Errors
+    ///
+    /// Returns `DspError::InvalidParameter` if any inner loop
+    /// rejects its parameters. Practically unreachable for the
+    /// pinned constants in this module.
+    pub fn new_with_mode(mode: LrptMode) -> Result<Self, DspError> {
+        let inner = match mode {
+            LrptMode::Qpsk => Self::build_qpsk_inner()?,
+            LrptMode::Oqpsk => Self::build_oqpsk_inner()?,
+        };
+        Ok(Self {
+            rrc: RrcFilter::new(SAMPLES_PER_SYMBOL),
+            inner,
+        })
+    }
+
+    fn build_qpsk_inner() -> Result<DemodInner, DspError> {
         #[allow(
             clippy::cast_precision_loss,
             reason = "SAMPLES_PER_SYMBOL is a tiny constant (= 2); the f32 conversion is exact"
         )]
         let sps_f = SAMPLES_PER_SYMBOL as f32;
-        Ok(Self {
-            rrc: RrcFilter::new(SAMPLES_PER_SYMBOL),
+        Ok(DemodInner::Qpsk {
             costas: Costas::new(COSTAS_LOOP_BW)?,
             gardner: Gardner::new(sps_f, GARDNER_OMEGA_GAIN, GARDNER_MU_GAIN)?,
+        })
+    }
+
+    fn build_oqpsk_inner() -> Result<DemodInner, DspError> {
+        let pll = MeteorPll::new(OQPSK_PLL_BW, true, None)?;
+        let timing = MmTiming::new(MM_SYM_FREQ, DBDEXTER_SYM_BW)?;
+        Ok(DemodInner::Oqpsk {
+            pll,
+            timing,
+            pending_i: 0.0,
         })
     }
 
@@ -90,17 +201,46 @@ impl LrptDemod {
     /// symbol pair `[i, q]` when the timing recovery fires a tick.
     pub fn process(&mut self, x: Complex) -> Option<[i8; 2]> {
         let filtered = self.rrc.process(x);
-        let derotated = self.costas.process(filtered);
-        self.gardner.process(derotated).map(slice_soft)
+        match &mut self.inner {
+            DemodInner::Qpsk { costas, gardner } => {
+                let derotated = costas.process(filtered);
+                gardner.process(derotated).map(slice_soft)
+            }
+            DemodInner::Oqpsk {
+                pll,
+                timing,
+                pending_i,
+            } => match timing.advance_timeslot_dual() {
+                1 => {
+                    // I-tick: mix and stash the in-phase sample.
+                    // The Q-tick half a symbol from now will pair
+                    // with this and drive the per-symbol updates.
+                    *pending_i = pll.mix_i(filtered);
+                    None
+                }
+                2 => {
+                    // Q-tick: mix, reassemble the I/Q pair, retime
+                    // the symbol clock, update the carrier
+                    // estimate, emit the soft symbol.
+                    let q = pll.mix_q(filtered);
+                    let symbol = Complex::new(*pending_i, q);
+                    timing.retime(symbol);
+                    pll.update_estimate(*pending_i, q);
+                    Some(slice_soft(symbol))
+                }
+                _ => None,
+            },
+        }
     }
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 
     #[test]
-    fn pipeline_produces_soft_symbols_from_synthetic_qpsk() {
+    fn qpsk_pipeline_produces_soft_symbols_from_synthetic_qpsk() {
         // Synthesize ~2 sps QPSK with no impairments. Pipeline
         // converges and emits signed i8 pairs.
         let mut demod = LrptDemod::new().expect("LrptDemod::new");
@@ -127,7 +267,69 @@ mod tests {
         // half is correct.
         assert!(
             emitted > 1500,
-            "pipeline should emit ~2000 soft symbols, got {emitted}",
+            "QPSK pipeline should emit ~2000 soft symbols, got {emitted}",
         );
+    }
+
+    #[test]
+    fn oqpsk_pipeline_produces_soft_symbols_from_synthetic_oqpsk() {
+        // Synthesize 2 sps OQPSK by interleaving I-only samples
+        // and Q-only samples on alternating sample indices — the
+        // canonical "Q delayed by Tsym/2" representation. The
+        // OQPSK chain should converge and emit one soft symbol
+        // per pair of input samples.
+        let mut demod =
+            LrptDemod::new_with_mode(LrptMode::Oqpsk).expect("LrptDemod::new_with_mode");
+        // Four hard QPSK constellation points expressed as I-only
+        // and Q-only halves at +/-0.707.
+        let i_vals = [0.707_f32, -0.707, 0.707, -0.707];
+        let q_vals = [0.707_f32, 0.707, -0.707, -0.707];
+        let mut emitted = 0_usize;
+        for n in 0..8000 {
+            let sym_idx = (n / 2) % 4;
+            let s = if n % 2 == 0 {
+                Complex::new(i_vals[sym_idx], 0.0)
+            } else {
+                Complex::new(0.0, q_vals[sym_idx])
+            };
+            if demod.process(s).is_some() {
+                emitted += 1;
+            }
+        }
+        // 8000 inputs at 2 sps → ~4000 emitted post-settle. Allow
+        // generous slack for the dbdexter loop's longer initial
+        // lock latency (the free-run sweep takes a moment to find
+        // zero offset on a clean signal).
+        assert!(
+            emitted > 3000,
+            "OQPSK pipeline should emit ~4000 soft symbols, got {emitted}",
+        );
+    }
+
+    #[test]
+    fn oqpsk_constructor_succeeds() {
+        // Sanity check: every constant we feed to the OQPSK
+        // chain's inner constructors is finite + positive, so
+        // construction should never fail.
+        assert!(LrptDemod::new_with_mode(LrptMode::Oqpsk).is_ok());
+    }
+
+    #[test]
+    fn oqpsk_pipeline_processes_zero_iq_without_emitting() {
+        // Zero IQ → no symbol decisions → no emissions, but the
+        // chain must not panic or produce noise either.
+        let mut demod = LrptDemod::new_with_mode(LrptMode::Oqpsk).unwrap();
+        let mut emitted = 0_usize;
+        for _ in 0..1000 {
+            // The OQPSK chain emits whatever the slicer makes of
+            // the zero-mixed samples — it's allowed to emit, just
+            // shouldn't crash. Count emissions only as a sanity
+            // signal.
+            if demod.process(Complex::default()).is_some() {
+                emitted += 1;
+            }
+        }
+        // 1000 inputs at 2 sps → at most ~500 emissions.
+        assert!(emitted <= 500);
     }
 }

--- a/crates/sdr-radio/src/lrpt_decoder.rs
+++ b/crates/sdr-radio/src/lrpt_decoder.rs
@@ -32,7 +32,7 @@
 
 use std::collections::HashMap;
 
-use sdr_dsp::lrpt::LrptDemod;
+use sdr_dsp::lrpt::{LrptDemod, LrptMode};
 use sdr_lrpt::LrptPipeline;
 use sdr_lrpt::image::IMAGE_WIDTH;
 use sdr_types::{Complex, DspError};
@@ -44,6 +44,11 @@ pub struct LrptDecoder {
     demod: LrptDemod,
     pipeline: LrptPipeline,
     image: LrptImage,
+    /// Modulation the decoder was built for. Stored so
+    /// [`Self::reset`] can re-construct the inner demod chain in
+    /// the same mode without the caller having to plumb the
+    /// modulation through a second time.
+    mode: LrptMode,
     /// Per-APID watermark — the last `channel.lines` count we
     /// pushed into the shared `LrptImage`. Indexed by APID
     /// (16-bit) since that's the identifier the demux stamps
@@ -54,18 +59,22 @@ pub struct LrptDecoder {
 }
 
 impl LrptDecoder {
-    /// Build a fresh decoder around the given shared image.
+    /// Build a fresh decoder around the given shared image and
+    /// modulation. METEOR-M N2 is QPSK; METEOR-M2 3 / METEOR-M2 4
+    /// are OQPSK — the mode picks which inner demod chain runs
+    /// (per [`LrptDemod::new_with_mode`]).
     ///
     /// # Errors
     ///
     /// Returns `DspError::InvalidParameter` if the underlying
     /// [`LrptDemod`] constructor rejects its parameters
     /// (practically unreachable — see that constructor's docs).
-    pub fn new(image: LrptImage) -> Result<Self, DspError> {
+    pub fn new(image: LrptImage, mode: LrptMode) -> Result<Self, DspError> {
         Ok(Self {
-            demod: LrptDemod::new()?,
+            demod: LrptDemod::new_with_mode(mode)?,
             pipeline: LrptPipeline::new(),
             image,
+            mode,
             last_pushed_lines: HashMap::new(),
         })
     }
@@ -142,7 +151,7 @@ impl LrptDecoder {
     /// Returns `DspError` if the demod re-construction fails
     /// (see [`LrptDemod::new`]).
     pub fn reset(&mut self) -> Result<(), DspError> {
-        self.demod = LrptDemod::new()?;
+        self.demod = LrptDemod::new_with_mode(self.mode)?;
         self.pipeline.reset();
         self.image.clear();
         self.last_pushed_lines.clear();
@@ -164,7 +173,7 @@ mod tests {
     #[test]
     fn lrpt_decoder_constructible() {
         let image = LrptImage::new();
-        let _decoder = LrptDecoder::new(image).expect("LrptDemod must construct");
+        let _decoder = LrptDecoder::new(image, LrptMode::Qpsk).expect("LrptDemod must construct");
     }
 
     #[test]
@@ -173,7 +182,7 @@ mod tests {
         // image lines. The decoder should run cleanly and the
         // shared image should stay empty.
         let image = LrptImage::new();
-        let mut decoder = LrptDecoder::new(image.clone()).unwrap();
+        let mut decoder = LrptDecoder::new(image.clone(), LrptMode::Qpsk).unwrap();
         let zeros = vec![Complex::default(); 1_000];
         decoder.process(&zeros);
         assert!(image.snapshot_channel(APID_TEST).is_none());
@@ -197,7 +206,7 @@ mod tests {
         // an empty pipeline harvests nothing on the first
         // call.
         let image = LrptImage::new();
-        let mut decoder = LrptDecoder::new(image.clone()).unwrap();
+        let mut decoder = LrptDecoder::new(image.clone(), LrptMode::Qpsk).unwrap();
         // Empty pipeline → empty assembler → harvest is a no-op.
         decoder.harvest_new_lines();
         assert!(decoder.last_pushed_lines.is_empty());
@@ -211,7 +220,7 @@ mod tests {
         let image = LrptImage::new();
         image.push_line(APID_TEST, &vec![42_u8; IMAGE_WIDTH]);
         assert!(image.snapshot_channel(APID_TEST).is_some());
-        let mut decoder = LrptDecoder::new(image.clone()).unwrap();
+        let mut decoder = LrptDecoder::new(image.clone(), LrptMode::Qpsk).unwrap();
         decoder.last_pushed_lines.insert(APID_TEST, 7);
         decoder.reset().expect("reset must succeed");
         assert!(decoder.last_pushed_lines.is_empty());

--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -214,6 +214,37 @@ pub const METEOR_M2_4_EXPECTED_LRPT_APIDS: &[u16] = &[64, 65, 68];
 /// their own decoder + viewer without the recorder itself caring
 /// about protocol details.
 ///
+/// LRPT modulation variant used by a Meteor-M satellite. Per #662,
+/// the original METEOR-M N2 (NORAD 40069, decommissioned) used
+/// standard QPSK; current generation METEOR-M2 satellites
+/// (M2-2, M2-3, M2-4) all use **Offset QPSK** (OQPSK) at 72 ksym/s.
+///
+/// The two variants share the same constellation (4 corner points)
+/// but differ in symbol timing: OQPSK delays Q by half a symbol
+/// period relative to I. A pure QPSK demod CAN lock on OQPSK but
+/// produces sub-quality soft symbols because the Gardner timing
+/// recovery error metric assumes I and Q are co-timed. That's the
+/// root cause of the silent-Meteor-pass debug session that
+/// surfaced this issue.
+///
+/// Carried on each [`KnownSatellite`] with `imaging_protocol =
+/// Some(Lrpt)` so the demod chain can dispatch correctly per
+/// satellite. `None` for non-LRPT satellites.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LrptModulation {
+    /// Standard QPSK at 72 ksym/s. Used by the original METEOR-M
+    /// N2 (now decommissioned). Kept as a variant so a future
+    /// satellite reverting to standard QPSK can be enrolled
+    /// without code changes.
+    Qpsk,
+    /// Offset QPSK at 72 ksym/s. Used by all current operational
+    /// METEOR-M2 satellites (M2-3, M2-4). Q is delayed by half a
+    /// symbol period; demodulator must use dual-tick timing
+    /// recovery and separate I/Q PLL mixes per
+    /// `original/meteor_demod/dsp/pll.c`.
+    Oqpsk,
+}
+
 /// `None` on a [`KnownSatellite::imaging_protocol`] means "in the
 /// catalog for pass-prediction display purposes, but auto-record
 /// is not yet wired for this satellite's protocol." The recorder's
@@ -329,6 +360,16 @@ pub struct KnownSatellite {
     /// produces a per-channel PNG regardless of whether it's in this
     /// set. The set drives diagnostics only.
     pub expected_lrpt_apids: Option<&'static [u16]>,
+    /// LRPT modulation variant for this satellite. `None` for
+    /// non-LRPT entries. `Some(LrptModulation::Oqpsk)` for current-
+    /// generation Meteor-M2 satellites (M2-3, M2-4) which transmit
+    /// Offset QPSK; `Some(Qpsk)` reserved for any future revival
+    /// of the original METEOR-M N2 (which used standard QPSK).
+    /// Drives the dispatch in `sdr_dsp::lrpt::LrptDemod` so the
+    /// timing recovery + PLL paths match the actual signal. Per
+    /// #662 — investigation showed our hardcoded-QPSK pipeline
+    /// can't cleanly demodulate OQPSK signals.
+    pub lrpt_modulation: Option<LrptModulation>,
 }
 
 impl KnownSatellite {
@@ -426,6 +467,9 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         // composites are unavailable until Roscosmos schedules
         // M2-3 back to standard mode. Per #645.
         expected_lrpt_apids: Some(METEOR_M2_3_EXPECTED_LRPT_APIDS),
+        // Current-generation METEOR-M2 satellites broadcast
+        // Offset QPSK at 72 ksym/s. Per #662.
+        lrpt_modulation: Some(LrptModulation::Oqpsk),
     },
     KnownSatellite {
         // METEOR-M2 4 launched in 2024 and is actively transmitting
@@ -453,6 +497,8 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         // passes — currently the easier first-decode target than
         // M2-3 for exactly that reason. Per #645.
         expected_lrpt_apids: Some(METEOR_M2_4_EXPECTED_LRPT_APIDS),
+        // Same OQPSK modulation as M2-3. Per #662.
+        lrpt_modulation: Some(LrptModulation::Oqpsk),
     },
     // ISS SSTV — epic #472. Currently 437.550 MHz UHF (ARISS Series
     // 31+, April 2026 onward, see #638); the catalog tracks the live
@@ -480,6 +526,7 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         // LRPT broadcast — the per-pass expected-APID set doesn't
         // apply.
         expected_lrpt_apids: None,
+        lrpt_modulation: None,
     },
     // Amateur-radio voice satellites — #649. Pure pass-prediction
     // entries: the user manually tunes / listens via the existing
@@ -518,6 +565,7 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         bandwidth_hz: HAM_SSB_BANDWIDTH_HZ,
         imaging_protocol: None,
         expected_lrpt_apids: None,
+        lrpt_modulation: None,
     },
     KnownSatellite {
         // SaudiSat-1C (SO-50). Single-channel FM voice repeater:
@@ -532,6 +580,7 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         bandwidth_hz: HAM_VOICE_NFM_BANDWIDTH_HZ,
         imaging_protocol: None,
         expected_lrpt_apids: None,
+        lrpt_modulation: None,
     },
     KnownSatellite {
         // PO-101 (Diwata-2 / Philippines). FM voice repeater +
@@ -549,6 +598,7 @@ pub const KNOWN_SATELLITES: &[KnownSatellite] = &[
         bandwidth_hz: HAM_VOICE_NFM_BANDWIDTH_HZ,
         imaging_protocol: None,
         expected_lrpt_apids: None,
+        lrpt_modulation: None,
     },
 ];
 

--- a/crates/sdr-sat/src/lib.rs
+++ b/crates/sdr-sat/src/lib.rs
@@ -730,6 +730,68 @@ mod tests {
     }
 
     #[test]
+    fn lrpt_modulation_pinned_for_active_meteor_satellites() {
+        // `lrpt_modulation` is part of the runtime demod-selection
+        // contract (sdr-dsp::lrpt::LrptDemod dispatches QPSK vs
+        // OQPSK pipelines on it). A future copy/paste that left
+        // a Meteor row at `None` would silently fall back to the
+        // legacy QPSK path and resurrect the zero-APID pass-failure
+        // that motivated #662 in the first place — so pin both
+        // active Meteor entries here. Per CR round 1 on PR #663.
+        let m2_3 = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.norad_id == METEOR_M2_3_NORAD_ID)
+            .expect("METEOR-M2 3 should be in KNOWN_SATELLITES");
+        assert_eq!(
+            m2_3.lrpt_modulation,
+            Some(LrptModulation::Oqpsk),
+            "METEOR-M2 3 transmits OQPSK; QPSK demod cannot decode it cleanly",
+        );
+        let m2_4 = KNOWN_SATELLITES
+            .iter()
+            .find(|s| s.norad_id == METEOR_M2_4_NORAD_ID)
+            .expect("METEOR-M2 4 should be in KNOWN_SATELLITES");
+        assert_eq!(
+            m2_4.lrpt_modulation,
+            Some(LrptModulation::Oqpsk),
+            "METEOR-M2 4 transmits OQPSK; QPSK demod cannot decode it cleanly",
+        );
+    }
+
+    #[test]
+    fn lrpt_modulation_only_set_on_lrpt_entries() {
+        // Inverse of the test above: the catalog is small enough
+        // that a stray `Some(_)` on a non-LRPT row would slip
+        // through review without this guard. Anything not flagged
+        // `imaging_protocol = Some(Lrpt)` must have
+        // `lrpt_modulation = None` — otherwise the field
+        // contradicts the rest of the row's contract. Per CR
+        // round 1 on PR #663.
+        for sat in KNOWN_SATELLITES {
+            let is_lrpt = sat.imaging_protocol == Some(ImagingProtocol::Lrpt);
+            if is_lrpt {
+                assert!(
+                    sat.lrpt_modulation.is_some(),
+                    "{} (NORAD {}) is an LRPT satellite but lrpt_modulation = None — \
+                     the demod chain would fall back to legacy QPSK and likely fail to decode",
+                    sat.name,
+                    sat.norad_id,
+                );
+            } else {
+                assert!(
+                    sat.lrpt_modulation.is_none(),
+                    "{} (NORAD {}) is not LRPT but carries lrpt_modulation = {:?} — \
+                     contradicts imaging_protocol = {:?}",
+                    sat.name,
+                    sat.norad_id,
+                    sat.lrpt_modulation,
+                    sat.imaging_protocol,
+                );
+            }
+        }
+    }
+
+    #[test]
     fn meteor_m2_4_carries_standard_mode_expected_apids() {
         // M2-4 broadcasts c1/c2/c4 (visual + visual + thermal IR) —
         // the standard set every composite recipe in

--- a/crates/sdr-ui/src/doppler_tracker.rs
+++ b/crates/sdr-ui/src/doppler_tracker.rs
@@ -307,6 +307,7 @@ mod tests {
         imaging_protocol: Some(sdr_sat::ImagingProtocol::Apt),
         // Doppler tracker tests don't read this field.
         expected_lrpt_apids: None,
+        lrpt_modulation: None,
     };
     static FIXTURE_B: KnownSatellite = KnownSatellite {
         name: "TEST_SAT_B",
@@ -316,6 +317,7 @@ mod tests {
         bandwidth_hz: TEST_APT_BANDWIDTH_HZ,
         imaging_protocol: Some(sdr_sat::ImagingProtocol::Apt),
         expected_lrpt_apids: None,
+        lrpt_modulation: None,
     };
     static FIXTURE_C: KnownSatellite = KnownSatellite {
         name: "TEST_SAT_C",
@@ -325,6 +327,7 @@ mod tests {
         bandwidth_hz: TEST_APT_BANDWIDTH_HZ,
         imaging_protocol: Some(sdr_sat::ImagingProtocol::Apt),
         expected_lrpt_apids: None,
+        lrpt_modulation: None,
     };
 
     fn noaa_15() -> &'static KnownSatellite {

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11538,6 +11538,28 @@ fn connect_satellites_panel(
                         // be at the wrong rate and the demod's
                         // resampler would sit at the wrong
                         // setpoint. Per epic #469 task 7.
+
+                        // Tell the DSP thread which Meteor
+                        // modulation to use for this pass —
+                        // METEOR-M N2 was QPSK; the active
+                        // METEOR-M2 3 / M2-4 are OQPSK. Sent
+                        // BEFORE `open_lrpt_viewer_if_needed`
+                        // (which triggers lazy decoder init)
+                        // so the freshly-built decoder uses
+                        // the right inner chain. Per #662.
+                        if let Some(modulation) = sdr_sat::KNOWN_SATELLITES
+                            .iter()
+                            .find(|s| s.norad_id == norad_id)
+                            .and_then(|s| s.lrpt_modulation)
+                        {
+                            let dsp_mode = match modulation {
+                                sdr_sat::LrptModulation::Qpsk => sdr_dsp::lrpt::LrptMode::Qpsk,
+                                sdr_sat::LrptModulation::Oqpsk => sdr_dsp::lrpt::LrptMode::Oqpsk,
+                            };
+                            state_a
+                                .send_dsp(sdr_core::messages::UiToDsp::SetLrptModulation(dsp_mode));
+                        }
+
                         crate::lrpt_viewer::open_lrpt_viewer_if_needed(
                             &parent_provider_a,
                             &state_a,

--- a/crates/sdr-ui/src/window.rs
+++ b/crates/sdr-ui/src/window.rs
@@ -11547,18 +11547,33 @@ fn connect_satellites_panel(
                         // (which triggers lazy decoder init)
                         // so the freshly-built decoder uses
                         // the right inner chain. Per #662.
-                        if let Some(modulation) = sdr_sat::KNOWN_SATELLITES
+                        //
+                        // Always send — even when the catalog
+                        // lookup misses or returns
+                        // `lrpt_modulation = None`. Otherwise
+                        // the previous pass's modulation leaks
+                        // into the next decoder init (the
+                        // controller stash defaults to OQPSK at
+                        // startup but mutates per
+                        // `SetLrptModulation`, so a Qpsk-then-
+                        // None sequence would silently keep the
+                        // Qpsk chain). Fallback is `Qpsk`
+                        // because that's the standards-default
+                        // LRPT modulation; a future LRPT
+                        // satellite that turns up uncatalogued
+                        // is more likely to be standard-spec
+                        // than Meteor-style OQPSK. Per CR
+                        // round 1 on PR #663.
+                        let modulation = sdr_sat::KNOWN_SATELLITES
                             .iter()
                             .find(|s| s.norad_id == norad_id)
                             .and_then(|s| s.lrpt_modulation)
-                        {
-                            let dsp_mode = match modulation {
-                                sdr_sat::LrptModulation::Qpsk => sdr_dsp::lrpt::LrptMode::Qpsk,
-                                sdr_sat::LrptModulation::Oqpsk => sdr_dsp::lrpt::LrptMode::Oqpsk,
-                            };
-                            state_a
-                                .send_dsp(sdr_core::messages::UiToDsp::SetLrptModulation(dsp_mode));
-                        }
+                            .unwrap_or(sdr_sat::LrptModulation::Qpsk);
+                        let dsp_mode = match modulation {
+                            sdr_sat::LrptModulation::Qpsk => sdr_dsp::lrpt::LrptMode::Qpsk,
+                            sdr_sat::LrptModulation::Oqpsk => sdr_dsp::lrpt::LrptMode::Oqpsk,
+                        };
+                        state_a.send_dsp(sdr_core::messages::UiToDsp::SetLrptModulation(dsp_mode));
 
                         crate::lrpt_viewer::open_lrpt_viewer_if_needed(
                             &parent_provider_a,


### PR DESCRIPTION
## Summary

- Ports the dbdexter `meteor_demod` reference (the same algorithm SatDump uses) to give the LRPT pipeline a proper OQPSK demod path. Current METEOR-M2 satellites (M2-3, M2-4) all transmit Offset QPSK at 72 ksym/s — Q delayed by Tsym/2 from I — and our previously-hardcoded standard-QPSK pipeline can lock onto OQPSK signals but produces sub-quality soft symbols (Gardner timing recovery's error metric assumes I and Q are co-timed, exactly the assumption OQPSK breaks). That's the strongest suspect for the silent-Meteor-pass debug arc this session.
- The new path lives in two modules under `crates/sdr-dsp/src/lrpt/`: `meteor_pll.rs` (Costas with separate `mix_i` / `mix_q` mixes, lock detection via EMA-of-error, free-run frequency sweep through ±fmax) and `mm_timing.rs` (Mueller-Muller timing with the dual-rail `advance_timeslot_dual` state machine — state 1 = I-tick mid-symbol, state 2 = Q-tick at the symbol boundary). `LrptDemod` dispatches between QPSK (existing SDR++-style Costas + Gardner) and OQPSK (new dbdexter chain) via a new `LrptMode` enum. The QPSK path is unchanged — no regression risk for legacy METEOR-M N2 archival recordings.
- Catalog now carries `KnownSatellite::lrpt_modulation: Option<LrptModulation>`; M2-3 and M2-4 are flagged `Oqpsk`. New `UiToDsp::SetLrptModulation` message routes the catalog-derived modulation from the wiring layer (window.rs auto-record arm) through to the DSP thread, which builds the appropriate inner chain on lazy decoder init.

## Algorithm choices (why dbdexter, not SDR++)

I started with SDR++'s OQPSK implementation (just a 1-sample delay on Q post-Costas, then standard Mueller-Muller) but its source has a `// TODO: Additional 1/24th sample delay` comment acknowledging the integer-sample delay leaves a fractional residual the timing loop never recovers. That matches the SDR++ community reputation: standard QPSK Meteors decode fine, OQPSK Meteors are marginal, "use SatDump or dbdexter for serious M2-3/M2-4 work."

The dbdexter approach is structurally different: instead of re-aligning the signal then using single-rail timing, it samples I and Q at their actual Tsym/2-offset instants via the dual-tick state machine, mixes each rail independently through `pll_mix_i` / `pll_mix_q`, and runs Mueller-Muller on the Q rail only. Combined with a much tighter PLL bandwidth (1 Hz vs SDR++'s ~720 Hz) plus a free-run frequency sweep that scans ±0.15 rad through the carrier-offset range until lock, it locks on signals that SDR++'s tuning sits on top of without ever locking.

Tuning per dbdexter `meteor_demod/demod.h`: `PLL_BW = 1` Hz, `SYM_BW = 0.00005`, `FREQ_MAX = 0.3` rad/call (halved for OQPSK).

## Test plan

- [x] `cargo test -p sdr-dsp lrpt::` — 31 tests pass, including 3 new ones exercising the OQPSK pipeline on synthetic 2-sps interleaved I/Q
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean (matches CI invocation)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --workspace --locked` — clean
- [x] `cargo bench -p sdr-dsp --bench lrpt_demod --no-run` — both QPSK and OQPSK benches compile (existing `lrpt_demod_1s_144ksps` bench renamed to `_qpsk_` and a parallel `_oqpsk_` bench added so future regressions in either path are catchable)
- [x] `make install CARGO_FLAGS="--release --features whisper-cuda"` succeeds; binary contains the new `LRPT modulation set to` log marker
- [ ] **(user)** Smoke against a recorded Meteor IQ: select METEOR-M2 4 in the satellites panel, confirm the log shows `LRPT modulation set to Oqpsk` followed by `LRPT decoder initialised at 144000 Hz IF rate, modulation = Oqpsk`, and watch for image rows in the LRPT viewer
- [ ] **(user)** Regression smoke: tune to a strong local FM station, confirm audio still works (controller wiring touched)

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LRPT modulation selection added: supports QPSK and OQPSK for satellite passes.
  * Automatic modulation selected from satellite catalog (Meteor‑M2 marked OQPSK).
  * LRPT viewer/auto-record now configures modulation before decoding starts.
  * Decoder re-initializes to apply modulation changes for the next reception.
  * Improved demodulation, carrier recovery, AGC and timing for more reliable LRPT decoding.

* **Tests**
  * Expanded LRPT tests to cover QPSK and OQPSK behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/rtl-sdr/pull/663)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->