### PR TITLE
chore(deps): bump rand 0.8 → 0.10 (#680)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +621,15 @@ dependencies = [
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1097,6 +1117,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2543,7 +2564,7 @@ dependencies = [
  "bitflags",
  "num-traits",
  "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2650,33 +2671,23 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2691,21 +2702,18 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -3202,7 +3210,7 @@ dependencies = [
  "libc",
  "librtlsdr-rs",
  "lz4_flex",
- "rand 0.8.6",
+ "rand 0.10.1",
  "rusb",
  "sdr-rtltcp-discovery",
  "socket2 0.5.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,9 +221,13 @@ chrono = { version = "0.4", default-features = false, features = ["std", "clock"
 # server (#394) key generator — `OsRng` wraps `/dev/urandom` on
 # unix and `BCryptGenRandom` on Windows, which is what we want for
 # a 32-byte pre-shared key (CSPRNG quality, no seed management).
-# Pinned to 0.8.x until we need the 0.9 API rework; 0.8 is still
-# the ecosystem-majority version as of the workspace's 1.95 pin.
-rand = "0.8"
+# Bumped 0.8 → 0.10 (#680): rand 0.9+ split the Rng traits into
+# infallible and fallible halves, and rand 0.10 renamed the OS
+# interface `OsRng` → `SysRng` (a fallible `TryRng`, since OS
+# entropy calls can fail). See
+# `sdr-server-rtltcp::auth::generate_random_auth_key` for how the
+# key generator adapts it back to the old infallible contract.
+rand = "0.10"
 
 # Constant-time primitives. Used by the rtl_tcp optional-auth
 # server (#394) for the `ConstantTimeEq` compare between the

--- a/crates/sdr-server-rtltcp/src/auth.rs
+++ b/crates/sdr-server-rtltcp/src/auth.rs
@@ -4,7 +4,7 @@
 //! Two responsibilities:
 //!
 //! 1. **Key generation** — [`generate_random_auth_key`] wraps
-//!    [`rand::rngs::OsRng`] to produce a 32-byte key. OS-backed
+//!    [`rand::rngs::SysRng`] to produce a 32-byte key. OS-backed
 //!    CSPRNG (reads from `/dev/urandom` on unix, `BCryptGenRandom`
 //!    on Windows), so no seed management on our side. 32 bytes =
 //!    256 bits of entropy, more than sufficient for the threat
@@ -25,7 +25,7 @@
 //! bridges the two with verification + a helper to produce the
 //! expected key at server-start time.
 
-use rand::RngCore;
+use rand::TryRng;
 use subtle::ConstantTimeEq;
 
 /// Size in bytes of the server-generated random key. 32 bytes
@@ -44,14 +44,21 @@ pub const DEFAULT_AUTH_KEY_LEN: usize = 32;
 /// - Tests that need a realistic key shape.
 ///
 /// OS-CSPRNG means there's no seed state on our side — every
-/// call is independent. `rand::rngs::OsRng` is infallible in
+/// call is independent. `rand::rngs::SysRng` is infallible in
 /// practice on our targets (the `try_fill_bytes` path would only
 /// surface an error on exotic platforms where `/dev/urandom` is
-/// unreadable; we don't support those).
+/// unreadable; we don't support those, hence the `.expect`).
 #[must_use]
 pub fn generate_random_auth_key() -> Vec<u8> {
     let mut buf = vec![0u8; DEFAULT_AUTH_KEY_LEN];
-    rand::rngs::OsRng.fill_bytes(&mut buf);
+    // rand 0.10 renamed the OS interface `OsRng` → `SysRng` and made it a
+    // fallible `TryRng` (OS entropy calls *can* fail in principle). The
+    // `.expect()` preserves the old infallible contract: getrandom(2) /
+    // getentropy don't fail in practice on the unix/Windows targets we
+    // support — see the doc comment above.
+    rand::rngs::SysRng
+        .try_fill_bytes(&mut buf)
+        .expect("OS CSPRNG (SysRng) unavailable — unsupported platform");
     buf
 }
 
@@ -132,7 +139,7 @@ mod tests {
 
     #[test]
     fn generate_random_auth_key_entropy_smoke_check() {
-        // Cheap sanity check that the OsRng is actually doing
+        // Cheap sanity check that the SysRng is actually doing
         // something — two consecutive calls should produce
         // different bytes. A broken rand impl (e.g., a stub
         // returning zeros) would fail this.
@@ -140,7 +147,7 @@ mod tests {
         let b = generate_random_auth_key();
         assert_ne!(
             a, b,
-            "two successive OsRng-based key generations must differ"
+            "two successive SysRng-based key generations must differ"
         );
     }
 

--- a/crates/sdr-ui/src/sidebar/server_panel.rs
+++ b/crates/sdr-ui/src/sidebar/server_panel.rs
@@ -69,7 +69,7 @@ pub const KEYRING_SERVICE: &str = "sdr-rs";
 /// Keyring entry name holding the `rtl_tcp` pre-shared auth key.
 /// Stored as a lowercase-hex string so it round-trips through
 /// keyring's `String` API without custom base64/UTF-8 coercion
-/// — `rand::OsRng`-backed keys are arbitrary bytes, not text.
+/// — `rand::rngs::SysRng`-backed keys are arbitrary bytes, not text.
 /// Per issue #395.
 pub const KEYRING_KEY_AUTH_KEY: &str = "rtl_tcp-server-auth-key";
 


### PR DESCRIPTION
Closes #680. First of the three deferred major-bump tickets from the dependency review (#679).

## What

Migrate the rtl_tcp server's pre-shared-key generator to the **rand 0.10** API.

- rand 0.9+ split the `Rng` traits into infallible/fallible halves; rand 0.10 renamed the OS-entropy interface **`OsRng` → `SysRng`** (a fallible `TryRng` backed by `getrandom(2)` / `/dev/urandom`).
- `generate_random_auth_key()` (`sdr-server-rtltcp::auth`):
  - `use rand::RngCore;` → `use rand::TryRng;`
  - `OsRng.fill_bytes(&mut buf)` → `SysRng.try_fill_bytes(&mut buf).expect(…)`
- `.expect()` preserves the prior infallible-in-practice contract (rand 0.8's `fill_bytes` also panicked on the exotic OS-RNG-unavailable path we don't support). `SysRng` implements `TryCryptoRng`, so the key stays crypto-grade; 32-byte length + per-call independence unchanged.
- Stale `OsRng` references in doc/comments updated to `SysRng` (incl. one in `sdr-ui/server_panel.rs`).

Single call site — `sdr-server-rtltcp` is the only consumer of `rand` in the workspace.

## Verification (under 1.96.0)

| Gate | Result |
|------|--------|
| `cargo fmt --all -- --check` | ✅ |
| `cargo clippy --all-targets --workspace -- -D warnings` | ✅ |
| `cargo test -p sdr-server-rtltcp` | ✅ 41 pass (entropy smoke + auth round-trip) |
| `cargo check --locked --workspace` | ✅ |
| `cargo audit` | ✅ 0 vulns |

Plus an adversarial review of the crypto change: confirmed `SysRng` resolves through getrandom to the kernel CSPRNG (`getrandom(2)` → `/dev/urandom`, marked `TryCryptoRng`), behavior is preserved, and no `rand` call sites were missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated secure key generation to work with the latest randomness library changes while preserving existing behavior.
  * Improved reliability around authentication key creation, with fallback handling for rare system randomness failures.
* **Chores**
  * Refreshed project dependency versions and related documentation comments to match the updated library API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->