### PR TITLE
chore(deps): bump librtlsdr-rs 0.1.0 → 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "librtlsdr-rs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7635559e721f8c647d757af50b944f55ca49c9841246239564d3324c0fae15c4"
+checksum = "758f1d427653dbbe1d36f470580cd880fb67d634ed82a67a407d8ce11939c681"
 dependencies = [
  "rusb",
  "thiserror 2.0.18",


### PR DESCRIPTION
## Summary

- Picks up the post-0.1.0 fixes + CR items from the librtlsdr-rs side (driver crate published this morning).
- Lockfile-only bump. `Cargo.toml` stays at `librtlsdr-rs = "0.1"` — that's the workspace convention for external deps (loose major.minor pin) and the new release is within that constraint, so explicit-pinning the patch level here would just diverge from how every other workspace dep is specified.

## Test plan

- [x] `cargo build --workspace --locked` clean
- [x] `cargo test --workspace --lib --locked` — 1300+ tests pass, 0 failures
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean (matches CI invocation)
- [x] `cargo fmt --all -- --check` clean
- [ ] **(user)** Smoke against live RTL-SDR — `make install CARGO_FLAGS="--release --features whisper-cuda"` already kicked off; once installed, tune to a known-good FM station to confirm device open + tuning + sample flow still work post-bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)