### PR TITLE
chore(deps): bump librtlsdr-rs 0.2.1 → 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "librtlsdr-rs"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2cb5fc8ac4f4b61f2eee6525c787e0f8f2440fcd3506ad1410eb045fa2e6b9"
+checksum = "7ea2d5048767c6bd1c23affaee9b5d457acb52075fefdfd60f552ae72a522880"
 dependencies = [
  "rusb",
  "thiserror 2.0.18",


### PR DESCRIPTION
## Summary

- Picks up the latest correctness fixes from the driver crate (v0.2.2 just published).
- Lockfile-only bump — `Cargo.toml` stays at `librtlsdr-rs = "0.2"` per the workspace convention.

## Test plan

- [x] `cargo build --workspace --locked` clean
- [x] `cargo test --workspace --lib --locked` — all green
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean (matches CI)
- [x] `cargo fmt --all -- --check` clean
- [ ] **(user)** Smoke against live RTL-SDR — `make install CARGO_FLAGS="--release --features whisper-cuda"` building now; tune to a known-good FM station to confirm device open + tuning + sample flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)