### PR TITLE
fix(spectrum): keep FFT plot + waterfall in sync on zoom (#657) + docs drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Rust port of SDR++ — software-defined radio application with GTK4 UI.
 
 ## Architecture
 
-22-member workspace (root binary + 21 library crates) with clear dependency boundaries.
+23-member workspace (root binary + 22 library crates) with clear dependency boundaries.
 The driver layer (`sdr-rtlsdr`) was spun out as a standalone published crate
 [`librtlsdr-rs`](https://crates.io/crates/librtlsdr-rs) and is consumed from
 crates.io rather than as a path dependency.
@@ -15,7 +15,7 @@ sdr-dsp               → Pure DSP: math, filters, FFT, demod, resampling, APT d
 sdr-config            → JSON configuration persistence + OS keyring (depends on: types)
 sdr-pipeline          → Threading, streaming, signal path (depends on: types, dsp, config)
 librtlsdr-rs          → External: pure-Rust port of librtlsdr over rusb — 5 tuner families
-sdr-rtltcp-discovery  → mDNS browser/responder for `_rtl_tcp._tcp.local.` services
+sdr-rtltcp-discovery  → External: mDNS browser/responder for `_rtl_tcp._tcp.local.` (crates.io)
 sdr-server-rtltcp     → `rtl_tcp` server — share a local dongle over TCP
 sdr-source-rtlsdr     → RTL-SDR source module (depends on: types, pipeline, librtlsdr-rs, config)
 sdr-source-network    → TCP/UDP IQ source (depends on: types, pipeline, config)
@@ -23,6 +23,7 @@ sdr-source-file       → WAV file playback source (depends on: types, pipeline,
 sdr-sink-audio        → PipeWire/CoreAudio output (depends on: types, pipeline, config)
 sdr-sink-network      → TCP/UDP audio output (depends on: types, pipeline, config)
 sdr-radio             → Radio decoder, demod, IF/AF chains, APT image buffer (depends on: types, dsp, pipeline)
+sdr-lrpt              → Meteor-M LRPT decode pipeline (QPSK → Viterbi → RS → JPEG)
 sdr-radioreference    → RadioReference.com SOAP client (depends on: types, config)
 sdr-sat               → Satellite pass prediction (SGP4) + TLE cache + ground-station catalog
 sdr-scanner           → Multi-channel scanner engine — projection, dwell/hang, lockout
@@ -32,6 +33,7 @@ sdr-core              → Headless cross-platform engine facade (macOS port path
 sdr-splash            → Cross-platform splash subprocess controller (stdin wire protocol)
 sdr-splash-gtk        → Linux GTK4 splash window implementation
 sdr-ui                → GTK4/libadwaita UI — Linux-only (depends on: all above)
+sdr-tray              → StatusNotifierItem tray-icon sidecar (Linux-only)
 sdr (binary)          → Entry point (depends on: ui, core, splash, transcription, …)
 ```
 

--- a/crates/sdr-ui/src/spectrum/fft_plot.rs
+++ b/crates/sdr-ui/src/spectrum/fft_plot.rs
@@ -55,21 +55,35 @@ const BACKGROUND_COLOR: [f64; 4] = [0.08, 0.08, 0.10, 1.0];
 /// are reduced to a single bin by taking the maximum dB value in each group.
 /// This preserves signal peaks. Returns a slice of the downsampled buffer,
 /// or the original data if no downsampling is needed.
+fn downsample_fft<'a>(data: &'a [f32], buf: &'a mut Vec<f32>) -> &'a [f32] {
+    if data.len() <= MAX_DISPLAY_BINS {
+        return data;
+    }
+    max_pool_to(data, buf, MAX_DISPLAY_BINS);
+    buf
+}
+
+/// Max-pool `data` into `out_bins` buckets (one max per bucket), writing
+/// the result into `buf`.
+///
+/// Bucket `i` spans `[floor(i·ratio), ceil((i+1)·ratio))`, so buckets
+/// overlap by up to one bin on non-integer ratios — this guarantees every
+/// input bin (including the final one) is covered by some bucket. The
+/// waterfall renderer's `downsample_to` uses the identical bucketing; the
+/// two MUST stay in lockstep, otherwise the FFT trace and the waterfall
+/// spectrogram disagree on the last bin whenever the FFT is wider than
+/// `MAX_DISPLAY_BINS` (the `.ceil()` here was previously missing — #657).
 #[allow(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss
 )]
-fn downsample_fft<'a>(data: &'a [f32], buf: &'a mut Vec<f32>) -> &'a [f32] {
-    if data.len() <= MAX_DISPLAY_BINS {
-        return data;
-    }
-    let out_bins = MAX_DISPLAY_BINS;
+fn max_pool_to(data: &[f32], buf: &mut Vec<f32>, out_bins: usize) {
     buf.resize(out_bins, f32::NEG_INFINITY);
     let ratio = data.len() as f32 / out_bins as f32;
     for (i, out) in buf.iter_mut().enumerate().take(out_bins) {
         let start = (i as f32 * ratio) as usize;
-        let end = (((i + 1) as f32) * ratio) as usize;
+        let end = (((i + 1) as f32) * ratio).ceil() as usize;
         let end = end.min(data.len());
         let mut max_val = f32::NEG_INFINITY;
         for &v in &data[start..end] {
@@ -79,7 +93,6 @@ fn downsample_fft<'a>(data: &'a [f32], buf: &'a mut Vec<f32>) -> &'a [f32] {
         }
         *out = max_val;
     }
-    buf
 }
 
 /// Cairo renderer for the FFT power spectrum plot.
@@ -679,5 +692,22 @@ mod tests {
         );
         // active - bw/2 = 145.875 MHz → x = 800 * (145.875M - 144M) / 4M = 375.0
         assert!((x - 375.0).abs() < 0.1, "expected ~375.0, got {x}");
+    }
+
+    /// The max-pool bucketing must match the waterfall's `downsample_to`
+    /// exactly (overlapping buckets via `.ceil()`), or the FFT trace and the
+    /// waterfall disagree on the final bin once the FFT is wider than
+    /// `MAX_DISPLAY_BINS`. 7 bins -> 3: ratio 2.333, buckets [0..3), [2..5),
+    /// [4..7). Without `.ceil()` the buckets would be [0..2), [2..4), [4..6),
+    /// dropping bins 6 (and the peak that lives there).
+    #[test]
+    fn max_pool_non_divisible_covers_all_bins() {
+        let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+        let mut buf = Vec::new();
+        max_pool_to(&data, &mut buf, 3);
+        assert_eq!(buf.len(), 3);
+        assert_eq!(buf[0], 3.0); // max(1, 2, 3)
+        assert_eq!(buf[1], 5.0); // max(3, 4, 5)
+        assert_eq!(buf[2], 7.0); // max(5, 6, 7) — final bin covered
     }
 }

--- a/crates/sdr-ui/src/spectrum/mod.rs
+++ b/crates/sdr-ui/src/spectrum/mod.rs
@@ -701,10 +701,9 @@ pub fn build_spectrum_view(
         &vfo_offset_callback,
         &scanner_axis_lock,
     );
-    attach_scroll_gesture(&waterfall_area, &vfo_state);
-
-    // Also attach scroll-to-zoom on the FFT area for convenience.
-    attach_scroll_gesture(&fft_area, &vfo_state);
+    // Scroll-to-zoom on both spectrum panes. They share `vfo_state`, so each
+    // zoom redraws both panes to keep them in sync. Per #657.
+    attach_scroll_gesture(&fft_area, &waterfall_area, &vfo_state);
 
     let paned = gtk4::Paned::builder()
         .orientation(gtk4::Orientation::Vertical)
@@ -1287,36 +1286,58 @@ fn attach_drag_gesture(
 /// Attach a scroll-to-zoom gesture to a `DrawingArea`.
 ///
 /// Scrolling zooms the frequency display range centered on the cursor position.
-fn attach_scroll_gesture(area: &gtk4::DrawingArea, vfo_state: &Rc<RefCell<VfoState>>) {
-    let scroll = gtk4::EventControllerScroll::new(
-        gtk4::EventControllerScrollFlags::VERTICAL | gtk4::EventControllerScrollFlags::DISCRETE,
-    );
+///
+/// Attaches to BOTH spectrum panes (FFT plot + waterfall). They share one
+/// `VfoState`, so a zoom on either pane must redraw both — otherwise the pane
+/// that didn't receive the scroll keeps rendering the previous zoom range and
+/// its VFO overlay / frequency axis drift out of alignment with the zoomed
+/// pane. Most visible while paused, when no fresh FFT frames force a redraw.
+/// Per #657.
+fn attach_scroll_gesture(
+    fft_area: &gtk4::DrawingArea,
+    waterfall_area: &gtk4::DrawingArea,
+    vfo_state: &Rc<RefCell<VfoState>>,
+) {
+    for target in [fft_area, waterfall_area] {
+        let scroll = gtk4::EventControllerScroll::new(
+            gtk4::EventControllerScrollFlags::VERTICAL | gtk4::EventControllerScrollFlags::DISCRETE,
+        );
 
-    let vfo_state = Rc::clone(vfo_state);
-    let area_weak = area.downgrade();
-    scroll.connect_scroll(move |_controller, _dx, dy| {
-        let Some(area) = area_weak.upgrade() else {
-            return glib::Propagation::Stop;
-        };
-        let width = f64::from(area.width());
+        let vfo_state = Rc::clone(vfo_state);
+        let target_weak = target.downgrade();
+        let fft_weak = fft_area.downgrade();
+        let waterfall_weak = waterfall_area.downgrade();
+        scroll.connect_scroll(move |_controller, _dx, dy| {
+            let Some(target) = target_weak.upgrade() else {
+                return glib::Propagation::Stop;
+            };
+            let width = f64::from(target.width());
 
-        // TODO: Anchor zoom on cursor position instead of display center.
-        // GTK4 EventControllerScroll doesn't provide position in the scroll
-        // signal. Add an EventControllerMotion to track the pointer and use
-        // its last-known X coordinate here for cursor-centered zoom.
-        let cursor_x = width / 2.0;
+            // TODO: Anchor zoom on cursor position instead of display center.
+            // GTK4 EventControllerScroll doesn't provide position in the scroll
+            // signal. Add an EventControllerMotion to track the pointer and use
+            // its last-known X coordinate here for cursor-centered zoom.
+            let cursor_x = width / 2.0;
 
-        let mut vfo = vfo_state.borrow_mut();
-        let cursor_hz = vfo.pixel_to_hz(cursor_x, width);
+            let mut vfo = vfo_state.borrow_mut();
+            let cursor_hz = vfo.pixel_to_hz(cursor_x, width);
 
-        // dy > 0 = scroll down = zoom out; dy < 0 = scroll up = zoom in.
-        vfo.zoom(cursor_hz, -dy);
+            // dy > 0 = scroll down = zoom out; dy < 0 = scroll up = zoom in.
+            vfo.zoom(cursor_hz, -dy);
+            drop(vfo);
 
-        drop(vfo);
-        area.queue_draw();
+            // Redraw BOTH panes — they share `vfo_state`, so a one-sided
+            // queue_draw would strand the other pane on the old zoom. Per #657.
+            if let Some(a) = fft_weak.upgrade() {
+                a.queue_draw();
+            }
+            if let Some(a) = waterfall_weak.upgrade() {
+                a.queue_draw();
+            }
 
-        glib::Propagation::Stop
-    });
+            glib::Propagation::Stop
+        });
 
-    area.add_controller(scroll);
+        target.add_controller(scroll);
+    }
 }


### PR DESCRIPTION
## Summary

Two spectrum-display correctness fixes plus a docs-drift cleanup, bundled for one review pass.

### 1. Zoom-while-paused desync — closes #657
`attach_scroll_gesture` mutated the **shared** `VfoState` via `vfo.zoom()` but only `queue_draw()`'d the pane that received the scroll event. The sibling pane kept rendering the previous zoom range, so the VFO overlay + frequency axis visibly misaligned between the FFT plot and the waterfall — most obvious **while paused**, when no fresh FFT frame forces a redraw.

Fix: `attach_scroll_gesture` now attaches to both panes and redraws **both** on every zoom. The two call sites collapse into one.

### 2. `fft_plot` downsample dropped the final bin
`fft_plot`'s max-pool downsampler computed the bucket `end` without `.ceil()`, so on non-integer ratios (FFT wider than `MAX_DISPLAY_BINS` = 4096) the final input bin(s) could be skipped — while the waterfall's `downsample_to` already used `.ceil()`. The two now use identical bucketing. Extracted `max_pool_to` and added a `downsample_non_divisible`-style regression test mirroring the waterfall's.

### 3. Docs drift (`CLAUDE.md`)
- `22-member workspace (root + 21 libs)` → **23 (root + 22)** — matches the README.
- Documented the two missing members: **`sdr-lrpt`** (Meteor-M LRPT decode pipeline) and **`sdr-tray`** (StatusNotifierItem tray-icon sidecar, Linux-only).
- Marked **`sdr-rtltcp-discovery`** as the external crates.io dependency it became when it was spun out (no longer a workspace member).

## Verification

| Gate | Result |
|------|--------|
| `cargo fmt --all -- --check` | ✅ clean |
| `cargo test -p sdr-ui` (spectrum, +new test) | ✅ 57 pass |
| `cargo clippy --all-targets --workspace -- -D warnings` | ✅ clean |
| Manual smoke (sherpa-cuda release) | ✅ zoom-while-paused keeps both panes in sync |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spectrum zooming now keeps the FFT and waterfall views synchronized, making scroll-based zooming feel smoother and more consistent.
  * Improved FFT downsampling coverage helps preserve visible peaks when the number of bins doesn’t divide evenly.

* **Bug Fixes**
  * Fixed an issue where the last peak could be dropped during spectrum downsampling.
  * Both spectrum panes now refresh together after zoom interactions, reducing display inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->