### PR TITLE
chore: pin Rust 1.96.0 + clear RUSTSEC-2026-0185 (quinn-proto)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2612,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## What

Two cohesive build-infra changes to get the workspace current and CI-green:

1. **`rust-toolchain.toml`: `1.95.0` → `1.96.0`** — latest stable (released 2026-05-25).
2. **`quinn-proto` `0.11.14` → `0.11.15`** (lockfile-only) — clears **RUSTSEC-2026-0185**.

## Why

The toolchain pin keeps local dev + CI on one known-good compiler. The `quinn-proto` bump clears a **HIGH (CVSS 7.5)** remote memory-exhaustion advisory (unbounded out-of-order QUIC stream reassembly) pulled in transitively via `reqwest` → `sdr-transcription` / `sdr-sat` / `sdr-radioreference`. The advisory was published 2026-06-22 and is what was **failing CI's `cargo audit` gate** on this branch.

## Verification (local, under 1.96.0, default `whisper-cpu` + GTK flavor)

| Gate | Result |
|------|--------|
| `cargo fmt --all -- --check` | ✅ clean |
| `cargo clippy --all-targets --workspace -- -D warnings` | ✅ clean — no new pedantic lints from the toolchain bump |
| `cargo check --locked --workspace` | ✅ clean (after the lock bump) |
| `cargo audit` | ✅ clean — 0 vulnerabilities |

Sherpa flavors (`sherpa-cpu` / `sherpa-cuda`) are left to CI's `sherpa-check` job, per the existing local-Whisper / CI-Sherpa split.

## Note

This does **not** cover the separate `tar 0.4.45 → 0.4.46` moderate advisory (GitHub dependabot #1) — that's handled by dependabot PR #676 and isn't flagged by `cargo audit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
