### PR TITLE
chore(deps): bump librtlsdr-rs 0.2.0 → 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "librtlsdr-rs"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efc477c5bdc561bb19351f55e98dbee08e8717cc89963af948e0398369521d3"
+checksum = "bc2cb5fc8ac4f4b61f2eee6525c787e0f8f2440fcd3506ad1410eb045fa2e6b9"
 dependencies = [
  "rusb",
  "thiserror 2.0.18",


### PR DESCRIPTION
## Summary

- Picks up the latest cleanup + CR follow-ups from the driver crate (v0.2.1 just published).
- Lockfile-only bump — `Cargo.toml` stays at `librtlsdr-rs = "0.2"` per the workspace convention.
- No breaking changes (driver authors confirmed).

## Test plan

- [x] `cargo build --workspace --locked` clean
- [x] `cargo test --workspace --lib --locked` — all green
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean (matches CI)
- [x] `cargo fmt --all -- --check` clean
- [ ] **(user)** Smoke against live RTL-SDR — `make install CARGO_FLAGS="--release --features whisper-cuda"` building now

🤖 Generated with [Claude Code](https://claude.com/claude-code)