### PR TITLE
chore(deps): bump librtlsdr-rs 0.2.2 → 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "librtlsdr-rs"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea2d5048767c6bd1c23affaee9b5d457acb52075fefdfd60f552ae72a522880"
+checksum = "a83b8f8955c4e8a305243f554953ef25e868d5e122c82ce468c6e056057b47f8"
 dependencies = [
  "rusb",
  "thiserror 2.0.18",


### PR DESCRIPTION
## Summary

- Picks up the latest audit-driven cleanup from the driver crate (v0.2.4 just published — skipping 0.2.3 was the upstream's choice).
- Lockfile-only bump — `Cargo.toml` stays at `librtlsdr-rs = "0.2"` per the workspace convention.

## Test plan

- [x] `cargo build --workspace --locked` clean
- [x] `cargo test --workspace --lib --locked` — all green
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean (matches CI)
- [x] `cargo fmt --all -- --check` clean
- [ ] **(user)** Smoke against live RTL-SDR — `make install CARGO_FLAGS="--release --features whisper-cuda"` building now

🤖 Generated with [Claude Code](https://claude.com/claude-code)