### PR TITLE
chore(deps): bump slowrx 0.5.0 → 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "slowrx"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4355b27327e8fd6ca705d6b80e58f32625f5a94b41d8dd410bc8a652c04b8307"
+checksum = "232da0e6a119e87239b96ec785a66f393eb4a49f23dbce35c8db43f881b16920"
 dependencies = [
  "rustfft",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,7 +318,7 @@ tempfile = "3"
 # `slowrx::resample::MAX_INPUT_SAMPLE_RATE_HZ` and internally resamples to
 # 11_025 Hz. Both `rustfft` and `thiserror` that slowrx brings are already
 # in the workspace dep tree, so no new transitive deps are added.
-slowrx = "0.5.0"
+slowrx = "0.5.2"
 
 [workspace.lints.rust]
 unsafe_code = "deny"


### PR DESCRIPTION
## Summary

- Bumps the `slowrx` SSTV-decoder dependency `0.5.0` → `0.5.2`, picking up the slowrx.rs fixes shipped in `0.5.1` / `0.5.2`: **VIS-detector fidelity** (slowrx#89) and **multi-image-per-pass streaming** (slowrx#90). Both matter for the ISS SSTV path — `SstvDecoder` in `sdr-core` (`sstv_decode_tap`) and `sstv_viewer` in `sdr-ui` — where an ARISS event typically sends ~12 images in a single pass.
- Lockfile-only churn beyond the manifest pin: `slowrx` gets the new version + checksum, nothing else moves.

## Test plan

- [x] `cargo build --workspace --locked` clean; `Cargo.lock` diff is just the `slowrx` version/checksum lines
- [x] `cargo check --workspace --locked` clean (Cargo.toml + Cargo.lock both touched)
- [x] `cargo test --workspace --lib --locked` — all green
- [x] `cargo clippy --all-targets --workspace -- -D warnings` clean (matches CI)
- [x] `cargo fmt --all -- --check` clean
- [ ] **(user)** Smoke — `make install CARGO_FLAGS="--release --features whisper-cuda"` building now; relaunch, open the SSTV viewer, and (with an ISS SSTV recording or a live ARISS pass) confirm decode + that multi-image streaming surfaces multiple frames per pass instead of stopping after the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependency to the latest patch version for improved stability and performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jasonherald/rtl-sdr/pull/674)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->