### PR TITLE
chore(deps): bump librtlsdr-rs 0.1.x → 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "librtlsdr-rs"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384d3c81ccfc800433c5246273e5d0d5d3d4f48e7647f477accfdfe5a44dabc6"
+checksum = "1efc477c5bdc561bb19351f55e98dbee08e8717cc89963af948e0398369521d3"
 dependencies = [
  "rusb",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,10 +138,10 @@ sdr-types = { path = "crates/sdr-types" }
 sdr-dsp = { path = "crates/sdr-dsp" }
 sdr-pipeline = { path = "crates/sdr-pipeline" }
 # librtlsdr-rs is the spun-out form of what used to be `crates/sdr-rtlsdr`;
-# pulled from crates.io now that v0.1.0 is published. Async-runtime
-# integrations are opt-in via the per-runtime cargo features (currently
-# unused by this app — the source thread uses the sync iterator).
-librtlsdr-rs = "0.1"
+# pulled from crates.io. Async-runtime integrations are opt-in via the
+# per-runtime cargo features (currently unused by this app — the source
+# thread uses the sync iterator).
+librtlsdr-rs = "0.2"
 sdr-source-rtlsdr = { path = "crates/sdr-source-rtlsdr" }
 sdr-source-network = { path = "crates/sdr-source-network" }
 sdr-server-rtltcp = { path = "crates/sdr-server-rtltcp" }


### PR DESCRIPTION
## Summary

Major-version bump on the driver crate. The release notes for v0.2.0 call out four breaking changes:

1. `RtlSdrError::Tuner(String)` → `Tuner(TunerError)` (typed)
2. `RtlSdrError` + `TunerError` are now `#[non_exhaustive]`
3. Struct-form variants for `DeviceNotFound`, `InvalidSampleRate`, `RegisterAccess`
4. `closest_gain` returns `Option<i32>`, `try_closest_gain` removed

A survey of every `librtlsdr_rs::` import in the workspace turned up **zero call sites** for any of them. Our consumer code:
- Propagates the driver's `RtlSdrError` via `?` and `#[from]` — never pattern-matches on it.
- Uses `set_gain_by_index` (table-index API) rather than `closest_gain`.
- Doesn't construct or destructure any of the restructured variants.

So the migration is a pure version refresh. Workspace pin moves from `"0.1"` to `"0.2"` so we don't silently roll back if a future `cargo update` re-resolves; comment updated to drop the now-historical "now that v0.1.0 is published" framing.

## Test plan

- [x] `cargo build --workspace --locked` clean
- [x] `cargo test --workspace --lib --locked` — all green, no failures
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean (matches CI invocation)
- [x] `cargo check --workspace --locked` clean (Cargo.toml + Cargo.lock both touched)
- [x] `cargo fmt --all -- --check` clean
- [ ] **(user)** Smoke against live RTL-SDR — `make install CARGO_FLAGS="--release --features whisper-cuda"` is building now; once installed, tune to a known-good FM station to confirm device open + tuning + sample flow still work post-bump

Reference: https://github.com/jasonherald/librtlsdr-rs/releases/tag/v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `librtlsdr-rs` dependency to version 0.2

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/rtl-sdr/pull/666)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->