### PR TITLE
chore(deps): bump librtlsdr-rs 0.1.1 → 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "librtlsdr-rs"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758f1d427653dbbe1d36f470580cd880fb67d634ed82a67a407d8ce11939c681"
+checksum = "384d3c81ccfc800433c5246273e5d0d5d3d4f48e7647f477accfdfe5a44dabc6"
 dependencies = [
  "rusb",
  "thiserror 2.0.18",


### PR DESCRIPTION
## Summary

- Picks up the latest driver fixes from upstream (librtlsdr-rs 0.1.2 published this morning).
- Lockfile-only bump. `Cargo.toml` stays at `librtlsdr-rs = "0.1"` — workspace convention is the loose major.minor pin, and the new release is within that constraint.

## Test plan

- [x] `cargo build --workspace --locked` clean
- [x] `cargo test --workspace --lib --locked` — all green
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean (matches CI)
- [x] `cargo fmt --all -- --check` clean
- [ ] **(user)** Smoke against live RTL-SDR — `make install CARGO_FLAGS="--release --features whisper-cuda"` already kicked off

🤖 Generated with [Claude Code](https://claude.com/claude-code)