### PR TITLE
chore(deps): bump librtlsdr-rs 0.2.4 → 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "librtlsdr-rs"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a83b8f8955c4e8a305243f554953ef25e868d5e122c82ce468c6e056057b47f8"
+checksum = "c3d00087653b34797386f2d15b03a57678d0544f6df318eb3c5b274a6b11d4d0"
 dependencies = [
  "rusb",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ sdr-pipeline = { path = "crates/sdr-pipeline" }
 # pulled from crates.io. Async-runtime integrations are opt-in via the
 # per-runtime cargo features (currently unused by this app — the source
 # thread uses the sync iterator).
-librtlsdr-rs = "0.2"
+librtlsdr-rs = "0.3"
 sdr-source-rtlsdr = { path = "crates/sdr-source-rtlsdr" }
 sdr-source-network = { path = "crates/sdr-source-network" }
 sdr-server-rtltcp = { path = "crates/sdr-server-rtltcp" }

--- a/crates/sdr-server-rtltcp/src/protocol.rs
+++ b/crates/sdr-server-rtltcp/src/protocol.rs
@@ -52,13 +52,24 @@ pub enum TunerTypeCode {
 impl From<TunerType> for TunerTypeCode {
     fn from(t: TunerType) -> Self {
         match t {
-            TunerType::Unknown => TunerTypeCode::Unknown,
             TunerType::E4000 => TunerTypeCode::E4000,
             TunerType::Fc0012 => TunerTypeCode::Fc0012,
             TunerType::Fc0013 => TunerTypeCode::Fc0013,
             TunerType::Fc2580 => TunerTypeCode::Fc2580,
             TunerType::R820T => TunerTypeCode::R820t,
             TunerType::R828D => TunerTypeCode::R828d,
+            // `TunerType::Unknown` plus any future variants the
+            // upstream adds (the enum is `#[non_exhaustive]` as of
+            // librtlsdr-rs 0.3) all map to the wire's `Unknown = 0`
+            // code. That's what `enum rtlsdr_tuner` in upstream
+            // `rtl-sdr.h` reserves for "type we don't have a code
+            // for", so old `rtl_tcp` clients see the right
+            // "unrecognised tuner" semantics rather than a
+            // misclassified known type. The `Unknown` arm and the
+            // catch-all are intentionally collapsed to one branch —
+            // explicit-then-wildcard would have identical bodies and
+            // trip `clippy::match_same_arms`.
+            TunerType::Unknown | _ => TunerTypeCode::Unknown,
         }
     }
 }


### PR DESCRIPTION
## Summary

Major-version bump on the driver. The 0.3.0 release notes call out **one** breaking change: `Block` and `TunerType` are now `#[non_exhaustive]`, so any exhaustive match on either must add a wildcard arm. **No variants were added or removed.**

A grep across the workspace turned up exactly **one** match site:

- `crates/sdr-server-rtltcp/src/protocol.rs::From<TunerType> for TunerTypeCode` — the projection from the driver's typed enum onto the wire-byte enum that the `rtl_tcp` protocol specifies.

We don't match on `Block` anywhere (only the driver itself uses it inside `RegisterAccess`, which we propagate via `?` and `#[from]`).

## Migration approach

Collapse the existing `TunerType::Unknown` arm and the new required wildcard into a single `TunerType::Unknown | _` branch. Both need to map to `TunerTypeCode::Unknown = 0` (the wire's "unrecognised tuner" code per upstream `rtl-sdr.h`'s `enum rtlsdr_tuner`), and `clippy::match_same_arms` would flag them as identical bodies if kept separate. Comment in the source documents the rationale so the explicit-Unknown branch isn't reintroduced by a future "be explicit" refactor.

Also updates the workspace pin from `"0.2"` to `"0.3"` so we don't silently roll back on a future re-resolve.

## Test plan

- [x] `cargo build --workspace --locked` clean
- [x] `cargo test --workspace --lib --locked` — all green
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean (matches CI; required two passes — first iteration tripped `match_same_arms` on the redundant `Unknown` + `_` arms)
- [x] `cargo fmt --all -- --check` clean
- [ ] **(user)** Smoke against live RTL-SDR — `make install CARGO_FLAGS="--release --features whisper-cuda"` building now

## Notes

Per upstream this is the LAST audit-pass-2 release; 0.3.x onwards will be normal feature/bug-fix work, no audit-driven catch-up.

Reference: https://github.com/jasonherald/librtlsdr-rs/releases/tag/v0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded core software radio library dependency to the latest stable version, incorporating necessary stability improvements and maintaining long-term compatibility for the SDR server platform.

* **Bug Fixes**
  * Enhanced tuner type detection logic to gracefully handle unknown or newly-supported tuner models, expanding hardware compatibility and ensuring reliable device support across various SDR equipment configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/rtl-sdr/pull/671)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->