### PR TITLE
chore(deps): bump bzip2 0.4 → 0.6 (#682)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +1992,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,7 +3464,7 @@ dependencies = [
 name = "sdr-transcription"
 version = "0.1.0"
 dependencies = [
- "bzip2",
+ "bzip2 0.6.1",
  "dirs-next",
  "earshot",
  "libc",
@@ -3686,7 +3701,7 @@ name = "sherpa-onnx-sys"
 version = "1.12.36"
 source = "git+https://github.com/jasonherald/sherpa-onnx.git?rev=628c333f9851101e9d2c228a49833f21337ebf06#628c333f9851101e9d2c228a49833f21337ebf06"
 dependencies = [
- "bzip2",
+ "bzip2 0.4.4",
  "tar",
  "ureq",
 ]

--- a/crates/sdr-transcription/Cargo.toml
+++ b/crates/sdr-transcription/Cargo.toml
@@ -63,7 +63,7 @@ tracing.workspace = true
 dirs-next.workspace = true
 libc.workspace = true
 tar = { version = "0.4", optional = true }
-bzip2 = { version = "0.4", optional = true }
+bzip2 = { version = "0.6", optional = true }
 
 [lints]
 workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,11 @@ allow = [
     "Zlib",
     "0BSD",
     "BSL-1.0",
+    # `bzip2-1.0.6` is the pure-Rust `libbz2-rs-sys` backend that bzip2 0.6
+    # pulls in by default (replacing the C `bzip2-sys`). It's the permissive
+    # BSD-style bzip2/libbzip2 license — GPL-compatible, so it links cleanly
+    # into this GPL-2.0-or-later app. Per #682.
+    "bzip2-1.0.6",
     # `LGPL-2.0-only` is `sdr-acars` — the spun-out acarsdec port, whose
     # upstream license is the GNU Library GPL v2 with no "or later" grant.
     # Linkable into this GPL-2.0-or-later app: LGPL→GPL is a permitted


### PR DESCRIPTION
Closes #682. Last of the three deferred major-bump tickets from the dependency review (#679).

## What

Bump `sdr-transcription`'s `bzip2` dependency — used to decompress the sherpa-onnx `.tar.bz2` model bundles on first-run download (`sherpa_model.rs:579`) — from **0.4 → 0.6**.

**Pure version bump, no source change:**
- `bzip2::read::BzDecoder::new(reader)` is byte-identical in 0.6.
- bzip2 0.6's default backend is now the **pure-Rust `libbz2-rs-sys`** (was the C `bzip2-sys`), so our extraction path no longer pulls a C library. 🎉

> A transitive `bzip2 0.4.4` + `bzip2-sys` still appear in the lock — they're a **build-dependency of `sherpa-onnx-sys`** (the pinned fork), outside our control. That clears when the sherpa-onnx fork is unpinned to upstream (separately tracked in the #679 review).

## Verification

Triple-build per the `sdr-transcription` testing rule:

| Flavor | Result |
|--------|--------|
| `cargo check --no-default-features --features sherpa-cpu` | ✅ (compiles the bzip2 call site) |
| `cargo check --no-default-features --features sherpa-cuda` | ✅ |
| `cargo check --no-default-features --features whisper-cuda` | ✅ |

Plus: `cargo fmt` ✅, `cargo clippy --locked --all-targets --workspace -- -D warnings` ✅, `cargo audit` ✅ (507 deps, 0 vulns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an optional compression dependency to a newer version for improved maintenance and compatibility.
  * Updated the license allowlist to permit the corresponding upstream bzip2 license entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->